### PR TITLE
Support for explicit downcasting indexed optics to regular ones

### DIFF
--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -47,6 +47,7 @@ library
                    Optics.Review
                    Optics.Setter
                    Optics.Traversal
+                   Optics.Unindexed
 
   exposed-modules: Data.Either.Optics
                    Data.Maybe.Optics

--- a/optics-core/src/Optics/Internal/Indexed.hs
+++ b/optics-core/src/Optics/Internal/Indexed.hs
@@ -98,6 +98,10 @@ class Functor f => FunctorWithIndex i f | f -> i where
   imap f = runIdentity #. itraverse (\i -> Identity #. f i)
   {-# INLINE imap #-}
 
+instance FunctorWithIndex i (IxContext i a b) where
+  imap f (IxContext ibt a) = IxContext (\i -> f i . ibt i) a
+  {-# INLINE imap #-}
+
 class (FunctorWithIndex i f, Foldable f
       ) => FoldableWithIndex i f | f -> i where
   ifoldMap :: Monoid m => (i -> a -> m) -> f a -> m

--- a/optics-core/src/Optics/Internal/IxSetter.hs
+++ b/optics-core/src/Optics/Internal/IxSetter.hs
@@ -3,6 +3,7 @@ module Optics.Internal.IxSetter where
 import Optics.Internal.Indexed
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
+import Optics.Internal.Utils
 
 -- | Type synonym for a type-modifying indexed setter.
 type IxSetter i o s t a b = Optic An_IxSetter i o s t a b
@@ -35,10 +36,10 @@ iset o f = iover o (\i _ -> f i)
 isets
   :: ((i -> a -> b) -> s -> t)
   -> IxSetter j (i -> j) s t a b
-isets f = Optic (\(IxFunArrow k) -> IxFunArrow $ \ij -> f $ \i -> k (ij i))
+isets f = Optic (dimap (IxContext (\_ -> id)) (\(IxContext g s) -> f g s) . imap')
 {-# INLINE isets #-}
 
 -- | Indexed setter via the 'FunctorWithIndex' class.
 imapped :: FunctorWithIndex i f => IxSetter j (i -> j) (f a) (f b) a b
-imapped = isets imap
+imapped = Optic imap'
 {-# INLINE imapped #-}

--- a/optics-core/src/Optics/Internal/Optic/Types.hs
+++ b/optics-core/src/Optics/Internal/Optic/Types.hs
@@ -86,12 +86,12 @@ type family Constraints (k :: OpticKind) (p :: * -> * -> * -> *) :: Constraint w
   Constraints 'A_Prism            p = Choice p
   Constraints 'A_PrismaticGetter  p = Cochoice p
   Constraints 'An_AffineTraversal p = (Strong p, Choice p)
-  Constraints 'A_Traversal        p = Traversing p
+  Constraints 'A_Traversal        p = TraversingWithIndex p
   Constraints 'An_IxTraversal     p = TraversingWithIndex p
-  Constraints 'A_Setter           p = Mapping p
+  Constraints 'A_Setter           p = MappingWithIndex p
   Constraints 'An_IxSetter        p = MappingWithIndex p
   Constraints 'A_Getter           p = (Bicontravariant p, Cochoice p, Strong p)
   Constraints 'An_AffineFold      p = (Bicontravariant p, Cochoice p, Strong p, Choice p)
-  Constraints 'A_Fold             p = (Bicontravariant p, Cochoice p, Traversing p)
+  Constraints 'A_Fold             p = (Bicontravariant p, Cochoice p, TraversingWithIndex p)
   Constraints 'An_IxFold          p = (Bicontravariant p, Cochoice p, TraversingWithIndex p)
   Constraints 'A_Review           p = (Bifunctor p, Choice p, Costrong p)

--- a/optics-core/src/Optics/Internal/Optic/Types.hs
+++ b/optics-core/src/Optics/Internal/Optic/Types.hs
@@ -89,7 +89,7 @@ type family Constraints (k :: OpticKind) (p :: * -> * -> * -> *) :: Constraint w
   Constraints 'A_Traversal        p = Traversing p
   Constraints 'An_IxTraversal     p = TraversingWithIndex p
   Constraints 'A_Setter           p = Mapping p
-  Constraints 'An_IxSetter        p = p ~ IxFunArrow
+  Constraints 'An_IxSetter        p = MappingWithIndex p
   Constraints 'A_Getter           p = (Bicontravariant p, Cochoice p, Strong p)
   Constraints 'An_AffineFold      p = (Bicontravariant p, Cochoice p, Strong p, Choice p)
   Constraints 'A_Fold             p = (Bicontravariant p, Cochoice p, Traversing p)

--- a/optics-core/src/Optics/Internal/Setter.hs
+++ b/optics-core/src/Optics/Internal/Setter.hs
@@ -11,14 +11,17 @@ type Setter i s t a b = Optic A_Setter i i s t a b
 type Setter' i s a = Optic' A_Setter i i s a
 
 -- | Explicitly cast an optic to a setter.
-toSetter :: Is k A_Setter => Optic k i i s t a b -> Setter i s t a b
+toSetter
+  :: Is k A_Setter
+  => Optic k i o s t a b
+  -> Optic A_Setter i o s t a b
 toSetter = sub
 {-# INLINE toSetter #-}
 
 -- | Apply a setter as a modifier.
 over
   :: Is k A_Setter
-  => Optic k i i s t a b
+  => Optic k i o s t a b
   -> (a -> b) -> s -> t
 over o = runFunArrow #. getOptic (toSetter o) .# FunArrow
 {-# INLINE over #-}
@@ -30,7 +33,7 @@ over o = runFunArrow #. getOptic (toSetter o) .# FunArrow
 --
 set
   :: Is k A_Setter
-  => Optic k i i s t a b
+  => Optic k i o s t a b
   -> b -> s -> t
 set o = over o . const
 {-# INLINE set #-}

--- a/optics-core/src/Optics/Internal/Traversal.hs
+++ b/optics-core/src/Optics/Internal/Traversal.hs
@@ -18,7 +18,10 @@ type TraversalVL s t a b = forall f. Applicative f => (a -> f b) -> s -> f t
 type TraversalVL' s a = TraversalVL s s a a
 
 -- | Explicitly cast an optic to a traversal.
-toTraversal :: Is k A_Traversal => Optic k i i s t a b -> Traversal i s t a b
+toTraversal
+  :: Is k A_Traversal
+  => Optic k i o s t a b
+  -> Optic A_Traversal i o s t a b
 toTraversal = sub
 {-# INLINE toTraversal #-}
 
@@ -35,7 +38,7 @@ traversed = traversalVL traverse
 -- | Map each element of a structure targeted by a 'Traversal', evaluate these
 -- actions from left to right, and collect the results.
 traverseOf
-  :: (Is k A_Traversal, Applicative f) => Optic k i i s t a b
+  :: (Is k A_Traversal, Applicative f) => Optic k i o s t a b
   -> (a -> f b) -> s -> f t
 traverseOf o = runStar #. getOptic (toTraversal o) .# Star
 {-# INLINE traverseOf #-}

--- a/optics-core/src/Optics/Internal/Utils.hs
+++ b/optics-core/src/Optics/Internal/Utils.hs
@@ -5,6 +5,9 @@ import Data.Coerce
 data Context a b t = Context (b -> t) a
   deriving Functor
 
+data IxContext i a b t = IxContext (i -> b -> t) a
+  deriving Functor
+
 (#.) :: Coercible b c => (b -> c) -> (a -> b) -> (a -> c)
 (#.) _f = coerce
 {-# INLINE (#.) #-}

--- a/optics-core/src/Optics/Unindexed.hs
+++ b/optics-core/src/Optics/Unindexed.hs
@@ -1,0 +1,23 @@
+module Optics.Unindexed where
+
+import Optics.Internal.Optic
+
+class UnindexableOptic k where
+  type UnindexedOptic k :: OpticKind
+  -- | Downcast an indexed optic to its unindexed equivalent.
+  unIx :: Optic k i o s t a b -> Optic (UnindexedOptic k) i o s t a b
+
+instance UnindexableOptic An_IxTraversal where
+  type UnindexedOptic An_IxTraversal = A_Traversal
+  unIx (Optic o) = Optic o
+  {-# INLINE unIx #-}
+
+instance UnindexableOptic An_IxFold where
+  type UnindexedOptic An_IxFold = A_Fold
+  unIx (Optic o) = Optic o
+  {-# INLINE unIx #-}
+
+instance UnindexableOptic An_IxSetter where
+  type UnindexedOptic An_IxSetter = A_Setter
+  unIx (Optic o) = Optic o
+  {-# INLINE unIx #-}


### PR DESCRIPTION
Proof of concept for #25 for now (in particular I think we should have a class with associated function `unIx` instead of `unIxTraversal` etc.

I think it can look better when representing indices as in #41, then regular versions have to accept optics with any list of indices instead of two free type parameters.

@phadej thoughts?
