### PR TITLE
RFC: Add 'Getting' to the hierarchy.

### DIFF
--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -16,6 +16,7 @@ library
     Optics.Equality
     Optics.Fold
     Optics.Getter
+    Optics.Getting
     Optics.Iso
     Optics.Lens
     Optics.Optic
@@ -28,6 +29,7 @@ library
     Optics.Internal.Equality
     Optics.Internal.Fold
     Optics.Internal.Getter
+    Optics.Internal.Getting
     Optics.Internal.Iso
     Optics.Internal.Lens
     Optics.Internal.Optic

--- a/optics-core/src/Optics.hs
+++ b/optics-core/src/Optics.hs
@@ -5,6 +5,7 @@ module Optics
 import Optics.Equality  as O
 import Optics.Fold      as O
 import Optics.Getter    as O
+import Optics.Getting   as O
 import Optics.Iso       as O
 import Optics.Lens      as O
 import Optics.Optic     as O

--- a/optics-core/src/Optics/Getter.hs
+++ b/optics-core/src/Optics/Getter.hs
@@ -4,7 +4,6 @@ module Optics.Getter
   , toGetter
   , mkGetter
   , to
-  , view
   , module Optics.Optic
   )
   where

--- a/optics-core/src/Optics/Getting.hs
+++ b/optics-core/src/Optics/Getting.hs
@@ -1,0 +1,12 @@
+module Optics.Getting
+  ( A_Getting
+  , Getting
+  , toGetting
+  , mkGetting
+  , view
+  , module Optics.Optic
+  )
+  where
+
+import Optics.Internal.Getting
+import Optics.Optic

--- a/optics-core/src/Optics/Internal.hs
+++ b/optics-core/src/Optics/Internal.hs
@@ -19,6 +19,7 @@ import GHC.Exts (Constraint)
 
 import Optics.Internal.Fold
 import Optics.Internal.Getter
+import Optics.Internal.Getting
 import Optics.Internal.Iso
 import Optics.Internal.Lens
 import Optics.Internal.Optic

--- a/optics-core/src/Optics/Internal/Getter.hs
+++ b/optics-core/src/Optics/Internal/Getter.hs
@@ -31,8 +31,3 @@ mkGetter = Optic
 to :: (s -> a) -> Getter s a
 to f = Optic (dimap f (contramap f))
 {-# INLINE to #-}
-
--- | Apply a getter.
-view :: Is k A_Getter => Optic' k s a -> s -> a
-view o = getConst . getOptic (toGetter o) Const
-{-# INLINE view #-}

--- a/optics-core/src/Optics/Internal/Getting.hs
+++ b/optics-core/src/Optics/Internal/Getting.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+module Optics.Internal.Getting where
+
+import Control.Applicative (Const(..))
+
+import Optics.Internal.Optic
+
+-- | Tag for a getting.
+data A_Getting r
+
+-- | Constraints corresponding to a getting.
+type instance Constraints (A_Getting r) p f =
+  (p ~ (->), f ~ Const r)
+
+-- | Type synonym for a getting.
+type Getting r s a = Optic' (A_Getting r) s a
+
+-- | Explicitly cast an optic to a getting.
+toGetting :: Is k (A_Getting r) => Optic' k s a -> Getting r s a
+toGetting = sub
+{-# INLINE toGetting #-}
+
+-- | Create a getting.
+mkGetting :: Optic_' (A_Getting r) s a -> Getting r s a
+mkGetting = Optic
+{-# INLINE mkGetting #-}
+
+-- | Apply a getting.
+view :: Is k (A_Getting a) => Optic' k s a -> s -> a
+view o = getConst . getOptic (toGetting o) Const
+{-# INLINE view #-}

--- a/optics-core/src/Optics/Internal/Subtyping.hs
+++ b/optics-core/src/Optics/Internal/Subtyping.hs
@@ -7,6 +7,7 @@ module Optics.Internal.Subtyping where
 import Optics.Internal.Equality
 import Optics.Internal.Fold
 import Optics.Internal.Getter
+import Optics.Internal.Getting
 import Optics.Internal.Iso
 import Optics.Internal.Lens
 import Optics.Internal.Optic
@@ -16,9 +17,14 @@ import Optics.Internal.Profunctor
 import Optics.Internal.Review
 import Optics.Internal.Setter
 
--- Instances for A_Fold
+-- Instances for A_Getting
 --
 -- (none)
+
+-- Instances for A_Fold
+
+instance (Monoid r) => Is A_Fold (A_Getting r) where
+  implies _ = id
 
 -- Instances for A_Setter
 --
@@ -26,10 +32,16 @@ import Optics.Internal.Setter
 
 -- Instances for A_Getter
 
+instance Is A_Getter (A_Getting r) where
+  implies _ = id
+
 instance Is A_Getter A_Fold where
   implies _ = id
 
 -- Instances for A_Traversal
+
+instance (Monoid r) => Is A_Traversal (A_Getting r) where
+  implies _ = id
 
 instance Is A_Traversal A_Fold where
   implies _ = id
@@ -38,6 +50,9 @@ instance Is A_Traversal A_Setter where
   implies _ = id
 
 -- Instances for A_Lens
+
+instance Is A_Lens (A_Getting r) where
+  implies _ = id
 
 instance Is A_Lens A_Fold where
   implies _ = id
@@ -57,6 +72,9 @@ instance Is A_Lens A_Traversal where
 
 -- Instances for A_Prism
 
+instance (Monoid r) => Is A_Prism (A_Getting r) where
+  implies _ = id
+
 instance Is A_Prism A_Fold where
   implies _ = id
 
@@ -70,6 +88,9 @@ instance Is A_Prism A_Traversal where
   implies _ = id
 
 -- Instances for An_Iso
+
+instance Is An_Iso (A_Getting r) where
+  implies _ = id
 
 instance Is An_Iso A_Fold where
   implies _ = id
@@ -93,6 +114,9 @@ instance Is An_Iso A_Prism where
   implies _ = id
 
 -- Instances for An_Equality
+
+instance Is An_Equality (A_Getting r) where
+  implies _ = id
 
 instance Is An_Equality A_Fold where
   implies _ = id
@@ -120,70 +144,85 @@ instance Is An_Equality An_Iso where
 
 -- Join instances
 
-instance Join A_Fold      A_Getter     A_Fold
-instance Join A_Fold      A_Traversal  A_Fold
-instance Join A_Fold      A_Lens       A_Fold
-instance Join A_Fold      A_Prism      A_Fold
-instance Join A_Fold      An_Iso       A_Fold
-instance Join A_Fold      An_Equality  A_Fold
+instance (Monoid r) => Join (A_Getting r) A_Fold        (A_Getting r)
+instance               Join (A_Getting r) A_Getter      (A_Getting r)
+instance (Monoid r) => Join (A_Getting r) A_Traversal   (A_Getting r)
+instance               Join (A_Getting r) A_Lens        (A_Getting r)
+instance (Monoid r) => Join (A_Getting r) A_Prism       (A_Getting r)
+instance               Join (A_Getting r) An_Iso        (A_Getting r)
+instance               Join (A_Getting r) An_Equality   (A_Getting r)
 
-instance Join A_Setter    A_Traversal  A_Setter
-instance Join A_Setter    A_Lens       A_Setter
-instance Join A_Setter    A_Prism      A_Setter
-instance Join A_Setter    An_Iso       A_Setter
-instance Join A_Setter    An_Equality  A_Setter
+instance (Monoid r) => Join A_Fold        (A_Getting r) (A_Getting r)
+instance               Join A_Fold        A_Getter      A_Fold
+instance               Join A_Fold        A_Traversal   A_Fold
+instance               Join A_Fold        A_Lens        A_Fold
+instance               Join A_Fold        A_Prism       A_Fold
+instance               Join A_Fold        An_Iso        A_Fold
+instance               Join A_Fold        An_Equality   A_Fold
 
-instance Join A_Getter    A_Fold       A_Fold
-instance Join A_Getter    A_Traversal  A_Fold
-instance Join A_Getter    A_Lens       A_Getter
-instance Join A_Getter    A_Prism      A_Fold
-instance Join A_Getter    An_Iso       A_Getter
-instance Join A_Getter    An_Equality  A_Getter
+instance               Join A_Setter      A_Traversal   A_Setter
+instance               Join A_Setter      A_Lens        A_Setter
+instance               Join A_Setter      A_Prism       A_Setter
+instance               Join A_Setter      An_Iso        A_Setter
+instance               Join A_Setter      An_Equality   A_Setter
 
-instance Join A_Traversal A_Fold       A_Fold
-instance Join A_Traversal A_Setter     A_Setter
-instance Join A_Traversal A_Getter     A_Fold
-instance Join A_Traversal A_Lens       A_Traversal
-instance Join A_Traversal A_Prism      A_Traversal
-instance Join A_Traversal An_Iso       A_Traversal
-instance Join A_Traversal An_Equality  A_Traversal
+instance               Join A_Getter      (A_Getting r) (A_Getting r)
+instance               Join A_Getter      A_Fold        A_Fold
+instance               Join A_Getter      A_Traversal   A_Fold
+instance               Join A_Getter      A_Lens        A_Getter
+instance               Join A_Getter      A_Prism       A_Fold
+instance               Join A_Getter      An_Iso        A_Getter
+instance               Join A_Getter      An_Equality   A_Getter
 
-instance Join A_Lens      A_Fold       A_Fold
-instance Join A_Lens      A_Setter     A_Setter
-instance Join A_Lens      A_Getter     A_Getter
-instance Join A_Lens      A_Traversal  A_Traversal
-instance Join A_Lens      A_Prism      A_Traversal
-instance Join A_Lens      An_Iso       A_Lens
-instance Join A_Lens      An_Equality  A_Lens
+instance (Monoid r) => Join A_Traversal   (A_Getting r) (A_Getting r)
+instance               Join A_Traversal   A_Fold        A_Fold
+instance               Join A_Traversal   A_Setter      A_Setter
+instance               Join A_Traversal   A_Getter      A_Fold
+instance               Join A_Traversal   A_Lens        A_Traversal
+instance               Join A_Traversal   A_Prism       A_Traversal
+instance               Join A_Traversal   An_Iso        A_Traversal
+instance               Join A_Traversal   An_Equality   A_Traversal
 
-instance Join A_Review    A_Prism      A_Review
-instance Join A_Review    An_Iso       A_Review
-instance Join A_Review    An_Equality  A_Review
+instance               Join A_Lens        (A_Getting r) (A_Getting r)
+instance               Join A_Lens        A_Fold        A_Fold
+instance               Join A_Lens        A_Setter      A_Setter
+instance               Join A_Lens        A_Getter      A_Getter
+instance               Join A_Lens        A_Traversal   A_Traversal
+instance               Join A_Lens        A_Prism       A_Traversal
+instance               Join A_Lens        An_Iso        A_Lens
+instance               Join A_Lens        An_Equality   A_Lens
 
-instance Join A_Prism     A_Fold       A_Fold
-instance Join A_Prism     A_Setter     A_Setter
-instance Join A_Prism     A_Getter     A_Fold
-instance Join A_Prism     A_Traversal  A_Traversal
-instance Join A_Prism     A_Lens       A_Traversal
-instance Join A_Prism     A_Review     A_Review
-instance Join A_Prism     An_Iso       A_Prism
-instance Join A_Prism     An_Equality  A_Prism
+instance               Join A_Review      A_Prism       A_Review
+instance               Join A_Review      An_Iso        A_Review
+instance               Join A_Review      An_Equality   A_Review
 
-instance Join An_Iso      A_Fold       A_Fold
-instance Join An_Iso      A_Setter     A_Setter
-instance Join An_Iso      A_Getter     A_Getter
-instance Join An_Iso      A_Traversal  A_Traversal
-instance Join An_Iso      A_Lens       A_Lens
-instance Join An_Iso      A_Review     A_Review
-instance Join An_Iso      A_Prism      A_Prism
-instance Join An_Iso      An_Equality  An_Iso
+instance (Monoid r) => Join A_Prism       (A_Getting r) (A_Getting r)
+instance               Join A_Prism       A_Fold        A_Fold
+instance               Join A_Prism       A_Setter      A_Setter
+instance               Join A_Prism       A_Getter      A_Fold
+instance               Join A_Prism       A_Traversal   A_Traversal
+instance               Join A_Prism       A_Lens        A_Traversal
+instance               Join A_Prism       A_Review      A_Review
+instance               Join A_Prism       An_Iso        A_Prism
+instance               Join A_Prism       An_Equality   A_Prism
 
-instance Join An_Equality A_Fold       A_Fold
-instance Join An_Equality A_Setter     A_Setter
-instance Join An_Equality A_Getter     A_Getter
-instance Join An_Equality A_Traversal  A_Traversal
-instance Join An_Equality A_Lens       A_Lens
-instance Join An_Equality A_Review     A_Review
-instance Join An_Equality A_Prism      A_Prism
-instance Join An_Equality An_Iso       An_Iso
+instance               Join An_Iso        (A_Getting r) (A_Getting r)
+instance               Join An_Iso        A_Fold        A_Fold
+instance               Join An_Iso        A_Setter      A_Setter
+instance               Join An_Iso        A_Getter      A_Getter
+instance               Join An_Iso        A_Traversal   A_Traversal
+instance               Join An_Iso        A_Lens        A_Lens
+instance               Join An_Iso        A_Review      A_Review
+instance               Join An_Iso        A_Prism       A_Prism
+instance               Join An_Iso        An_Equality   An_Iso
+
+instance               Join An_Equality   (A_Getting r) (A_Getting r)
+instance               Join An_Equality   A_Fold        A_Fold
+instance               Join An_Equality   A_Setter      A_Setter
+instance               Join An_Equality   A_Getter      A_Getter
+instance               Join An_Equality   A_Traversal   A_Traversal
+instance               Join An_Equality   A_Lens        A_Lens
+instance               Join An_Equality   A_Review      A_Review
+instance               Join An_Equality   A_Prism       A_Prism
+instance               Join An_Equality   An_Iso        An_Iso
 


### PR DESCRIPTION
(I'm in principle ok to merge this for now, but I'm not convinced that this is the right approach, even though it mirrors what the lens package does.)

This is above Fold.

Fold, Traversal, and everything below can be cast to a Getting
with an extra Monoid constraint.

Getter, Lens and everything below can be cast to a Getting without
any extra constraints.