### PR TITLE
Add optics-sop library.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,3 @@
 packages:
-  optics-core/*.cabal
+  optics-core/*.cabal,
+  optics-sop/*.cabal

--- a/optics-sop/LICENSE
+++ b/optics-sop/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2017, Well-Typed LLP
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Andres Loeh nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/optics-sop/Setup.hs
+++ b/optics-sop/Setup.hs
@@ -1,0 +1,4 @@
+import Distribution.Simple
+
+main :: IO ()
+main = defaultMain

--- a/optics-sop/optics-sop.cabal
+++ b/optics-sop/optics-sop.cabal
@@ -1,0 +1,20 @@
+name: optics-sop
+version: 0.1
+license: BSD3
+license-file: LICENSE
+build-type: Simple
+cabal-version: >= 1.10
+tested-with: GHC == 7.10.3, GHC == 8.0.2
+
+library
+  default-language: Haskell2010
+  hs-source-dirs: src
+  ghc-options: -Wall
+  build-depends:
+    base >= 4.8 && < 5,
+    generics-sop >= 0.2.4.0 && < 0.3,
+    optics-core >= 0.1 && < 1
+  exposed-modules:
+    Generics.SOP.Optics
+    Optics.SOP
+    Optics.SOP.ToTuple

--- a/optics-sop/src/Generics/SOP/Optics.hs
+++ b/optics-sop/src/Generics/SOP/Optics.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+module Generics.SOP.Optics
+  ( rep
+  , sop
+  , z
+  , i
+  , k
+  , record
+  , npHead
+  , npTail
+  , npSingleton
+  , _Z
+  , _S
+  )
+  where
+
+import Generics.SOP
+import Optics hiding (from, to)
+
+-- | Iso between a generic type and its representation.
+rep :: Generic a => Iso' a (Rep a)
+rep = iso from to
+
+-- | Iso induced by the 'SOP' newtype.
+sop :: Iso' (SOP f xss) (NS (NP f) xss)
+sop = iso unSOP SOP
+
+-- | Iso between a one-element sum and its contents.
+z :: Iso' (NS f '[ x ]) (f x)
+z = iso unZ Z
+
+-- | Iso induced by the 'I' newtype.
+i :: Iso' (I x) x
+i = iso unI I
+
+-- | Iso induced by the 'K' newtype.
+k :: Iso' (K x y) x
+k = iso unK K
+
+-- | Iso between a generic record type and its product representation.
+record :: (Generic a, Code a ~ '[ xs ]) => Iso' a (NP I xs)
+record = rep % sop % z
+
+-- | Lens accessing the head of an 'NP'.
+npHead :: Lens' (NP f (x ': xs)) (f x)
+npHead = mkLens (\ f (x :* xs) -> (:* xs) <$> f x)
+
+-- | Lens accessing the tail of an 'NP'.
+npTail :: Lens' (NP f (x ': xs)) (NP f xs)
+npTail = mkLens (\ f (x :* xs) -> (x :*) <$> f xs)
+
+-- | Iso between a single-element 'NP' and its contents.
+npSingleton :: Iso' (NP f '[ x ]) (f x)
+npSingleton = iso hd (:* Nil) 
+
+-- | Prism for the first option in an 'NS'.
+_Z :: Prism' (NS f (x ': xs)) (f x)
+_Z = prism Z $ \ ns -> case ns of
+  Z x -> Right x
+  S _ -> Left ns
+
+-- | Prism for the other options in an 'NS'.
+_S :: Prism' (NS f (x ': xs)) (NS f xs)
+_S = prism S $ \ ns -> case ns of
+  Z _ -> Left ns
+  S x -> Right x

--- a/optics-sop/src/Optics/SOP.hs
+++ b/optics-sop/src/Optics/SOP.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+module Optics.SOP
+  ( WrappedLens(..)
+  , WrappedNPPrism(..)
+  , WrappedPrism(..)
+  , lenses
+  , npPrisms
+  , prisms
+  , LensesFor(..)
+  , NPPrismsFor(..)
+  , PrismsFor(..)
+  , mkLenses
+  , mkNPPrisms
+  , mkPrisms
+  )
+  where
+
+import Data.Coerce
+import Generics.SOP
+import Optics
+
+import Generics.SOP.Optics
+import Optics.SOP.ToTuple
+
+-- | Wrapped form of a simple lens, to enable partial application.
+newtype WrappedLens    s a  = WrappedLens    { unWrapLens :: Lens' s a }
+-- | Wrapped form of a prism to an 'NP', to enable partial application.
+newtype WrappedNPPrism s xs = WrappedNPPrism { unWrapNPPrism :: Prism' s (NP I xs) }
+-- | Wrapped form of a prism to a tuple, to enable partial application.
+newtype WrappedPrism   s xs = WrappedPrism   { unWrapPrism :: Prism' s (ToTuple xs) }
+
+-- | Produce an 'NP' of wrapped lenses for a generic record type.
+lenses ::
+  forall a xs .
+  (Generic a, Code a ~ '[ xs ]) => NP (WrappedLens a) xs
+lenses = hmap (coerce (record %)) (go sList)
+  where
+    go :: forall ys . SList ys -> NP (WrappedLens (NP I ys)) ys
+    go SNil  = Nil
+    go SCons = coerce (npHead % i) :* hmap (coerce (npTail %)) (go sList)
+
+-- | Produce an 'NP' of wrapped prisms for a generic record type.
+--
+-- Prisms match the big type to a product of the constructor arguments.
+-- In this variant, 'NP' is used to represent these products.
+--
+npPrisms ::
+  forall a xss .
+  (Generic a, Code a ~ xss) => NP (WrappedNPPrism a) xss
+npPrisms = hmap (coerce (rep % sop %)) (go sList)
+  where
+    go :: forall yss . SList yss -> NP (WrappedNPPrism (NS (NP I) yss)) yss
+    go SNil  = Nil
+    go SCons = coerce _Z :* hmap (coerce (_S %)) (go sList)
+
+-- | Produce an 'NP' of wrapped prisms for a generic record type.
+--
+-- Prisms match the big type to a product of the constructor arguments.
+-- In this variant, tuples are used to represent these products.
+--
+prisms ::
+  forall a xss .
+  (Generic a, Code a ~ xss, All TupleLike xss) => NP (WrappedPrism a) xss
+prisms =
+  hcmap (Proxy :: Proxy TupleLike)
+    (\ (WrappedNPPrism p) -> WrappedPrism (p % tuple)) npPrisms
+
+-- | Map a type-level function over a type-level list.
+--
+-- Used to unpack the wrapped variants of optics in a product.
+--
+type family Unpack f xs where
+  Unpack f '[]       = '[]
+  Unpack f (x ': xs) = ApplyWrapped f x ': Unpack f xs
+
+-- | Type-level function that unwraps a wrapped optic.
+type family ApplyWrapped (f :: k -> *) (x :: k) :: *
+type instance ApplyWrapped (WrappedLens s)    a  = Lens' s a
+type instance ApplyWrapped (WrappedNPPrism s) xs = Prism' s (NP I xs)
+type instance ApplyWrapped (WrappedPrism s)   xs = Prism' s (ToTuple xs)
+
+-- | Convenience type synonym combining unpacking a type-level
+-- list with turning it into a tuple.
+--
+type TupleUnpack f xs = (TupleLike (Unpack f xs)) => ToTuple (Unpack f xs)
+
+-- | Given an unpacking function for the elements,
+-- unpack an 'NP' and turn it into a tuple.
+--
+tupleUnpack ::
+  forall f xs .
+  (forall x . f x -> ApplyWrapped f x) -> NP f xs -> TupleUnpack f xs
+tupleUnpack un = view tuple . go
+  where
+    go :: forall ys . NP f ys -> NP I (Unpack f ys)
+    go Nil       = Nil
+    go (x :* xs) = I (un x) :* go xs
+
+-- | Wrapper type holding the lenses for a generic datatype as a tuple.
+newtype LensesFor a =
+  Lenses ((Generic a) => TupleUnpack (WrappedLens a) (Extract (Code a)))
+
+-- | Helper function needed by 'LensesFor'.
+type family Extract xss where
+  Extract '[ xs ] = xs
+
+-- | Wrapper type holding the ('NP'-)prisms for a generic datatype as a tuple.
+data NPPrismsFor a =
+  NPPrisms ((Generic a) => TupleUnpack (WrappedNPPrism a) (Code a))
+
+-- | Wrapper type holding the (tuple-)prisms for a generic datatype as a tuple.
+data PrismsFor a =
+  Prisms ((Generic a) => TupleUnpack (WrappedPrism a) (Code a))
+
+-- | Produce all lenses for a generic record datatype.
+mkLenses :: forall a xs . (Generic a, Code a ~ '[ xs ]) => LensesFor a
+mkLenses =
+  Lenses (tupleUnpack unWrapLens (lenses :: NP (WrappedLens a) xs))
+
+-- | Produce all ('NP'-)prisms for a generic datatype.
+mkNPPrisms :: forall a xss . (Generic a, Code a ~ xss) => NPPrismsFor a
+mkNPPrisms =
+  NPPrisms (tupleUnpack unWrapNPPrism (npPrisms :: NP (WrappedNPPrism a) xss))
+
+-- | Produce all (tuple-)prisms for a generic datatype.
+mkPrisms :: forall a xss . (Generic a, Code a ~ xss, All TupleLike xss) => PrismsFor a
+mkPrisms =
+ Prisms (tupleUnpack unWrapPrism (prisms :: NP (WrappedPrism a) xss))

--- a/optics-sop/src/Optics/SOP/ToTuple.hs
+++ b/optics-sop/src/Optics/SOP/ToTuple.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+module Optics.SOP.ToTuple where
+
+import Generics.SOP hiding (from, to)
+import Optics
+
+import Generics.SOP.Optics
+
+type family ToTuple (xs :: [*]) :: * where
+  ToTuple '[]                                        = ()
+  ToTuple '[x1]                                      = x1
+  ToTuple '[x1, x2]                                  = (x1, x2)
+  ToTuple '[x1, x2, x3]                              = (x1, x2, x3)
+  ToTuple '[x1, x2, x3, x4]                          = (x1, x2, x3, x4)
+  ToTuple '[x1, x2, x3, x4, x5]                      = (x1, x2, x3, x4, x5)
+  ToTuple '[x1, x2, x3, x4, x5, x6]                  = (x1, x2, x3, x4, x5, x6)
+  ToTuple '[x1, x2, x3, x4, x5, x6, x7]              = (x1, x2, x3, x4, x5, x6, x7)
+  ToTuple '[x1, x2, x3, x4, x5, x6, x7, x8]          = (x1, x2, x3, x4, x5, x6, x7, x8)
+  ToTuple '[x1, x2, x3, x4, x5, x6, x7, x8, x9]      = (x1, x2, x3, x4, x5, x6, x7, x8, x9)
+  ToTuple '[x1, x2, x3, x4, x5, x6, x7, x8, x9, x10] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10)
+
+class TupleLike xs where
+  tuple :: Iso' (NP I xs) (ToTuple xs)
+  default tuple :: (Generic a, Code a ~ '[ xs ], ToTuple xs ~ a) => Iso' (NP I xs) (ToTuple xs)
+  tuple = from record
+
+instance TupleLike '[]
+instance TupleLike '[x1] where
+  tuple = npSingleton % i
+instance TupleLike '[x1, x2]
+instance TupleLike '[x1, x2, x3]
+instance TupleLike '[x1, x2, x3, x4]
+instance TupleLike '[x1, x2, x3, x4, x5]
+instance TupleLike '[x1, x2, x3, x4, x5, x6]
+instance TupleLike '[x1, x2, x3, x4, x5, x6, x7]
+instance TupleLike '[x1, x2, x3, x4, x5, x6, x7, x8]
+instance TupleLike '[x1, x2, x3, x4, x5, x6, x7, x8, x9]
+instance TupleLike '[x1, x2, x3, x4, x5, x6, x7, x8, x9, x10]
+


### PR DESCRIPTION
The library currently has two purposes:

- It defines optics that are useful for working with generics-sop.
- It provides generic functions that allow to derive lenses, prisms
  and isomorphisms for suitable generic datatypes automatically.