### PR TITLE
Expose CheckIndices for haddock and cleaner signatures

### DIFF
--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -84,6 +84,7 @@ library
 
   default-extensions:
     BangPatterns
+    DataKinds
     DefaultSignatures
     DeriveFunctor
     FlexibleContexts
@@ -97,5 +98,3 @@ library
     TupleSections
     TypeFamilies
     TypeOperators
-
-  default-extensions: DataKinds

--- a/optics-core/src/Optics/Internal/Indexed.hs
+++ b/optics-core/src/Optics/Internal/Indexed.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Optics.Internal.Indexed where
 

--- a/optics-core/src/Optics/Internal/Optic/Subtyping.hs
+++ b/optics-core/src/Optics/Internal/Optic/Subtyping.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Instances to implement the subtyping hierarchy between optics.

--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -8,8 +8,10 @@ module Optics.Optic
   , Join
   , (%)
   , (%%)
-  , Append,
+  , Append
+  , CheckIndices
   )
   where
 
+import Optics.Internal.Indexed
 import Optics.Internal.Optic


### PR DESCRIPTION
Solves #78.

I skipped the internal superclass because it actually makes things worse.

```haskell
λ> :t itraverseOf
itraverseOf
  :: (Optics.Internal.Indexed.CheckIndicesInternal i,
      Is k A_Traversal, Applicative f) =>
     Optic k '[i] s t a b -> (i -> a -> f b) -> s -> f t
```

I don't think it's a big deal though as this class is only for helpful error messages.