### PR TITLE
Make view return a list of results for (indexed) traversals and folds

### DIFF
--- a/optics-core/src/Optics/Core.hs
+++ b/optics-core/src/Optics/Core.hs
@@ -21,6 +21,7 @@ import Optics.Indexed         as O
 import Optics.Iso             as O
 import Optics.Lens            as O
 import Optics.LensyReview     as O
+import Optics.Operators       as O
 import Optics.Passthrough     as O
 import Optics.Prism           as O
 import Optics.PrismaticGetter as O

--- a/optics-core/src/Optics/Operators.hs
+++ b/optics-core/src/Optics/Operators.hs
@@ -38,7 +38,7 @@ infixl 1 <&>
 #endif
 
 -- | Flipped infix version of 'view'.
-(^.) :: ViewableOptic k a => s -> Optic' k is s a -> ViewResult k a
+(^.) :: ViewableOptic k is a => s -> Optic' k is s a -> ViewResult k is a
 (^.) = flip view
 {-# INLINE (^.) #-}
 

--- a/optics-core/src/Optics/Operators.hs
+++ b/optics-core/src/Optics/Operators.hs
@@ -58,7 +58,7 @@ infixl 8 ^..
 
 infixl 8 ^?
 
--- | Flipped infix version of 'review'.
+-- | Infix version of 'review'.
 (#) :: Is k A_Review => Optic' k is t b -> b -> t
 (#) = review
 {-# INLINE (#) #-}

--- a/optics-core/src/Optics/Operators.hs
+++ b/optics-core/src/Optics/Operators.hs
@@ -8,8 +8,6 @@ module Optics.Operators
   ( (&)
   , (<&>)
   , (^.)
-  , (^..)
-  , (^?)
   , (#)
   , (%~)
   , (.~)
@@ -43,20 +41,6 @@ infixl 1 <&>
 {-# INLINE (^.) #-}
 
 infixl 8 ^.
-
--- | Flipped infix version of 'toListOf'.
-(^..) :: Is k A_Fold => s -> Optic' k is s a -> [a]
-(^..) = flip toListOf
-{-# INLINE (^..) #-}
-
-infixl 8 ^..
-
--- | Flipped infix version of 'preview'.
-(^?) :: Is k A_Fold => s -> Optic' k is s a -> Maybe a
-(^?) = flip preview
-{-# INLINE (^?) #-}
-
-infixl 8 ^?
 
 -- | Infix version of 'review'.
 (#) :: Is k A_Review => Optic' k is t b -> b -> t

--- a/optics-core/src/Optics/Passthrough.hs
+++ b/optics-core/src/Optics/Passthrough.hs
@@ -1,42 +1,55 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Optics.Passthrough where
 
-import Optics.Internal.Optic
+import Control.Arrow (first)
+import Data.Monoid
+
 import Optics.AffineTraversal
+import Optics.IxTraversal
 import Optics.Lens
 import Optics.Prism
 import Optics.Traversal
 import Optics.View
+import Optics.Internal.Optic
 
-class (Is k A_Traversal, ViewableOptic k r) => PermeableOptic k r where
+class (Is k A_Traversal, ViewableOptic k is r) => PermeableOptic k is r where
   -- | Modify the target of an 'Optic' returning some extra information of type 'r'.
   passthrough
     :: Optic k is s t a b
     -> (a -> (r, b))
     -> s
-    -> (ViewResult k r, t)
+    -> (ViewResult k is r, t)
 
-instance PermeableOptic An_Iso r where
+instance is ~ NoIx => PermeableOptic An_Iso is r where
   passthrough = toLensVL
   {-# INLINE passthrough #-}
 
-instance PermeableOptic A_Lens r where
+instance is ~ NoIx => PermeableOptic A_Lens is r where
   passthrough = toLensVL
   {-# INLINE passthrough #-}
 
-instance PermeableOptic A_Prism r where
+instance is ~ NoIx => PermeableOptic A_Prism is r where
   passthrough o f s = withPrism o $ \bt sta -> case sta s of
     Left t -> (Nothing, t)
     Right a -> case f a of
       (r, b) -> (Just r, bt b)
   {-# INLINE passthrough #-}
 
-instance PermeableOptic An_AffineTraversal r where
+instance is ~ NoIx => PermeableOptic An_AffineTraversal is r where
   passthrough o f s = withAffineTraversal o $ \sbt sta -> case sta s of
     Left t -> (Nothing, t)
     Right a -> case f a of
       (r, b) -> (Just r, sbt s b)
   {-# INLINE passthrough #-}
 
-instance Monoid r => PermeableOptic A_Traversal r where
-  passthrough = traverseOf
+instance PermeableOptic A_Traversal NoIx r where
+  passthrough o f = first (`appEndo` [])
+    . traverseOf o (first (\r -> Endo (r :)) . f)
+  {-# INLINE passthrough #-}
+
+instance (CheckIndices "passthrough" 1 i (i ': is)
+         ) => PermeableOptic A_Traversal (i ': is) r where
+  passthrough o f = first (`appEndo` [])
+    . itraverseOf o (\i -> first (\r -> Endo ((i, r) :)) . f)
   {-# INLINE passthrough #-}

--- a/optics-th/src/Optics/TH.hs
+++ b/optics-th/src/Optics/TH.hs
@@ -76,7 +76,6 @@ import Language.Haskell.TH.Syntax hiding (lift)
 
 import Language.Haskell.TH
 import Optics.Core
-import Optics.Operators
 import Optics.TH.Internal.Product
 import Optics.TH.Internal.Sum
 import Optics.TH.Internal.Utils

--- a/optics-th/tests/Optics/TH/Tests.hs
+++ b/optics-th/tests/Optics/TH/Tests.hs
@@ -9,7 +9,6 @@
 module Main where
 
 import Optics.Core
-import Optics.Operators
 import Optics.TH
 
 import Optics.TH.Tests.T799 ()

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -44,7 +44,8 @@ library
     Optics.Each
 
   -- operators
-  exposed-modules:    Optics.Operators.State
+  exposed-modules:    Optics.Operators.Compat
+                    , Optics.Operators.State
 
   -- data
   exposed-modules:

--- a/optics/src/Optics/Operators/Compat.hs
+++ b/optics/src/Optics/Operators/Compat.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE FlexibleContexts #-}
+module Optics.Operators.Compat where
+
+import Optics.Fold
+
+-- | Flipped infix version of 'toListOf'.
+(^..) :: Is k A_Fold => s -> Optic' k is s a -> [a]
+(^..) = flip toListOf
+{-# INLINE (^..) #-}
+
+infixl 8 ^..
+
+-- | Flipped infix version of 'preview'.
+(^?) :: Is k A_Fold => s -> Optic' k is s a -> Maybe a
+(^?) = flip preview
+{-# INLINE (^?) #-}
+
+infixl 8 ^?

--- a/optics/src/Optics/Operators/State.hs
+++ b/optics/src/Optics/Operators/State.hs
@@ -16,17 +16,28 @@ import Control.Monad.State (MonadState)
 import qualified Control.Monad.State as State
 
 import Optics.Core
-import Optics.Operators
 
 infix 4 .=, ?=, %=
 
-(.=) :: (MonadState s m, Is k A_Setter) => Optic k is s s a b -> b -> m ()
+(.=)
+  :: (Is k A_Setter, MonadState s m)
+  => Optic k is s s a b
+  -> b
+  -> m ()
 o .= x = o %= const x
 
-(?=) :: (MonadState s m, Is k A_Setter) => Optic k is s s (Maybe a) (Maybe b) -> b -> m ()
+(?=)
+  :: (Is k A_Setter, MonadState s m)
+  => Optic k is s s (Maybe a) (Maybe b)
+  -> b
+  -> m ()
 o ?= x = o %= const (Just x)
 
-(%=) :: (MonadState s m, Is k A_Setter) => Optic k is s s a b -> (a -> b) -> m ()
+(%=)
+  :: (Is k A_Setter, MonadState s m)
+  => Optic k is s s a b
+  -> (a -> b)
+  -> m ()
 o %= f = State.modify (o %~ f)
 
 -------------------------------------------------------------------------------
@@ -34,7 +45,11 @@ o %= f = State.modify (o %~ f)
 -------------------------------------------------------------------------------
 
 infix 4 %%=
-(%%=) :: (MonadState s m, PermeableOptic k r) => Optic k is s s a b -> (a -> (r, b)) -> m (ViewResult k r)
+(%%=)
+  :: (PermeableOptic k is r, MonadState s m)
+  => Optic k is s s a b
+  -> (a -> (r, b))
+  -> m (ViewResult k is r)
 o %%= f = State.state (passthrough o f)
 
 -------------------------------------------------------------------------------
@@ -43,13 +58,25 @@ o %%= f = State.state (passthrough o f)
 
 infix 4 <.=, <?=, <%=
 
-(<%=) :: (MonadState s m, PermeableOptic k b) => Optic k is s s a b -> (a -> b) -> m (ViewResult k b)
+(<%=)
+  :: (PermeableOptic k is b, MonadState s m)
+  => Optic k is s s a b
+  -> (a -> b)
+  -> m (ViewResult k is b)
 o <%= f = o %%= \a -> let b = f a in (b, b)
 
-(<?=) :: (MonadState s m, PermeableOptic k (Maybe b)) => Optic k is s s (Maybe a) (Maybe b) -> b -> m (ViewResult k (Maybe b))
+(<?=)
+  :: (PermeableOptic k is (Maybe b), MonadState s m)
+  => Optic k is s s (Maybe a) (Maybe b)
+  -> b
+  -> m (ViewResult k is (Maybe b))
 o <?= b = o <.= Just b
 
-(<.=) :: (MonadState s m, PermeableOptic k b) => Optic k is s s a b -> b -> m (ViewResult k b)
+(<.=)
+  :: (PermeableOptic k is b, MonadState s m)
+  => Optic k is s s a b
+  -> b
+  -> m (ViewResult k is b)
 o <.= b = o <%= const b
 
 -------------------------------------------------------------------------------
@@ -58,11 +85,23 @@ o <.= b = o <%= const b
 
 infix 4 <<.=, <<?=, <<%=
 
-(<<%=) :: (MonadState s m, PermeableOptic k a) => Optic k is s s a b -> (a -> b) -> m (ViewResult k a)
+(<<%=)
+  :: (PermeableOptic k is a, MonadState s m)
+  => Optic k is s s a b
+  -> (a -> b)
+  -> m (ViewResult k is a)
 o <<%= f = o %%= \a -> (a, f a)
 
-(<<?=) :: (MonadState s m, PermeableOptic k (Maybe a)) => Optic k is s s (Maybe a) (Maybe b) -> b -> m (ViewResult k (Maybe a))
+(<<?=)
+  :: (PermeableOptic k is (Maybe a), MonadState s m)
+  => Optic k is s s (Maybe a) (Maybe b)
+  -> b
+  -> m (ViewResult k is (Maybe a))
 o <<?= b = o <<.= Just b
 
-(<<.=) :: (MonadState s m, PermeableOptic k a) => Optic k is s s a b -> b -> m (ViewResult k a)
+(<<.=)
+  :: (PermeableOptic k is a, MonadState s m)
+  => Optic k is s s a b
+  -> b
+  -> m (ViewResult k is a)
 o <<.= b = o <<%= const b


### PR DESCRIPTION
Alright, nobody protested after I posted https://github.com/well-typed/optics/issues/57#issuecomment-456911279 so here's an implementation for testing the waters.

I'm also exporting `Optics.Operators `as part of `Optic.Core`. It currently has 6 operators:
- `&` - reexported from base
- `<&>` - reexported from base
- `^.` - with this change it somewhat becomes "one operator to view them all", i.e. it just works for majority of optics and gives you the result you'd expect (especially with traversals and folds). As a bonus you can run it for indexed variants and get indices.
- `#` - primarily for reverse application of `Iso` and `Prism`
- `%~` and `.~` - along with `&` used for nice update/set syntax: `T{_age=5} & age %~ (+1)`

I think they are core and should be exported by default.

I also moved `^..` and `^?` to `Optics.Operators.Compat` as I think `^.` is sufficient. `^..` and `^?` actually give you an illusion of type safety - they return `[a]` and `Maybe a` respectively, but they work for any fold. That means that if you refactor the code and e.g. your prism becomes a fold, return type of `^?` will not change and you might lose results if you miss it. This won't happen with `^.` because its return type will change from `Maybe a` to `[a]` and GHC will complain.

Demonstration:
```haskell
λ> Left "hi" ^. _Left
Just "hi"
λ> (1,2) ^. _1
1
λ> [Left ('c', "hi"), Right 42, Left ('a', "there")] ^. traversed % _Left % _2
["hi","there"]
λ> [Left ('c', "hi"), Right 42, Left ('a', "there")] ^. itraversed % _Left % _2
[(0,"hi"),(2,"there")]
```