### PR TITLE
Use DataKinds only where it's needed

### DIFF
--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -87,7 +87,6 @@ library
 
   default-extensions:
     BangPatterns
-    DataKinds
     DefaultSignatures
     DeriveFunctor
     FlexibleContexts

--- a/optics-core/src/Optics/Arrow.hs
+++ b/optics-core/src/Optics/Arrow.hs
@@ -49,7 +49,7 @@ instance ArrowChoice p => Choice (WrappedArrow p) where
 
 class Arrow arr => ArrowOptic k arr where
   -- | Turn an optic into an arrow transformer.
-  overA :: Optic k '[] s t a b -> arr a b -> arr s t
+  overA :: Optic k is s t a b -> arr a b -> arr s t
 
 instance Arrow arr => ArrowOptic An_Equality arr where
   overA = overA__
@@ -90,7 +90,7 @@ instance ArrowChoice arr => ArrowOptic An_AffineTraversal arr where
 -- has the type @'Either' 'String' ('Int', 'Bool', 'Char')@
 assignA
   :: (Is k A_Setter, Arrow arr)
-  => Optic k '[] s t a b
+  => Optic k is s t a b
   -> arr s b -> arr s t
 assignA o p = arr (flip $ set o) &&& p >>> arr (uncurry id)
 {-# INLINE assignA #-}
@@ -100,7 +100,7 @@ assignA o p = arr (flip $ set o) &&& p >>> arr (uncurry id)
 -- | Internal implementation of overA.
 overA__
   :: Constraints k (WrappedArrow arr)
-  => Optic k '[] s t a b
+  => Optic k is s t a b
   -> arr a b -> arr s t
 overA__ o = unwrapArrow #. getOptic o .# WrapArrow
 {-# INLINE overA__ #-}

--- a/optics-core/src/Optics/Indexed.hs
+++ b/optics-core/src/Optics/Indexed.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeApplications #-}
 module Optics.Indexed
   (

--- a/optics-core/src/Optics/Internal/Indexed.hs
+++ b/optics-core/src/Optics/Internal/Indexed.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Optics.Internal.Indexed where
 

--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 -- | Core optic types and subtyping machinery.
 --
 -- This module contains the core 'Optic' types, and the underlying

--- a/optics-core/src/Optics/Internal/Optic/Subtyping.hs
+++ b/optics-core/src/Optics/Internal/Optic/Subtyping.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE UndecidableInstances #-}
-
 -- | Instances to implement the subtyping hierarchy between optics.
 --
 module Optics.Internal.Optic.Subtyping where

--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -1,7 +1,8 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE InstanceSigs #-}
 module Optics.Internal.Optic.TypeLevel where
 
 import Data.Type.Equality

--- a/optics-core/src/Optics/LensyReview.hs
+++ b/optics-core/src/Optics/LensyReview.hs
@@ -9,7 +9,7 @@ import Optics.Internal.Optic
 import Optics.Optic
 
 -- | Type synonym for a type-modifying lensy review.
-type LensyReview s t a b = Optic A_LensyReview '[] s t a b
+type LensyReview s t a b = Optic A_LensyReview NoIx s t a b
 
 -- | Type synonym for a type-preserving lensy review.
-type LensyReview' b t = Optic' A_LensyReview '[] t b
+type LensyReview' b t = Optic' A_LensyReview NoIx t b

--- a/optics-core/src/Optics/Prism.hs
+++ b/optics-core/src/Optics/Prism.hs
@@ -22,7 +22,7 @@ import Optics.Internal.Prism
 import Optics.Optic
 
 -- | Use a 'Prism' to work over part of a structure.
-aside :: Is k A_Prism => Optic k '[] s t a b -> Prism (e, s) (e, t) (e, a) (e, b)
+aside :: Is k A_Prism => Optic k is s t a b -> Prism (e, s) (e, t) (e, a) (e, b)
 aside k =
   withPrism k     $ \bt seta ->
   prism (fmap bt) $ \(e,s) ->
@@ -34,8 +34,8 @@ aside k =
 -- | Given a pair of prisms, project sums.
 without
   :: (Is k A_Prism, Is l A_Prism)
-  => Optic k '[] s t a b
-  -> Optic l '[] u v c d
+  => Optic k is s t a b
+  -> Optic l is u v c d
   -> Prism (Either s u) (Either t v) (Either a c) (Either b d)
 without k =
   withPrism k         $ \bt seta k' ->
@@ -50,7 +50,7 @@ without k =
 -- matches only if all the elements of the container match the 'Prism'.
 below
   :: (Is k A_Prism, Traversable f)
-  => Optic' k '[] s a
+  => Optic' k is s a
   -> Prism' (f s) (f a)
 below k =
   withPrism k     $ \bt seta ->

--- a/optics-core/src/Optics/PrismaticGetter.hs
+++ b/optics-core/src/Optics/PrismaticGetter.hs
@@ -9,7 +9,7 @@ import Optics.Internal.Optic
 import Optics.Optic
 
 -- | Type synonym for a type-modifying prismatic getter.
-type PrismaticGetter s t a b = Optic A_PrismaticGetter '[] s t a b
+type PrismaticGetter s t a b = Optic A_PrismaticGetter NoIx s t a b
 
 -- | Type synonym for a type-preserving prismatic getter.
-type PrismaticGetter' s a = Optic' A_PrismaticGetter '[] s a
+type PrismaticGetter' s a = Optic' A_PrismaticGetter NoIx s a

--- a/optics-core/src/Optics/Unindexed.hs
+++ b/optics-core/src/Optics/Unindexed.hs
@@ -8,19 +8,28 @@ import Optics.Internal.Optic.TypeLevel
 
 class UnindexableOptic k where
   -- | Downcast an indexed optic to its unindexed equivalent.
-  unIx :: ConstN is => Optic k is s t a b -> Optic k '[] s t a b
+  unIx :: ConstN is => Optic k is s t a b -> Optic k NoIx s t a b
 
 instance UnindexableOptic A_Traversal where
-  unIx :: forall is s t a b. ConstN is => Optic A_Traversal is s t a b -> Optic A_Traversal '[] s t a b
+  unIx
+    :: forall is s t a b. ConstN is
+    => Optic A_Traversal is   s t a b
+    -> Optic A_Traversal NoIx s t a b
   unIx (Optic o) = Optic (ixcontramap (constN @is). o)
   {-# INLINE unIx #-}
 
 instance UnindexableOptic A_Fold where
-  unIx :: forall is s t a b. ConstN is => Optic A_Fold is s t a b -> Optic A_Fold '[] s t a b
+  unIx
+    :: forall is s t a b. ConstN is
+    => Optic A_Fold is   s t a b
+    -> Optic A_Fold NoIx s t a b
   unIx (Optic o) = Optic (ixcontramap (constN @is). o)
   {-# INLINE unIx #-}
 
 instance UnindexableOptic A_Setter where
-  unIx :: forall is s t a b. ConstN is => Optic A_Setter is s t a b -> Optic A_Setter '[] s t a b
+  unIx
+    :: forall is s t a b. ConstN is
+    => Optic A_Setter is   s t a b
+    -> Optic A_Setter NoIx s t a b
   unIx (Optic o) = Optic (ixcontramap (constN @is). o)
   {-# INLINE unIx #-}


### PR DESCRIPTION
Helps to catch unneeded restriction of indices and we get to see how easy it's to avoid introducing it.