### PR TITLE
Hide Constraints type family

### DIFF
--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -29,7 +29,6 @@ library
     Optics.Setter
     Optics.Traversal
   other-modules:
-    Optics.Internal
     Optics.Internal.Equality
     Optics.Internal.Fold
     Optics.Internal.Getter
@@ -43,3 +42,10 @@ library
     Optics.Internal.Subtyping
     Optics.Internal.Tagged
     Optics.Internal.Traversal
+
+test-suite optics-tests
+  default-language: Haskell2010
+  type: exitcode-stdio-1.0
+  main-is: Optics/Tests.hs
+  hs-source-dirs: tests
+  build-depends: base, optics-core

--- a/optics-core/src/Data/Tuple/Optics.hs
+++ b/optics-core/src/Data/Tuple/Optics.hs
@@ -17,7 +17,7 @@ import Optics.Lens
 -- TODO: Introduce a 'Field1' class?
 --
 _1 :: Lens (a, b) (c, b) a c
-_1 = mkLens (\ wrap (a, b) -> (\ c -> (c, b)) <$> wrap a)
+_1 = vlLens (\ wrap (a, b) -> (\ c -> (c, b)) <$> wrap a)
 {-# INLINE _1 #-}
 
 -- | Lens for the second component of a pair.
@@ -25,7 +25,7 @@ _1 = mkLens (\ wrap (a, b) -> (\ c -> (c, b)) <$> wrap a)
 -- TODO: Introduce a 'Field2' class?
 --
 _2 :: Lens (a, b) (a, c) b c
-_2 = mkLens (\ wrap (a, b) -> (\ c -> (a, c)) <$> wrap b)
+_2 = vlLens (\ wrap (a, b) -> (\ c -> (a, c)) <$> wrap b)
 {-# INLINE _2 #-}
 
 -- | Iso between the curried and uncurried versions of a function.

--- a/optics-core/src/Optics/Equality.hs
+++ b/optics-core/src/Optics/Equality.hs
@@ -3,7 +3,7 @@ module Optics.Equality
   , Equality
   , Equality'
   , toEquality
-  , mkEquality
+  , vlEquality
   , Identical(..)
   , runEq
   , module Optics.Optic

--- a/optics-core/src/Optics/Fold.hs
+++ b/optics-core/src/Optics/Fold.hs
@@ -3,7 +3,7 @@ module Optics.Fold
   ( A_Fold
   , Fold
   , toFold
-  , mkFold
+  , vlFold
   , foldMapOf
   , foldrOf
   , foldlOf'

--- a/optics-core/src/Optics/Getter.hs
+++ b/optics-core/src/Optics/Getter.hs
@@ -2,7 +2,7 @@ module Optics.Getter
   ( A_Getter
   , Getter
   , toGetter
-  , mkGetter
+  , vlGetter
   , to
   , view
   , module Optics.Optic

--- a/optics-core/src/Optics/Internal.hs
+++ b/optics-core/src/Optics/Internal.hs
@@ -13,65 +13,15 @@
 --
 module Optics.Internal where
 
-import Optics.Internal.Fold
+import Data.Either.Optics
+import Data.Tuple.Optics
+
 import Optics.Internal.Getter
 import Optics.Internal.Iso
 import Optics.Internal.Lens
 import Optics.Internal.Optic
 import Optics.Internal.Traversal
-import Optics.Internal.Prism
-import Optics.Internal.Setter
 import Optics.Internal.Subtyping ()
-
-
-
-mapped :: Functor f => Setter (f a) (f b) a b
-mapped = sets fmap
-
-
-traversalOf :: forall k s t a b . Is k A_Traversal => Optic k s t a b -> Optic_ A_Traversal s t a b
-traversalOf = getOptic . toTraversal
-
-
-_1 :: Lens (a,y) (b,y) a b
-_1 = lens fst (\ (_,y) x -> (x,y))
-
-
-_Right :: Prism (Either c a) (Either c b) a b
-_Right = prism Right (either (Left . Left) Right)
-
-
-
-
-
-
--- | A constraint that can never be satisfied (accompanied by a
--- helpful witness to anything you like).
-class Absurd where
-  absurd :: a
-
--- | In order to get nice error messages, we complete the type lattice
--- with a universal supertype, whose constraints can never be
--- satisfied.
-data Bogus
-type instance Constraints Bogus p f = Absurd
-instance Is k Bogus where
-  implies = absurd
-
--- | This typeclass has no instances, and is used so that we get
--- suitable unsolved constraint errors when attempting to compose
--- flavours that do not have a (non-'Bogus') common supertype.
---
--- For example, if you try to compose a fold with a setter then you
--- will get an error
---
--- > Could not deduce (CanCompose A_Fold A_Setter)
-class Absurd => CanCompose k l
-
-instance CanCompose A_Fold   A_Setter => Join A_Fold   A_Setter Bogus
-instance CanCompose A_Setter A_Fold   => Join A_Setter A_Fold   Bogus
-instance CanCompose A_Setter A_Getter => Join A_Setter A_Getter Bogus
-instance CanCompose A_Getter A_Setter => Join A_Getter A_Setter Bogus
 
 
 -- | Composing a lens and a traversal yields a traversal

--- a/optics-core/src/Optics/Internal.hs
+++ b/optics-core/src/Optics/Internal.hs
@@ -76,7 +76,7 @@ instance CanCompose A_Getter A_Setter => Join A_Getter A_Setter Bogus
 
 -- | Composing a lens and a traversal yields a traversal
 comp1 :: Traversable t => Optic A_Traversal (t a, y) (t b, y) a b
-comp1 = _1 % mkTraversal traverse
+comp1 = _1 % vlTraversal traverse
 
 -- | Composing two lenses yields a lens
 comp2 :: Optic A_Lens ((a, y), y1) ((b, y), y1) a b

--- a/optics-core/src/Optics/Internal/Equality.hs
+++ b/optics-core/src/Optics/Internal/Equality.hs
@@ -23,8 +23,8 @@ toEquality :: Is k An_Equality => Optic k s t a b -> Equality s t a b
 toEquality = sub
 {-# INLINE toEquality #-}
 
--- | Create an equality.
-mkEquality :: Optic_ An_Equality s t a b -> Equality s t a b
+-- | Build an equality from the van Laarhoven representation.
+mkEquality :: (forall p f . p a (f b) -> p s (f t)) -> Equality s t a b
 mkEquality = Optic
 {-# INLINE mkEquality #-}
 

--- a/optics-core/src/Optics/Internal/Equality.hs
+++ b/optics-core/src/Optics/Internal/Equality.hs
@@ -24,9 +24,9 @@ toEquality = sub
 {-# INLINE toEquality #-}
 
 -- | Build an equality from the van Laarhoven representation.
-mkEquality :: (forall p f . p a (f b) -> p s (f t)) -> Equality s t a b
-mkEquality = Optic
-{-# INLINE mkEquality #-}
+vlEquality :: (forall p f . p a (f b) -> p s (f t)) -> Equality s t a b
+vlEquality = Optic
+{-# INLINE vlEquality #-}
 
 -- | Proof of reflexivity.
 simple :: Equality' a a

--- a/optics-core/src/Optics/Internal/Fold.hs
+++ b/optics-core/src/Optics/Internal/Fold.hs
@@ -25,9 +25,9 @@ toFold = sub
 {-# INLINE toFold #-}
 
 -- | Build a fold from the van Laarhoven representation.
-mkFold :: (forall f . (Applicative f, Contravariant f) => (a -> f a) -> s -> f s) -> Fold s a
-mkFold = Optic
-{-# INLINE mkFold #-}
+vlFold :: (forall f . (Applicative f, Contravariant f) => (a -> f a) -> s -> f s) -> Fold s a
+vlFold = Optic
+{-# INLINE vlFold #-}
 
 -- | Fold via embedding into a monoid.
 foldMapOf :: (Monoid r, Is k A_Fold) => Optic' k s a -> (a -> r) -> s -> r

--- a/optics-core/src/Optics/Internal/Fold.hs
+++ b/optics-core/src/Optics/Internal/Fold.hs
@@ -24,8 +24,8 @@ toFold :: Is k A_Fold => Optic' k s a -> Fold s a
 toFold = sub
 {-# INLINE toFold #-}
 
--- | Create a fold.
-mkFold :: Optic_' A_Fold s a -> Fold s a
+-- | Build a fold from the van Laarhoven representation.
+mkFold :: (forall f . (Applicative f, Contravariant f) => (a -> f a) -> s -> f s) -> Fold s a
 mkFold = Optic
 {-# INLINE mkFold #-}
 

--- a/optics-core/src/Optics/Internal/Getter.hs
+++ b/optics-core/src/Optics/Internal/Getter.hs
@@ -22,8 +22,8 @@ toGetter :: Is k A_Getter => Optic' k s a -> Getter s a
 toGetter = sub
 {-# INLINE toGetter #-}
 
--- | Create a getter.
-mkGetter :: Optic_' A_Getter s a -> Getter s a
+-- | Build a getter from the van Laarhoven representation.
+mkGetter :: (forall f . (Contravariant f, Functor f) => (a -> f a) -> s -> f s) -> Getter s a
 mkGetter = Optic
 {-# INLINE mkGetter #-}
 

--- a/optics-core/src/Optics/Internal/Getter.hs
+++ b/optics-core/src/Optics/Internal/Getter.hs
@@ -23,9 +23,9 @@ toGetter = sub
 {-# INLINE toGetter #-}
 
 -- | Build a getter from the van Laarhoven representation.
-mkGetter :: (forall f . (Contravariant f, Functor f) => (a -> f a) -> s -> f s) -> Getter s a
-mkGetter = Optic
-{-# INLINE mkGetter #-}
+vlGetter :: (forall f . (Contravariant f, Functor f) => (a -> f a) -> s -> f s) -> Getter s a
+vlGetter = Optic
+{-# INLINE vlGetter #-}
 
 -- | Build a getter from a function.
 to :: (s -> a) -> Getter s a

--- a/optics-core/src/Optics/Internal/Iso.hs
+++ b/optics-core/src/Optics/Internal/Iso.hs
@@ -26,9 +26,9 @@ toIso = sub
 {-# INLINE toIso #-}
 
 -- | Build an iso from the van Laarhoven representation.
-mkIso :: (forall p f . (Profunctor p, Functor f) => p a (f b) -> p s (f t)) -> Iso s t a b
-mkIso = Optic
-{-# INLINE mkIso #-}
+vlIso :: (forall p f . (Profunctor p, Functor f) => p a (f b) -> p s (f t)) -> Iso s t a b
+vlIso = Optic
+{-# INLINE vlIso #-}
 
 -- | Build an iso from a pair of inverse functions.
 iso :: (s -> a) -> (b -> t) -> Iso s t a b

--- a/optics-core/src/Optics/Internal/Iso.hs
+++ b/optics-core/src/Optics/Internal/Iso.hs
@@ -25,8 +25,8 @@ toIso :: Is k An_Iso => Optic k s t a b -> Iso s t a b
 toIso = sub
 {-# INLINE toIso #-}
 
--- | Create a lens.
-mkIso :: Optic_ An_Iso s t a b -> Iso s t a b
+-- | Build an iso from the van Laarhoven representation.
+mkIso :: (forall p f . (Profunctor p, Functor f) => p a (f b) -> p s (f t)) -> Iso s t a b
 mkIso = Optic
 {-# INLINE mkIso #-}
 

--- a/optics-core/src/Optics/Internal/Lens.hs
+++ b/optics-core/src/Optics/Internal/Lens.hs
@@ -22,8 +22,8 @@ toLens :: Is k A_Lens => Optic k s t a b -> Lens s t a b
 toLens = sub
 {-# INLINE toLens #-}
 
--- | Create a lens.
-mkLens :: Optic_ A_Lens s t a b -> Lens s t a b
+-- | Build a lens from the van Laarhoven representation.
+mkLens :: (forall f . Functor f => (a -> f b) -> s -> f t) -> Lens s t a b
 mkLens = Optic
 {-# INLINE mkLens #-}
 

--- a/optics-core/src/Optics/Internal/Lens.hs
+++ b/optics-core/src/Optics/Internal/Lens.hs
@@ -23,11 +23,11 @@ toLens = sub
 {-# INLINE toLens #-}
 
 -- | Build a lens from the van Laarhoven representation.
-mkLens :: (forall f . Functor f => (a -> f b) -> s -> f t) -> Lens s t a b
-mkLens = Optic
-{-# INLINE mkLens #-}
+vlLens :: (forall f . Functor f => (a -> f b) -> s -> f t) -> Lens s t a b
+vlLens = Optic
+{-# INLINE vlLens #-}
 
 -- | Build a lens from a getter and setter.
 lens :: (s -> a) -> (s -> b -> t) -> Lens s t a b
-lens get set = mkLens (\ f s -> set s <$> f (get s))
+lens get set = vlLens (\ f s -> set s <$> f (get s))
 {-# INLINE lens #-}

--- a/optics-core/src/Optics/Internal/Prism.hs
+++ b/optics-core/src/Optics/Internal/Prism.hs
@@ -24,14 +24,14 @@ toPrism = sub
 {-# INLINE toPrism #-}
 
 -- | Build a prism from the van Laarhoven representation.
-mkPrism :: (forall p f . (Choice p, Applicative f) => p a (f b) -> p s (f t)) -> Prism s t a b
-mkPrism = Optic
-{-# INLINE mkPrism #-}
+vlPrism :: (forall p f . (Choice p, Applicative f) => p a (f b) -> p s (f t)) -> Prism s t a b
+vlPrism = Optic
+{-# INLINE vlPrism #-}
 
 -- | Build a prism from a constructor and a matcher.
 prism :: (b -> t) -> (s -> Either t a) -> Prism s t a b
 prism construct match =
-  mkPrism (\ p -> dimap match (either pure (fmap construct)) (right' p))
+  vlPrism (\ p -> dimap match (either pure (fmap construct)) (right' p))
 {-# INLINE prism #-}
 
 -- withPrism

--- a/optics-core/src/Optics/Internal/Prism.hs
+++ b/optics-core/src/Optics/Internal/Prism.hs
@@ -23,8 +23,8 @@ toPrism :: Is k A_Prism => Optic k s t a b -> Prism s t a b
 toPrism = sub
 {-# INLINE toPrism #-}
 
--- | Create a prism.
-mkPrism :: Optic_ A_Prism s t a b -> Prism s t a b
+-- | Build a prism from the van Laarhoven representation.
+mkPrism :: (forall p f . (Choice p, Applicative f) => p a (f b) -> p s (f t)) -> Prism s t a b
 mkPrism = Optic
 {-# INLINE mkPrism #-}
 

--- a/optics-core/src/Optics/Internal/Review.hs
+++ b/optics-core/src/Optics/Internal/Review.hs
@@ -27,8 +27,8 @@ toReview :: Is k A_Review => Optic k s t a b -> Review s t a b
 toReview = sub
 {-# INLINE toReview #-}
 
--- | Create a review.
-mkReview :: Optic_ A_Review s t a b -> Review s t a b
+-- | Build a review from the van Laarhoven representation.
+mkReview :: (forall p . (Choice p, Bifunctor p) => p a (Identity b) -> p s (Identity t)) -> Review s t a b
 mkReview = Optic
 {-# INLINE mkReview #-}
 

--- a/optics-core/src/Optics/Internal/Review.hs
+++ b/optics-core/src/Optics/Internal/Review.hs
@@ -28,7 +28,7 @@ toReview = sub
 {-# INLINE toReview #-}
 
 -- | Build a review from the van Laarhoven representation.
-mkReview :: (forall p . (Choice p, Bifunctor p) => p a (Identity b) -> p s (Identity t)) -> Review s t a b
-mkReview = Optic
-{-# INLINE mkReview #-}
+vlReview :: (forall p . (Choice p, Bifunctor p) => p a (Identity b) -> p s (Identity t)) -> Review s t a b
+vlReview = Optic
+{-# INLINE vlReview #-}
 

--- a/optics-core/src/Optics/Internal/Setter.hs
+++ b/optics-core/src/Optics/Internal/Setter.hs
@@ -25,12 +25,12 @@ toSetter :: Is k A_Setter => Optic k s t a b -> Setter s t a b
 toSetter = sub
 {-# INLINE toSetter #-}
 
--- | Create a setter.
-mkSetter :: Optic_ A_Setter s t a b -> Setter s t a b
-mkSetter = Optic
+-- | Build a setter from the van Laarhoven representation.
+mkSetter :: ((a -> Identity b) -> s -> Identity t) -> Setter s t a b
+mkSetter x = Optic x
 {-# INLINE mkSetter #-}
 
--- | Build a setter.
+-- | Build a setter from a function to modify the element(s).
 sets :: ((a -> b) -> (s -> t)) -> Setter s t a b
 sets f = Optic (coerce f)
 {-# INLINE sets #-}

--- a/optics-core/src/Optics/Internal/Setter.hs
+++ b/optics-core/src/Optics/Internal/Setter.hs
@@ -26,9 +26,9 @@ toSetter = sub
 {-# INLINE toSetter #-}
 
 -- | Build a setter from the van Laarhoven representation.
-mkSetter :: ((a -> Identity b) -> s -> Identity t) -> Setter s t a b
-mkSetter x = Optic x
-{-# INLINE mkSetter #-}
+vlSetter :: ((a -> Identity b) -> s -> Identity t) -> Setter s t a b
+vlSetter x = Optic x
+{-# INLINE vlSetter #-}
 
 -- | Build a setter from a function to modify the element(s).
 sets :: ((a -> b) -> (s -> t)) -> Setter s t a b

--- a/optics-core/src/Optics/Internal/Setter.hs
+++ b/optics-core/src/Optics/Internal/Setter.hs
@@ -35,6 +35,10 @@ sets :: ((a -> b) -> (s -> t)) -> Setter s t a b
 sets f = Optic (coerce f)
 {-# INLINE sets #-}
 
+-- | Build a setter from a functor.
+mapped :: Functor f => Setter (f a) (f b) a b
+mapped = sets fmap
+
 -- | Apply a setter as a modifier.
 over :: Is k A_Setter => Optic k s t a b -> (a -> b) -> s -> t
 over o = coerce (getOptic (toSetter o))

--- a/optics-core/src/Optics/Internal/Traversal.hs
+++ b/optics-core/src/Optics/Internal/Traversal.hs
@@ -36,3 +36,8 @@ vlTraversal = Optic
 _traverse :: Traversable t => Traversal (t a) (t b) a b
 _traverse = vlTraversal traverse
 {-# INLINE _traverse #-}
+
+-- | Convert a traversal to the van Laarhoven representation.
+traversalOf :: forall k s t a b . Is k A_Traversal => Optic k s t a b
+            -> (forall f . Applicative f => (a -> f b) -> s -> f t)
+traversalOf = getOptic . toTraversal

--- a/optics-core/src/Optics/Internal/Traversal.hs
+++ b/optics-core/src/Optics/Internal/Traversal.hs
@@ -24,9 +24,9 @@ toTraversal = sub
 {-# INLINE toTraversal #-}
 
 -- | Build a traversal from the van Laarhoven representation.
-mkTraversal :: (forall f . Applicative f => (a -> f b) -> s -> f t) -> Traversal s t a b
-mkTraversal = Optic
-{-# INLINE mkTraversal #-}
+vlTraversal :: (forall f . Applicative f => (a -> f b) -> s -> f t) -> Traversal s t a b
+vlTraversal = Optic
+{-# INLINE vlTraversal #-}
 
 -- | Traversal via the 'Traversal' class.
 --
@@ -34,5 +34,5 @@ mkTraversal = Optic
 -- use 'traverse'. The name here is preliminary.
 --
 _traverse :: Traversable t => Traversal (t a) (t b) a b
-_traverse = mkTraversal traverse
+_traverse = vlTraversal traverse
 {-# INLINE _traverse #-}

--- a/optics-core/src/Optics/Internal/Traversal.hs
+++ b/optics-core/src/Optics/Internal/Traversal.hs
@@ -23,8 +23,8 @@ toTraversal :: Is k A_Traversal => Optic k s t a b -> Traversal s t a b
 toTraversal = sub
 {-# INLINE toTraversal #-}
 
--- | Create a traversal.
-mkTraversal :: Optic_ A_Traversal s t a b -> Traversal s t a b
+-- | Build a traversal from the van Laarhoven representation.
+mkTraversal :: (forall f . Applicative f => (a -> f b) -> s -> f t) -> Traversal s t a b
 mkTraversal = Optic
 {-# INLINE mkTraversal #-}
 

--- a/optics-core/src/Optics/Iso.hs
+++ b/optics-core/src/Optics/Iso.hs
@@ -3,7 +3,7 @@ module Optics.Iso
   , Iso
   , Iso'
   , toIso
-  , mkIso
+  , vlIso
   , iso
   , withIso
   , from

--- a/optics-core/src/Optics/Lens.hs
+++ b/optics-core/src/Optics/Lens.hs
@@ -3,7 +3,7 @@ module Optics.Lens
   , Lens
   , Lens'
   , toLens
-  , mkLens
+  , vlLens
   , lens
   , module Optics.Optic
   )

--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -1,9 +1,6 @@
 module Optics.Optic
   ( Optic()
-  , Optic_
-  , Optic__
   , Optic'
-  , Optic_'
   , Is()
   , sub
   , Join()

--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -4,10 +4,11 @@ module Optics.Optic
   , Is()
   , sub
   , Join()
+  , CanCompose()
   , (%)
   , (%%)
   )
   where
 
 import Optics.Internal.Optic
-import Optics.Internal.Subtyping ()
+import Optics.Internal.Subtyping (CanCompose)

--- a/optics-core/src/Optics/Prism.hs
+++ b/optics-core/src/Optics/Prism.hs
@@ -3,7 +3,7 @@ module Optics.Prism
   , Prism
   , Prism'
   , toPrism
-  , mkPrism
+  , vlPrism
   , prism
   , module Optics.Optic
   )

--- a/optics-core/src/Optics/Review.hs
+++ b/optics-core/src/Optics/Review.hs
@@ -4,7 +4,7 @@ module Optics.Review
   , Review
   , Review'
   , toReview
-  , mkReview
+  , vlReview
   , re
   , review
   , module Optics.Optic

--- a/optics-core/src/Optics/Setter.hs
+++ b/optics-core/src/Optics/Setter.hs
@@ -7,6 +7,7 @@ module Optics.Setter
   , sets
   , over
   , set
+  , mapped
   , module Optics.Optic
   )
   where

--- a/optics-core/src/Optics/Setter.hs
+++ b/optics-core/src/Optics/Setter.hs
@@ -3,7 +3,7 @@ module Optics.Setter
   , Setter
   , Setter'
   , toSetter
-  , mkSetter
+  , vlSetter
   , sets
   , over
   , set

--- a/optics-core/src/Optics/Traversal.hs
+++ b/optics-core/src/Optics/Traversal.hs
@@ -5,6 +5,7 @@ module Optics.Traversal
   , toTraversal
   , vlTraversal
   , _traverse
+  , traversalOf
   , module Optics.Optic
   )
   where

--- a/optics-core/src/Optics/Traversal.hs
+++ b/optics-core/src/Optics/Traversal.hs
@@ -3,7 +3,7 @@ module Optics.Traversal
   , Traversal
   , Traversal'
   , toTraversal
-  , mkTraversal
+  , vlTraversal
   , _traverse
   , module Optics.Optic
   )

--- a/optics-core/tests/Optics/Tests.hs
+++ b/optics-core/tests/Optics/Tests.hs
@@ -9,19 +9,13 @@
            #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
--- | Remnants that have not yet been moved to other modules.
---
-module Optics.Internal where
+-- | At the moment, merely compiling this module is all the testing we do.
+module Main where
 
 import Data.Either.Optics
 import Data.Tuple.Optics
 
-import Optics.Internal.Getter
-import Optics.Internal.Iso
-import Optics.Internal.Lens
-import Optics.Internal.Optic
-import Optics.Internal.Traversal
-import Optics.Internal.Subtyping ()
+import Optics
 
 
 -- | Composing a lens and a traversal yields a traversal
@@ -52,3 +46,7 @@ eg2 = view _1
 -- These don't typecheck, as one would expect:
 --   to fst % mapped  -- Cannot compose a getter with a setter
 --   toLens (to fst)  -- Cannot use a getter as a lens
+
+
+main :: IO ()
+main = return ()

--- a/optics-sop/src/Generics/SOP/Optics.hs
+++ b/optics-sop/src/Generics/SOP/Optics.hs
@@ -46,15 +46,15 @@ record = rep % sop % z
 
 -- | Lens accessing the head of an 'NP'.
 npHead :: Lens (NP f (x ': xs)) (NP f (y ': xs)) (f x) (f y)
-npHead = mkLens (\ f (x :* xs) -> (:* xs) <$> f x)
+npHead = vlLens (\ f (x :* xs) -> (:* xs) <$> f x)
 
 -- | Lens accessing the tail of an 'NP'.
 npTail :: Lens (NP f (x ': xs)) (NP f (x ': ys)) (NP f xs) (NP f ys)
-npTail = mkLens (\ f (x :* xs) -> (x :*) <$> f xs)
+npTail = vlLens (\ f (x :* xs) -> (x :*) <$> f xs)
 
 -- | Iso between a single-element 'NP' and its contents.
 npSingleton :: Iso (NP f '[ x ]) (NP g '[ y ]) (f x) (g y)
-npSingleton = iso hd (:* Nil) 
+npSingleton = iso hd (:* Nil)
 
 -- | Prism for the first option in an 'NS'.
 _Z :: Prism (NS f (x ': xs)) (NS f (y ': xs)) (f x) (f y)


### PR DESCRIPTION
This removes all mention of the `Constraints` type family from the public interface.

Should we also rename the `mk...` functions?