### PR TITLE
Resolve #42: rename record to productRep

### DIFF
--- a/optics-sop/optics-sop.cabal
+++ b/optics-sop/optics-sop.cabal
@@ -12,7 +12,7 @@ library
   ghc-options: -Wall
   build-depends:
     base >= 4.9 && < 5,
-    generics-sop >= 0.2.4.0 && < 0.4,
+    generics-sop >= 0.3.1.0 && < 0.4,
     optics-core >= 0.1 && < 1
   exposed-modules:
     Generics.SOP.Optics

--- a/optics-sop/src/Generics/SOP/Optics.hs
+++ b/optics-sop/src/Generics/SOP/Optics.hs
@@ -8,7 +8,7 @@ module Generics.SOP.Optics
   , z
   , i
   , k
-  , record
+  , productRep
   , npHead
   , npTail
   , npSingleton
@@ -17,6 +17,7 @@ module Generics.SOP.Optics
   )
   where
 
+import Prelude hiding (product)
 import Generics.SOP
 import Optics hiding (to)
 
@@ -40,9 +41,9 @@ i = iso unI I
 k :: Iso i (K a b) (K c d) a c
 k = iso unK K
 
--- | Iso between a generic record type and its product representation.
-record :: (Generic a, Generic b, Code a ~ '[ xs ], Code b ~ '[ ys ]) => Iso i a b (NP I xs) (NP I ys)
-record = rep % sop % z
+-- | Iso between a generic product type and its product representation.
+productRep :: (IsProductType a xs, IsProductType b ys) => Iso i a b (NP I xs) (NP I ys)
+productRep = rep % sop % z
 
 -- | Lens accessing the head of an 'NP'.
 npHead :: Lens i (NP f (x ': xs)) (NP f (y ': xs)) (f x) (f y)

--- a/optics-sop/src/Optics/SOP.hs
+++ b/optics-sop/src/Optics/SOP.hs
@@ -35,17 +35,17 @@ newtype WrappedNPPrism i s xs = WrappedNPPrism { unWrapNPPrism :: Prism' i s (NP
 -- | Wrapped form of a prism to a tuple, to enable partial application.
 newtype WrappedPrism   i s xs = WrappedPrism   { unWrapPrism :: Prism' i s (ToTuple xs) }
 
--- | Produce an 'NP' of wrapped lenses for a generic record type.
+-- | Produce an 'NP' of wrapped lenses for a generic product type.
 lenses ::
   forall i a xs .
-  (Generic a, Code a ~ '[ xs ]) => NP (WrappedLens i a) xs
-lenses = hmap (coerce (record %)) (go sList)
+  (IsProductType a xs) => NP (WrappedLens i a) xs
+lenses = hmap (coerce (productRep %)) (go sList)
   where
     go :: forall ys . SList ys -> NP (WrappedLens i (NP I ys)) ys
     go SNil  = Nil
     go SCons = coerce (npHead % i) :* hmap (coerce (npTail %)) (go sList)
 
--- | Produce an 'NP' of wrapped prisms for a generic record type.
+-- | Produce an 'NP' of wrapped prisms for a generic product type.
 --
 -- Prisms match the big type to a product of the constructor arguments.
 -- In this variant, 'NP' is used to represent these products.
@@ -59,7 +59,7 @@ npPrisms = hmap (coerce (rep % sop %)) (go sList)
     go SNil  = Nil
     go SCons = coerce _Z :* hmap (coerce (_S %)) (go sList)
 
--- | Produce an 'NP' of wrapped prisms for a generic record type.
+-- | Produce an 'NP' of wrapped prisms for a generic product type.
 --
 -- Prisms match the big type to a product of the constructor arguments.
 -- In this variant, tuples are used to represent these products.
@@ -119,7 +119,7 @@ data PrismsFor i a =
   Prisms ((Generic a) => TupleUnpack (WrappedPrism i a) (Code a))
 
 -- | Produce all lenses for a generic record datatype.
-mkLenses :: forall i a xs . (Generic a, Code a ~ '[ xs ]) => LensesFor i a
+mkLenses :: forall i a xs . (IsProductType a xs) => LensesFor i a
 mkLenses =
   Lenses (tupleUnpack unWrapLens (lenses :: NP (WrappedLens i a) xs))
 

--- a/optics-sop/src/Optics/SOP/ToTuple.hs
+++ b/optics-sop/src/Optics/SOP/ToTuple.hs
@@ -30,8 +30,8 @@ type family ToTuple (xs :: [*]) :: * where
 
 class TupleLike xs where
   tuple :: Iso' i (NP I xs) (ToTuple xs)
-  default tuple :: (Generic a, Code a ~ '[ xs ], ToTuple xs ~ a) => Iso' i (NP I xs) (ToTuple xs)
-  tuple = re record
+  default tuple :: (IsProductType a xs, ToTuple xs ~ a) => Iso' i (NP I xs) (ToTuple xs)
+  tuple = re productRep
 
 instance TupleLike '[]
 instance TupleLike '[x1] where


### PR DESCRIPTION
`product` is a name from Prelude, so we use `productRep`, as it's
like `rep` but for products.