### PR TITLE
Implement equivalent of Conjoined from lens for efficient optics degradation

### DIFF
--- a/optics-core/src/Optics/Internal/Fold.hs
+++ b/optics-core/src/Optics/Internal/Fold.hs
@@ -83,7 +83,7 @@ traverseOf_
   :: (Is k A_Fold, Applicative f)
   => Optic' k is s a
   -> (a -> f r) -> s -> f ()
-traverseOf_ o f = runTraversed . foldMapOf o (Traversed #. f)
+traverseOf_ o = \f -> runTraversed . foldMapOf o (Traversed #. f)
 {-# INLINE traverseOf_ #-}
 
 -- | A version of 'traverseOf_' with the arguments flipped.

--- a/optics-core/src/Optics/Internal/IxSetter.hs
+++ b/optics-core/src/Optics/Internal/IxSetter.hs
@@ -38,7 +38,24 @@ isets
 isets f = Optic (iroam f)
 {-# INLINE isets #-}
 
+-- | Build an indexed setter from function to modify the element(s) in both its
+-- unindexed and indexed version.
+--
+-- Appropriate version of the setter will be automatically picked for maximum
+-- efficiency depending on whether it is used as indexed or regular one.
+--
+-- @
+-- 'over'  ('conjoinedSets' f g) ≡ 'over'  ('sets' f)
+-- 'iover' ('conjoinedFold' f g) ≡ 'iover' ('isets' g)
+-- @
+conjoinedSets
+  :: ((     a -> b) -> s -> t)
+  -> ((i -> a -> b) -> s -> t)
+  -> IxSetter i s t a b
+conjoinedSets f g = Optic $ conjoined (roam f) (iroam g)
+{-# INLINE conjoinedSets #-}
+
 -- | Indexed setter via the 'FunctorWithIndex' class.
 imapped :: FunctorWithIndex i f => IxSetter i (f a) (f b) a b
-imapped = isets imap
+imapped = conjoinedSets fmap imap
 {-# INLINE imapped #-}

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -2,6 +2,8 @@ module Optics.IxFold
   ( A_Fold
   , IxFold
   , toIxFold
+  , ixFoldVL
+  , conjoinedFold
   , ifoldMapOf
   , ifoldrOf
   , ifoldlOf'

--- a/optics-core/src/Optics/IxSetter.hs
+++ b/optics-core/src/Optics/IxSetter.hs
@@ -7,6 +7,7 @@ module Optics.IxSetter
   , iover
   , iset
   , isets
+  , conjoinedSets
   , imapped
   , module Optics.Optic
   ) where

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -5,6 +5,7 @@ module Optics.IxTraversal
   , TraversableWithIndex(..)
   , toIxTraversal
   , ixTraversalVL
+  , conjoinedTraversal
   , itraversed
   , itraverseOf
   , iforOf


### PR DESCRIPTION
Woohoo!

Now we get degradation of indexed optics without loss of efficiency in comparison to regular versions. And the implementation is surprisingly simple.