### PR TITLE
Split optics-extra, port bytestring/text/vector stuff from lens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,10 +68,10 @@ install:
   - "sed -i.bak 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config"
   - rm -fv cabal.project cabal.project.local
   - grep -Ev -- '^\s*--' ${HOME}/.cabal/config | grep -Ev '^\s*$'
-  - "printf 'packages: \"optics\" \"optics-core\" \"optics-sop\" \"optics-th\" \"generic-optics\" \"metametapost\"\\n' > cabal.project"
+  - "printf 'packages: \"optics\" \"optics-core\" \"optics-extra\" \"optics-sop\" \"optics-th\" \"generic-optics\" \"metametapost\"\\n' > cabal.project"
   - "printf 'write-ghc-environment-files: always\\n' >> cabal.project"
   - touch cabal.project.local
-  - "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg  | grep -vw -- optics | grep -vw -- optics-core | grep -vw -- optics-sop | grep -vw -- optics-th | grep -vw -- generic-optics | grep -vw -- metametapost | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
+  - "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg  | grep -vw -- optics | grep -vw -- optics-core | grep -vw -- optics-extra | grep -vw -- optics-sop | grep -vw -- optics-th | grep -vw -- generic-optics | grep -vw -- metametapost | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
   - cat cabal.project || true
   - cat cabal.project.local || true
   - if [ -f "optics/configure.ac" ]; then
@@ -79,6 +79,9 @@ install:
     fi
   - if [ -f "optics-core/configure.ac" ]; then
       (cd "optics-core" && autoreconf -i);
+    fi
+  - if [ -f "optics-extra/configure.ac" ]; then
+      (cd "optics-extra" && autoreconf -i);
     fi
   - if [ -f "optics-sop/configure.ac" ]; then
       (cd "optics-sop" && autoreconf -i);
@@ -95,7 +98,7 @@ install:
   - rm -f cabal.project.freeze
   - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
   - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
-  - rm -rf .ghc.environment.* "optics"/dist "optics-core"/dist "optics-sop"/dist "optics-th"/dist "generic-optics"/dist "metametapost"/dist
+  - rm -rf .ghc.environment.* "optics"/dist "optics-core"/dist "optics-extra"/dist "optics-sop"/dist "optics-th"/dist "generic-optics"/dist "metametapost"/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 
 # Here starts the actual work to be performed for the package under test;
@@ -106,10 +109,10 @@ script:
   - mv dist-newstyle/sdist/*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR} || false
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
-  - "printf 'packages: optics-*/*.cabal optics-core-*/*.cabal optics-sop-*/*.cabal optics-th-*/*.cabal generic-optics-*/*.cabal metametapost-*/*.cabal\\n' > cabal.project"
+  - "printf 'packages: optics-*/*.cabal optics-core-*/*.cabal optics-extra-*/*.cabal optics-sop-*/*.cabal optics-th-*/*.cabal generic-optics-*/*.cabal metametapost-*/*.cabal\\n' > cabal.project"
   - "printf 'write-ghc-environment-files: always\\n' >> cabal.project"
   - touch cabal.project.local
-  - "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg  | grep -vw -- optics | grep -vw -- optics-core | grep -vw -- optics-sop | grep -vw -- optics-th | grep -vw -- generic-optics | grep -vw -- metametapost | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
+  - "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg  | grep -vw -- optics | grep -vw -- optics-core | grep -vw -- optics-extra | grep -vw -- optics-sop | grep -vw -- optics-th | grep -vw -- generic-optics | grep -vw -- metametapost | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
   - cat cabal.project || true
   - cat cabal.project.local || true
   # this builds all libraries and executables (without tests/benchmarks)
@@ -122,6 +125,7 @@ script:
   # cabal check
   - (cd optics-* && cabal check)
   - (cd optics-core-* && cabal check)
+  - (cd optics-extra-* && cabal check)
   - (cd optics-sop-* && cabal check)
   - (cd optics-th-* && cabal check)
   - (cd generic-optics-* && cabal check)

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,7 @@
 packages:
   optics/*.cabal
   optics-core/*.cabal
+  optics-extra/*.cabal
   optics-sop/*.cabal
   optics-th/*.cabal
   generic-optics/*.cabal

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -62,6 +62,7 @@ library
     -- internal modules
     Optics.Internal.Bi
     Optics.Internal.Concrete
+    Optics.Internal.Fold
     Optics.Internal.Indexed
     Optics.Internal.IxFold
     Optics.Internal.IxSetter
@@ -73,6 +74,7 @@ library
     Optics.Internal.Profunctor
     Optics.Internal.Re
     Optics.Internal.Tagged
+    Optics.Internal.Traversal
     Optics.Internal.Utils
 
   default-extensions:

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -19,11 +19,10 @@ library
   hs-source-dirs:     src
   build-depends:      base >=4.9 && <5
 
-  -- these dependencies are to provide FunctorWithIndex instances
+  -- base *WithIndex instances
   build-depends:
       array         >=0.5.1.1 && <0.6
     , containers    >=0.5.7.1 && <0.7
-    , transformers  >=0.5     && <0.6
 
   ghc-options:        -Wall
 
@@ -38,7 +37,7 @@ library
     Optics.Equality
     Optics.Fold
     Optics.Getter
-    Optics.Indexed
+    Optics.Indexed.Core
     Optics.Iso
     Optics.IxFold
     Optics.IxSetter

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -19,9 +19,6 @@ library
   hs-source-dirs:     src
   build-depends:      base >=4.9 && <5
 
-  -- this is for 'viewM'
-  build-depends:      mtl >=2.2.2 && <2.3
-
   -- these dependencies are to provide FunctorWithIndex instances
   build-depends:
       array         >=0.5.1.1 && <0.6

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -72,6 +72,7 @@ library
     Optics.Internal.Optic.Types
     Optics.Internal.Profunctor
     Optics.Internal.Re
+    Optics.Internal.Setter
     Optics.Internal.Tagged
     Optics.Internal.Traversal
     Optics.Internal.Utils

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -86,10 +86,12 @@ library
     FlexibleInstances
     FunctionalDependencies
     GADTs
+    InstanceSigs
     LambdaCase
     MultiParamTypeClasses
     RankNTypes
     ScopedTypeVariables
     TupleSections
+    TypeApplications
     TypeFamilies
     TypeOperators

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -5,7 +5,7 @@ license-file:  LICENSE
 build-type:    Simple
 cabal-version: 1.24
 maintainer:    oleg@well-typed.com
-author:        Adam Gundry, Andres Löh, Andrzej Rybczak, Oleg Grenrus
+author:        Edward Kmett, Adam Gundry, Andres Löh, Andrzej Rybczak, Oleg Grenrus
 tested-with:   ghc ==8.0.2 ghc ==8.2.2 ghc ==8.4.4 ghc ==8.6.3
 synopsis:      Optics as an abstract interface: core definitions
 category:      Data, Optics, Lenses, Generics

--- a/optics-core/src/Data/Tuple/Optics.hs
+++ b/optics-core/src/Data/Tuple/Optics.hs
@@ -1,14 +1,4 @@
 {-# LANGUAGE UndecidableInstances   #-}
--------------------------------------------------------------------------------
--- |
--- Module      :  Data.Tuple.Optics
--- Copyright   :  (C) 2012-16 Edward Kmett
--- License     :  BSD-style (see the file LICENSE)
--- Maintainer  :  Edward Kmett <ekmett@gmail.com>
--- Stability   :  provisional
--- Portability :  Rank2Types
---
--------------------------------------------------------------------------------
 module Data.Tuple.Optics
   (
   -- * Tuples

--- a/optics-core/src/Optics/AffineTraversal.hs
+++ b/optics-core/src/Optics/AffineTraversal.hs
@@ -4,6 +4,7 @@ module Optics.AffineTraversal
   , AffineTraversal'
   , toAffineTraversal
   , atraversal
+  , atraversal'
   , withAffineTraversal
   , module Optics.Optic
   )
@@ -36,6 +37,11 @@ atraversal match update = Optic $
   . first'
   . right'
 {-# INLINE atraversal #-}
+
+-- | Build a type-preserving affine traversal from a matcher and an updater.
+atraversal' :: (s -> Maybe a) -> (s -> b -> s) -> AffineTraversal s s a b
+atraversal' sma sbs = atraversal (\s -> maybe (Left s) Right (sma s)) sbs
+{-# INLINE atraversal' #-}
 
 -- With with an affine traversal as a matcher and an updater.
 withAffineTraversal

--- a/optics-core/src/Optics/AffineTraversal.hs
+++ b/optics-core/src/Optics/AffineTraversal.hs
@@ -37,11 +37,12 @@ atraversal match update = Optic $
   . right'
 {-# INLINE atraversal #-}
 
+-- With with an affine traversal as a matcher and an updater.
 withAffineTraversal
   :: Is k An_AffineTraversal
   => Optic k is s t a b
-  -> ((s -> b -> t) -> (s -> Either t a) -> r)
+  -> ((s -> Either t a) -> (s -> b -> t) -> r)
   -> r
 withAffineTraversal o k =
   case getOptic (toAffineTraversal o) (AffineMarket (\_ b -> b) Right) of
-    AffineMarket setter match -> k setter match
+    AffineMarket update match -> k match update

--- a/optics-core/src/Optics/Arrow.hs
+++ b/optics-core/src/Optics/Arrow.hs
@@ -7,7 +7,9 @@ import Control.Arrow
 import Data.Coerce
 import qualified Control.Category as C
 
-import Optics.Core
+import Optics.AffineTraversal
+import Optics.Prism
+import Optics.Setter
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
 import Optics.Internal.Utils

--- a/optics-core/src/Optics/Core.hs
+++ b/optics-core/src/Optics/Core.hs
@@ -9,11 +9,14 @@
 --
 module Optics.Core
   ( module O
+  , module D
   )
   where
 
 import Optics.AffineFold      as O
 import Optics.AffineTraversal as O
+import Optics.Arrow           as O
+import Optics.Coerce          as O
 import Optics.Equality        as O
 import Optics.Fold            as O
 import Optics.Getter          as O
@@ -29,3 +32,7 @@ import Optics.Review          as O
 import Optics.Setter          as O
 import Optics.Traversal       as O
 import Optics.View            as O
+
+import Data.Either.Optics     as D
+import Data.Maybe.Optics      as D
+import Data.Tuple.Optics      as D

--- a/optics-core/src/Optics/Core.hs
+++ b/optics-core/src/Optics/Core.hs
@@ -20,8 +20,11 @@ import Optics.Coerce          as O
 import Optics.Equality        as O
 import Optics.Fold            as O
 import Optics.Getter          as O
-import Optics.Indexed         as O
+import Optics.Indexed.Core    as O
 import Optics.Iso             as O
+import Optics.IxFold          as O
+import Optics.IxSetter        as O
+import Optics.IxTraversal     as O
 import Optics.Lens            as O
 import Optics.LensyReview     as O
 import Optics.Passthrough     as O

--- a/optics-core/src/Optics/Fold.hs
+++ b/optics-core/src/Optics/Fold.hs
@@ -14,6 +14,7 @@ module Optics.Fold
   , forOf_
   , folded
   , folding
+  , foldring
     -- * Concrete folds
   , has
   , andOf
@@ -40,6 +41,7 @@ import Data.Foldable
 import Data.Monoid
 
 import Optics.Internal.Bi
+import Optics.Internal.Fold
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
 import Optics.Internal.Utils
@@ -76,7 +78,7 @@ preview o = getFirst #. foldMapOf o (First #. Just)
 foldVL
   :: (forall f. Applicative f => (a -> f r) -> s -> f ())
   -> Fold s a
-foldVL f = Optic (rphantom . wander f . rphantom)
+foldVL f = Optic (foldVL__ f)
 {-# INLINE foldVL #-}
 
 -- | Fold via embedding into a monoid.
@@ -148,6 +150,16 @@ folded = foldVL traverse_
 folding :: Foldable f => (s -> f a) -> Fold s a
 folding f = Optic (contrabimap f (\_ -> ()) . wander traverse_)
 {-# INLINE folding #-}
+
+-- | Obtain a 'Fold' by lifting 'foldr' like function.
+--
+-- >>> toListOf (foldring foldr) [1,2,3,4]
+-- [1,2,3,4]
+foldring
+  :: (forall f. Applicative f => (a -> f r -> f r) -> f r -> s -> f r)
+  -> Fold s a
+foldring fr = Optic (foldring__ fr)
+{-# INLINE foldring #-}
 
 ----------------------------------------
 -- Concrete folds

--- a/optics-core/src/Optics/Fold.hs
+++ b/optics-core/src/Optics/Fold.hs
@@ -122,7 +122,7 @@ traverseOf_
   :: (Is k A_Fold, Applicative f)
   => Optic' k is s a
   -> (a -> f r) -> s -> f ()
-traverseOf_ o = \f -> runTraversed . foldMapOf o (Traversed #. f)
+traverseOf_ o f = runTraversed . foldMapOf o (Traversed #. f)
 {-# INLINE traverseOf_ #-}
 
 -- | A version of 'traverseOf_' with the arguments flipped.
@@ -137,7 +137,7 @@ forOf_ = flip . traverseOf_
 
 -- | Fold via the 'Foldable' class.
 folded :: Foldable f => Fold (f a) a
-folded = foldVL traverse_
+folded = Optic folded__
 {-# INLINE folded #-}
 
 -- | Obtain a 'Fold' by lifting an operation that returns a 'Foldable' result.

--- a/optics-core/src/Optics/Indexed.hs
+++ b/optics-core/src/Optics/Indexed.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeApplications #-}
 module Optics.Indexed
   (
   -- * Indexed optics

--- a/optics-core/src/Optics/Indexed/Core.hs
+++ b/optics-core/src/Optics/Indexed/Core.hs
@@ -1,13 +1,6 @@
 {-# LANGUAGE DataKinds #-}
-module Optics.Indexed
-  (
-  -- * Indexed optics
-    module Optics.IxTraversal
-  , module Optics.IxFold
-  , module Optics.IxSetter
-
-  -- * Index composition and modification
-  , (<%>)
+module Optics.Indexed.Core
+  ( (<%>)
   , (%>)
   , (<%)
   , reindex
@@ -16,16 +9,6 @@ module Optics.Indexed
   , icompose4
   , icompose5
   , IxOptic(..)
-
-  -- * Functors with index
-  , FunctorWithIndex (..)
-  -- ** Foldable with index
-  , FoldableWithIndex (..)
-  , itraverse_
-  , ifor_
-  -- ** Traversable with index
-  , TraversableWithIndex (..)
-  , ifor
   ) where
 
 import Optics.Internal.Indexed
@@ -34,9 +17,6 @@ import Optics.Internal.Optic.TypeLevel
 import Optics.Internal.Profunctor
 
 import Optics.Fold
-import Optics.IxFold
-import Optics.IxSetter
-import Optics.IxTraversal
 import Optics.Setter
 import Optics.Traversal
 

--- a/optics-core/src/Optics/Internal/Fold.hs
+++ b/optics-core/src/Optics/Internal/Fold.hs
@@ -1,6 +1,7 @@
 module Optics.Internal.Fold where
 
 import Data.Functor
+import Data.Foldable
 
 import Optics.Internal.Bi
 import Optics.Internal.Optic
@@ -13,6 +14,13 @@ foldVL__
   -> Optic__ p i i s t a b
 foldVL__ f = rphantom . wander f . rphantom
 {-# INLINE foldVL__ #-}
+
+-- | Internal implementation of 'folded'.
+folded__
+  :: (Bicontravariant p, Traversing p, Foldable f)
+  => Optic__ p i i (f a) (f b) a b
+folded__ = foldVL__ traverse_
+{-# INLINE folded__ #-}
 
 -- | Internal implementation of 'foldring'.
 foldring__

--- a/optics-core/src/Optics/Internal/Fold.hs
+++ b/optics-core/src/Optics/Internal/Fold.hs
@@ -1,0 +1,25 @@
+module Optics.Internal.Fold where
+
+import Data.Functor
+
+import Optics.Internal.Bi
+import Optics.Internal.Optic
+import Optics.Internal.Profunctor
+
+-- | Internal implementation of 'foldVL'.
+foldVL__
+  :: (Bicontravariant p, Traversing p)
+  => (forall f. Applicative f => (a -> f r) -> s -> f ())
+  -> Optic__ p i i s s a a
+foldVL__ f = rphantom . wander f . rphantom
+{-# INLINE foldVL__ #-}
+
+-- | Internal implementation of 'foldring'.
+foldring__
+  :: (Bicontravariant p, Traversing p)
+  => (forall f. Applicative f => (a -> f r -> f r) -> f r -> s -> f r)
+  -> Optic__ p i i s s a a
+foldring__ fr = foldVL__ $ \f -> void . fr (\a -> (f a *>)) (pure v)
+  where
+    v = error "foldring__: value used"
+{-# INLINE foldring__ #-}

--- a/optics-core/src/Optics/Internal/Fold.hs
+++ b/optics-core/src/Optics/Internal/Fold.hs
@@ -10,7 +10,7 @@ import Optics.Internal.Profunctor
 foldVL__
   :: (Bicontravariant p, Traversing p)
   => (forall f. Applicative f => (a -> f r) -> s -> f ())
-  -> Optic__ p i i s s a a
+  -> Optic__ p i i s t a b
 foldVL__ f = rphantom . wander f . rphantom
 {-# INLINE foldVL__ #-}
 
@@ -18,7 +18,7 @@ foldVL__ f = rphantom . wander f . rphantom
 foldring__
   :: (Bicontravariant p, Traversing p)
   => (forall f. Applicative f => (a -> f r -> f r) -> f r -> s -> f r)
-  -> Optic__ p i i s s a a
+  -> Optic__ p i i s t a b
 foldring__ fr = foldVL__ $ \f -> void . fr (\a -> (f a *>)) (pure v)
   where
     v = error "foldring__: value used"

--- a/optics-core/src/Optics/Internal/Indexed.hs
+++ b/optics-core/src/Optics/Internal/Indexed.hs
@@ -24,10 +24,6 @@ import qualified Data.Sequence as Seq
 import Optics.Internal.Profunctor
 import Optics.Internal.Utils
 
-#if !MIN_VERSION_containers(0,5,8)
-import Data.Foldable (fold)
-#endif
-
 -- | Generate sensible error messages in case a user tries to pass either a
 -- unindexed optic or indexed optic with unflattened indices where indexed optic
 -- with a single index is expected.
@@ -267,7 +263,7 @@ instance FoldableWithIndex Int Seq.Seq where
 #if MIN_VERSION_containers(0,5,8)
   ifoldMap = Seq.foldMapWithIndex
 #else
-  ifoldMap f = fold . Seq.mapWithIndex f
+  ifoldMap f = ifoldr (\i -> mappend . f i) mempty
 #endif
   {-# INLINE ifoldMap #-}
 
@@ -275,11 +271,8 @@ instance FoldableWithIndex Int Seq.Seq where
   {-# INLINE ifoldr #-}
 
 instance TraversableWithIndex Int Seq.Seq where
-#if MIN_VERSION_containers(0,5,8)
-  itraverse = Seq.traverseWithIndex
-#else
+  -- This is much faster than Seq.traverseWithIndex. wut?
   itraverse f = sequenceA . Seq.mapWithIndex f
-#endif
   {-# INLINE itraverse #-}
 
 -- IntMap

--- a/optics-core/src/Optics/Internal/IxFold.hs
+++ b/optics-core/src/Optics/Internal/IxFold.hs
@@ -12,7 +12,7 @@ import Optics.Internal.Optic
 ixFoldVL__
   :: (Bicontravariant p, Traversing p)
   => (forall f. Applicative f => (i -> a -> f r) -> s -> f ())
-  -> Optic__ p j (i -> j) s s a a
+  -> Optic__ p j (i -> j) s t a b
 ixFoldVL__ f = rphantom . iwander f . rphantom
 {-# INLINE ixFoldVL__ #-}
 
@@ -27,7 +27,7 @@ ifolded__ = conjoinedFold__ traverse_ itraverse_
 ifoldring__
   :: (Bicontravariant p, Traversing p)
   => (forall f. Applicative f => (i -> a -> f r -> f r) -> f r -> s -> f r)
-  -> Optic__ p j (i -> j) s s a a
+  -> Optic__ p j (i -> j) s t a b
 ifoldring__ fr = ixFoldVL__ $ \f -> void . fr (\i a -> (f i a *>)) (pure v)
   where
     v = error "ifoldring__: value used"

--- a/optics-core/src/Optics/Internal/IxFold.hs
+++ b/optics-core/src/Optics/Internal/IxFold.hs
@@ -1,5 +1,6 @@
 module Optics.Internal.IxFold where
 
+import Data.Functor
 import Data.Foldable
 
 import Optics.Internal.Bi
@@ -7,12 +8,30 @@ import Optics.Internal.Indexed
 import Optics.Internal.Profunctor
 import Optics.Internal.Optic
 
+-- | Internal implementation of 'ixFoldVL'.
+ixFoldVL__
+  :: (Bicontravariant p, Traversing p)
+  => (forall f. Applicative f => (i -> a -> f r) -> s -> f ())
+  -> Optic__ p j (i -> j) s s a a
+ixFoldVL__ f = rphantom . iwander f . rphantom
+{-# INLINE ixFoldVL__ #-}
+
 -- | Internal implementation of 'ifolded'.
 ifolded__
   :: (Bicontravariant p, Traversing p, FoldableWithIndex i f)
   => Optic__ p j (i -> j) (f a) (f b) a b
 ifolded__ = conjoinedFold__ traverse_ itraverse_
 {-# INLINE ifolded__ #-}
+
+-- | Internal implementation of 'ifoldring'.
+ifoldring__
+  :: (Bicontravariant p, Traversing p)
+  => (forall f. Applicative f => (i -> a -> f r -> f r) -> f r -> s -> f r)
+  -> Optic__ p j (i -> j) s s a a
+ifoldring__ fr = ixFoldVL__ $ \f -> void . fr (\i a -> (f i a *>)) (pure v)
+  where
+    v = error "ifoldring__: value used"
+{-# INLINE ifoldring__ #-}
 
 -- | Internal implementation of 'conjoinedFold'.
 conjoinedFold__

--- a/optics-core/src/Optics/Internal/IxTraversal.hs
+++ b/optics-core/src/Optics/Internal/IxTraversal.hs
@@ -1,10 +1,12 @@
 module Optics.Internal.IxTraversal where
 
+import Optics.Internal.Fold
 import Optics.Internal.Indexed
 import Optics.Internal.IxFold
 import Optics.Internal.IxSetter
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
+import Optics.Internal.Setter
 
 -- | Internal implementation of 'itraversed'.
 itraversed__
@@ -13,7 +15,27 @@ itraversed__
 itraversed__ = conjoinedTraversal__ traverse itraverse
 {-# INLINE [0] itraversed__ #-}
 
+-- Because itraversed__ inlines late, GHC needs rewrite rules for all cases in
+-- order to generate optimal code for each of them. The ones that rewrite
+-- traversal into a traversal correspond to an early inline.
+
 {-# RULES
+
+"itraversed__ -> wander traverse"
+  forall (o :: Star g j a b). itraversed__ o = wander traverse (reStar o)
+    :: TraversableWithIndex i f => Star g (i -> j) (f a) (f b)
+
+"itraversed__ -> folded__"
+  forall (o :: Forget r j a b). itraversed__ o = folded__ (reForget o)
+    :: FoldableWithIndex i f => Forget r (i -> j) (f a) (f b)
+
+"itraversed__ -> mapped__"
+  forall (o :: FunArrow j a b). itraversed__ o = mapped__ (reFunArrow o)
+    :: FunctorWithIndex i f => FunArrow (i -> j) (f a) (f b)
+
+"itraversed__ -> itraverse"
+  forall (o :: IxStar g j a b). itraversed__ o = iwander itraverse o
+    :: TraversableWithIndex i f => IxStar g (i -> j) (f a) (f b)
 
 "itraversed__ -> ifolded__"
   forall (o :: IxForget r j a b). itraversed__ o = ifolded__ o

--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- | Core optic types and subtyping machinery.
 --

--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeApplications #-}
 module Optics.Internal.Optic.TypeLevel where
 
 -- | Curry a type-level list.

--- a/optics-core/src/Optics/Internal/Profunctor.hs
+++ b/optics-core/src/Optics/Internal/Profunctor.hs
@@ -34,6 +34,23 @@ newtype IxFunArrow i a b = IxFunArrow { runIxFunArrow :: i -> a -> b }
 
 ----------------------------------------
 
+-- | Repack 'Star' to change its index type.
+reStar :: Star f i a b -> Star f j a b
+reStar (Star k) = Star k
+{-# INLINE reStar #-}
+
+-- | Repack 'Forget' to change its index type.
+reForget :: Forget r i a b -> Forget r j a b
+reForget (Forget k) = Forget k
+{-# INLINE reForget #-}
+
+-- | Repack 'FunArrow' to change its index type.
+reFunArrow :: FunArrow i a b -> FunArrow j a b
+reFunArrow (FunArrow k) = FunArrow k
+{-# INLINE reFunArrow #-}
+
+----------------------------------------
+
 class Profunctor p where
   dimap :: (a -> b) -> (c -> d) -> p i b c -> p i a d
   lmap  :: (a -> b)             -> p i b c -> p i a c

--- a/optics-core/src/Optics/Internal/Setter.hs
+++ b/optics-core/src/Optics/Internal/Setter.hs
@@ -1,0 +1,11 @@
+module Optics.Internal.Setter where
+
+import Optics.Internal.Profunctor
+import Optics.Internal.Optic
+
+-- | Internal implementation of 'mapped'.
+mapped__
+  :: (Mapping p, Functor f)
+  => Optic__ p i i (f a) (f b) a b
+mapped__ = roam fmap
+{-# INLINE mapped__ #-}

--- a/optics-core/src/Optics/Internal/Traversal.hs
+++ b/optics-core/src/Optics/Internal/Traversal.hs
@@ -2,10 +2,32 @@ module Optics.Internal.Traversal where
 
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
+import Optics.Internal.Fold
+import Optics.Internal.Setter
 
 -- | Internal implementation of 'traversed'.
 traversed__
   :: (Traversing p, Traversable f)
   => Optic__ p i i (f a) (f b) a b
 traversed__ = wander traverse
-{-# INLINE traversed__ #-}
+{-# INLINE [0] traversed__ #-}
+
+-- Because traversed__ inlines late, GHC needs rewrite rules for all cases in
+-- order to generate optimal code for each of them. The one that rewrites
+-- traversal into a traversal correspond to an early inline.
+
+{-# RULES
+
+"traversed__ -> wander traverse"
+  forall (o :: Star g i a b). traversed__ o = wander traverse o
+    :: Traversable f => Star g i (f a) (f b)
+
+"traversed__ -> folded__"
+  forall (o :: Forget r i a b). traversed__ o = folded__ o
+    :: Foldable f => Forget r i (f a) (f b)
+
+"traversed__ -> mapped__"
+  forall (o :: FunArrow i a b). traversed__ o = mapped__ o
+    :: Functor f => FunArrow i (f a) (f b)
+
+#-}

--- a/optics-core/src/Optics/Internal/Traversal.hs
+++ b/optics-core/src/Optics/Internal/Traversal.hs
@@ -1,0 +1,11 @@
+module Optics.Internal.Traversal where
+
+import Optics.Internal.Optic
+import Optics.Internal.Profunctor
+
+-- | Internal implementation of 'traversed'.
+traversed__
+  :: (Traversing p, Traversable f)
+  => Optic__ p i i (f a) (f b) a b
+traversed__ = wander traverse
+{-# INLINE traversed__ #-}

--- a/optics-core/src/Optics/Iso.hs
+++ b/optics-core/src/Optics/Iso.hs
@@ -88,7 +88,7 @@ curried = iso curry uncurry
 -- @
 --
 -- @
--- 'uncurried' = 'from' 'curried'
+-- 'uncurried' = 're' 'curried'
 -- @
 --
 -- >>> (view1 uncurried (+)) (1,2)

--- a/optics-core/src/Optics/Iso.hs
+++ b/optics-core/src/Optics/Iso.hs
@@ -11,6 +11,7 @@ module Optics.Iso
   , curried
   , uncurried
   , flipped
+  , involuted
   , Swapped(..)
   -- * Re-exports
   , module Optics.Optic
@@ -105,6 +106,22 @@ uncurried = iso uncurry curry
 flipped :: Iso (a -> b -> c) (a' -> b' -> c') (b -> a -> c) (b' -> a' -> c')
 flipped = iso flip flip
 {-# INLINE flipped #-}
+
+-- | Given a function that is its own inverse, this gives you an 'Iso' using it
+-- in both directions.
+--
+-- @
+-- 'involuted' ≡ 'Control.Monad.join' 'iso'
+-- @
+--
+-- >>> "live" ^. involuted reverse
+-- "evil"
+--
+-- >>> "live" & involuted reverse %~ ('d':)
+-- "lived"
+involuted :: (a -> a) -> Iso' a a
+involuted a = iso a a
+{-# INLINE involuted #-}
 
 -- | This class provides for symmetric bifunctors.
 class Bifunctor p => Swapped p where

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -12,12 +12,12 @@ module Optics.IxFold
   , itraverseOf_
   , iforOf_
   , ifolded
+  , ifoldring
   , module Optics.Optic
   ) where
 
 import Data.Monoid
 
-import Optics.Internal.Bi
 import Optics.Internal.Indexed
 import Optics.Internal.IxFold
 import Optics.Internal.Optic
@@ -42,7 +42,7 @@ toIxFold = castOptic
 ixFoldVL
   :: (forall f. Applicative f => (i -> a -> f r) -> s -> f ())
   -> IxFold i s a
-ixFoldVL f = Optic (rphantom . iwander f . rphantom)
+ixFoldVL f = Optic (ixFoldVL__ f)
 {-# INLINE ixFoldVL #-}
 
 -- | Build an indexed fold from the van Laarhoven representation of both its
@@ -124,3 +124,13 @@ iforOf_ = flip . itraverseOf_
 ifolded :: FoldableWithIndex i f => IxFold i (f a) a
 ifolded = Optic ifolded__
 {-# INLINE ifolded #-}
+
+-- | Obtain an 'IxFold' by lifting 'ifoldr' like function.
+--
+-- >>> itoListOf (ifoldring ifoldr) "hello"
+-- [(0,'h'),(1,'e'),(2,'l'),(3,'l'),(4,'o')]
+ifoldring
+  :: (forall f. Applicative f => (i -> a -> f r -> f r) -> f r -> s -> f r)
+  -> IxFold i s a
+ifoldring fr = Optic (ifoldring__ fr)
+{-# INLINE ifoldring #-}

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -109,7 +109,10 @@ itraverseOf_
   :: (Is k A_Fold, Applicative f, CheckIndices "itraverseOf_" 1 i is)
   => Optic' k is s a
   -> (i -> a -> f r) -> s -> f ()
-itraverseOf_ o f = runTraversed . ifoldMapOf o (\i -> Traversed #. f i)
+itraverseOf_ o f s =
+  -- We want to have the definition fully eta-expanded as it allows GHC to
+  -- generate better code (in particular for folding over a Vector).
+  runTraversed $ ifoldMapOf o (\i -> Traversed #. f i) s
 {-# INLINE itraverseOf_ #-}
 
 -- | A version of 'itraverseOf_' with the arguments flipped.

--- a/optics-core/src/Optics/Passthrough.hs
+++ b/optics-core/src/Optics/Passthrough.hs
@@ -31,7 +31,7 @@ instance PermeableOptic A_Prism r where
   {-# INLINE passthrough #-}
 
 instance PermeableOptic An_AffineTraversal r where
-  passthrough o f s = withAffineTraversal o $ \sbt sta -> case sta s of
+  passthrough o f s = withAffineTraversal o $ \sta sbt -> case sta s of
     Left t -> (Nothing, t)
     Right a -> case f a of
       (r, b) -> (Just r, sbt s b)

--- a/optics-core/src/Optics/Setter.hs
+++ b/optics-core/src/Optics/Setter.hs
@@ -12,6 +12,7 @@ module Optics.Setter
 
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
+import Optics.Internal.Setter
 import Optics.Internal.Utils
 import Optics.Optic
 
@@ -59,5 +60,5 @@ sets f = Optic (roam f)
 
 -- | Setter via the 'Functor' class.
 mapped :: Functor f => Setter (f a) (f b) a b
-mapped = sets fmap
+mapped = Optic mapped__
 {-# INLINE mapped #-}

--- a/optics-core/src/Optics/Traversal.hs
+++ b/optics-core/src/Optics/Traversal.hs
@@ -25,6 +25,7 @@ module Optics.Traversal
 import Optics.Internal.Indexed
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
+import Optics.Internal.Traversal
 import Optics.Internal.Utils
 import Optics.Optic
 
@@ -60,7 +61,7 @@ traversalVL t = Optic (wander t)
 
 -- | Traversal via the 'Traversable' class.
 traversed :: Traversable t => Traversal (t a) (t b) a b
-traversed = traversalVL traverse
+traversed = Optic traversed__
 {-# INLINE traversed #-}
 
 -- | Map each element of a structure targeted by a 'Traversal', evaluate these

--- a/optics-core/src/Optics/View.hs
+++ b/optics-core/src/Optics/View.hs
@@ -1,7 +1,5 @@
 module Optics.View where
 
-import Control.Monad.Reader.Class
-
 import Optics.AffineFold
 import Optics.Fold
 import Optics.Getter
@@ -59,10 +57,3 @@ instance Monoid r => ViewableOptic A_Fold r where
   type ViewResult A_Fold r = r
   view = viewN
   {-# INLINE view #-}
-
--- | Generalization of 'view' from @(->) s@ to arbitrary @MonadReader s m@.
-viewM
-  :: (ViewableOptic k r, MonadReader s m)
-  => Optic' k is s r
-  -> m (ViewResult k r)
-viewM = asks . view

--- a/optics-extra/LICENSE
+++ b/optics-extra/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2017-2018, Well-Typed LLP
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Andres Loeh nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/optics-extra/Setup.hs
+++ b/optics-extra/Setup.hs
@@ -1,0 +1,4 @@
+import Distribution.Simple
+
+main :: IO ()
+main = defaultMain

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -16,16 +16,16 @@ library
   default-language:   Haskell2010
   hs-source-dirs:     src
 
-  build-depends: base >=4.9 && <5
-               , optics-core
-               , array         >=0.5.1.1  && <0.6
-               , bytestring    >=0.10.8.0 && <0.11
-               , containers    >=0.5.7.1  && <0.7
-               , mtl           >=2.2.2    && <2.3
-               , text
-               , transformers  >=0.5      && <0.6
-               , unordered-containers
-               , vector        >=0.11     && <0.13
+  build-depends: optics-core            >= 0.1       && <1.0
+               , array                  >= 0.5.1.1   && <0.6
+               , base                   >= 4.9       && <5
+               , bytestring             >= 0.10.8    && <0.11
+               , containers             >= 0.5.7.1   && <0.7
+               , mtl                    >= 2.2.2     && <2.3
+               , text                   >= 1.2       && <1.3
+               , transformers           >= 0.5       && <0.6
+               , unordered-containers   >= 0.2.6     && <0.3
+               , vector                 >= 0.11      && <0.13
 
   ghc-options:        -Wall
 

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -18,14 +18,14 @@ library
 
   build-depends: base >=4.9 && <5
                , optics-core
-
-  -- this is for 'viewM'
-  build-depends: mtl >=2.2.2 && <2.3
-
-  -- these dependencies are to provide FunctorWithIndex instances
-  build-depends: array         >=0.5.1.1 && <0.6
-               , containers    >=0.5.7.1 && <0.7
-               , transformers  >=0.5     && <0.6
+               , array         >=0.5.1.1  && <0.6
+               , bytestring    >=0.10.8.0 && <0.11
+               , containers    >=0.5.7.1  && <0.7
+               , mtl           >=2.2.2    && <2.3
+               , text
+               , transformers  >=0.5      && <0.6
+               , unordered-containers
+               , vector        >=0.11     && <0.13
 
   ghc-options:        -Wall
 
@@ -36,6 +36,9 @@ library
                    Optics.Operators.State
                    Data.Set.Optics
                    GHC.Generics.Optics
+                   Data.Text.Optics
+                   Data.Text.Strict.Optics
+                   Data.Text.Lazy.Optics
 
   default-extensions:
     BangPatterns

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -32,13 +32,17 @@ library
   -- main module to land with repl
   exposed-modules: Optics.Extra
 
-  exposed-modules: Optics.Each
-                   Optics.Operators.State
+
+  exposed-modules: Optics.Extra.Internal
                    Data.Set.Optics
-                   GHC.Generics.Optics
+                   Data.Text.Lazy.Optics
                    Data.Text.Optics
                    Data.Text.Strict.Optics
-                   Data.Text.Lazy.Optics
+                   Data.Vector.Generic.Optics
+                   Data.Vector.Optics
+                   GHC.Generics.Optics
+                   Optics.Each
+                   Optics.Operators.State
 
   default-extensions:
     BangPatterns

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -46,6 +46,7 @@ library
                    Data.Vector.Optics
                    GHC.Generics.Optics
                    Optics.Each
+                   Optics.Indexed
                    Optics.Operators.State
 
   default-extensions:

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -33,7 +33,11 @@ library
   exposed-modules: Optics.Extra
 
 
-  exposed-modules: Optics.Extra.Internal
+  exposed-modules: Optics.Extra.Internal.ByteString
+                   Optics.Extra.Internal.Vector
+                   Data.ByteString.Lazy.Optics
+                   Data.ByteString.Optics
+                   Data.ByteString.Strict.Optics
                    Data.Set.Optics
                    Data.Text.Lazy.Optics
                    Data.Text.Optics

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -1,0 +1,56 @@
+name:          optics-extra
+version:       0.1
+license:       BSD3
+license-file:  LICENSE
+build-type:    Simple
+cabal-version: 1.24
+maintainer:    oleg@well-typed.com
+author:        Edward Kmett, Andrzej Rybczak
+tested-with:   ghc ==8.0.2 ghc ==8.2.2 ghc ==8.4.4 ghc ==8.6.3
+synopsis:      Extra utilities and instances for optics-core
+category:      Data, Optics, Lenses, Generics
+description:
+  This package provides extra definitions and instances that extend @optics-core@ package.
+
+library
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+
+  build-depends: base >=4.9 && <5
+               , optics-core
+
+  -- this is for 'viewM'
+  build-depends: mtl >=2.2.2 && <2.3
+
+  -- these dependencies are to provide FunctorWithIndex instances
+  build-depends: array         >=0.5.1.1 && <0.6
+               , containers    >=0.5.7.1 && <0.7
+               , transformers  >=0.5     && <0.6
+
+  ghc-options:        -Wall
+
+  -- main module to land with repl
+  exposed-modules: Optics.Extra
+
+  exposed-modules: Optics.Each
+                   Optics.Operators.State
+                   Data.Set.Optics
+                   GHC.Generics.Optics
+
+  default-extensions:
+    BangPatterns
+    DefaultSignatures
+    DeriveFunctor
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GADTs
+    InstanceSigs
+    LambdaCase
+    MultiParamTypeClasses
+    RankNTypes
+    ScopedTypeVariables
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeOperators

--- a/optics-extra/src/Data/ByteString/Lazy/Optics.hs
+++ b/optics-extra/src/Data/ByteString/Lazy/Optics.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE PatternSynonyms #-}
+-- | Lazy 'ByteString' lenses.
+module Data.ByteString.Lazy.Optics
+  ( packedBytes, unpackedBytes, bytes
+  , packedChars, unpackedChars, chars
+  , pattern Bytes
+  , pattern Chars
+  ) where
+
+import Data.ByteString.Lazy       as Words
+import Data.ByteString.Lazy.Char8 as Char8
+import Data.Int (Int64)
+import Data.Word (Word8)
+
+import Optics.Core
+import Optics.Extra.Internal.ByteString
+
+-- $setup
+-- >>> :set -XOverloadedStrings
+-- >>> import Numeric.Lens
+
+-- | 'Data.ByteString.Lazy.pack' (or 'Data.ByteString.Lazy.unpack') a list of
+-- bytes into a 'ByteString'.
+--
+-- @
+-- 'packedBytes' ≡ 're' 'unpackedBytes'
+-- 'Data.ByteString.pack' x ≡  x '^.' 'packedBytes'
+-- 'Data.ByteString.unpack' x ≡ x '^.' 're' 'packedBytes'
+-- @
+--
+-- >>> [104,101,108,108,111]^.packedBytes == Char8.pack "hello"
+-- True
+packedBytes :: Iso' [Word8] ByteString
+packedBytes = iso Words.pack Words.unpack
+{-# INLINE packedBytes #-}
+
+-- | 'Data.ByteString.Lazy.unpack' (or 'Data.ByteString.Lazy.pack') a
+-- 'ByteString' into a list of bytes.
+--
+-- @
+-- 'unpackedBytes' ≡ 're' 'packedBytes'
+-- 'Data.ByteString.unpack' x ≡ x '^.' 'unpackedBytes'
+-- 'Data.ByteString.pack' x ≡  x '^.' 're' 'unpackedBytes'
+-- @
+--
+-- >>> "hello"^.packedChars.unpackedBytes
+-- [104,101,108,108,111]
+unpackedBytes :: Iso' ByteString [Word8]
+unpackedBytes = re packedBytes
+{-# INLINE unpackedBytes #-}
+
+-- | Traverse the individual bytes in a 'ByteString'.
+--
+-- This 'Traversal' walks each strict 'ByteString' chunk in a tree-like fashion
+-- enable zippers to seek to locations more quickly and accelerate many monoidal
+-- queries, but up to associativity (and constant factors) it is equivalent to
+-- the much slower:
+--
+-- @
+-- 'bytes' ≡ 'unpackedBytes' '.' 'traversed'
+-- @
+--
+-- >>> anyOf bytes (== 0x80) (Char8.pack "hello")
+-- False
+--
+-- Note that when just using this as a 'Setter', @'sets'
+-- 'Data.ByteString.Lazy.map'@ can be more efficient.
+bytes :: IxTraversal' Int64 ByteString Word8
+bytes = traversedLazy
+{-# INLINE bytes #-}
+
+-- | 'Data.ByteString.Lazy.Char8.pack' (or 'Data.ByteString.Lazy.Char8.unpack')
+-- a list of characters into a 'ByteString'.
+--
+-- When writing back to the 'ByteString' it is assumed that every 'Char' lies
+-- between @'\x00'@ and @'\xff'@.
+--
+-- @
+-- 'packedChars' ≡ 're' 'unpackedChars'
+-- 'Data.ByteString.Char8.pack' x ≡ x '^.' 'packedChars'
+-- 'Data.ByteString.Char8.unpack' x ≡ x '^.' 're' 'packedChars'
+-- @
+--
+-- >>> "hello"^.packedChars.each.re (base 16 . enum).to (\x -> if Prelude.length x == 1 then '0':x else x)
+-- "68656c6c6f"
+packedChars :: Iso' String ByteString
+packedChars = iso Char8.pack Char8.unpack
+{-# INLINE packedChars #-}
+
+-- | 'Data.ByteString.Lazy.Char8.unpack' (or 'Data.ByteString.Lazy.Char8.pack')
+-- a list of characters into a 'ByteString'
+--
+-- When writing back to the 'ByteString' it is assumed that every 'Char' lies
+-- between @'\x00'@ and @'\xff'@.
+--
+-- @
+-- 'unpackedChars' ≡ 're' 'packedChars'
+-- 'Data.ByteString.Char8.unpack' x ≡ x '^.' 'unpackedChars'
+-- 'Data.ByteString.Char8.pack' x ≡ x '^.' 're' 'unpackedChars'
+-- @
+--
+-- >>> [104,101,108,108,111]^.packedBytes.unpackedChars
+-- "hello"
+unpackedChars :: Iso' ByteString String
+unpackedChars = re packedChars
+{-# INLINE unpackedChars #-}
+
+-- | Traverse the individual bytes in a 'ByteString' as characters.
+--
+-- When writing back to the 'ByteString' it is assumed that every 'Char' lies
+-- between @'\x00'@ and @'\xff'@.
+--
+-- This 'Traversal' walks each strict 'ByteString' chunk in a tree-like fashion
+-- enable zippers to seek to locations more quickly and accelerate many monoidal
+-- queries, but up to associativity (and constant factors) it is equivalent to:
+--
+-- @
+-- 'chars' = 'unpackedChars' '.' 'traversed'
+-- @
+--
+-- >>> anyOf chars (== 'h') "hello"
+-- True
+chars :: IxTraversal' Int64 ByteString Char
+chars = traversedLazy8
+{-# INLINE chars #-}
+
+pattern Bytes :: [Word8] -> ByteString
+pattern Bytes b <- (view unpackedBytes -> b) where
+  Bytes b = review unpackedBytes b
+
+pattern Chars :: [Char] -> ByteString
+pattern Chars b <- (view unpackedChars -> b) where
+  Chars b = review unpackedChars b

--- a/optics-extra/src/Data/ByteString/Optics.hs
+++ b/optics-extra/src/Data/ByteString/Optics.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE PatternSynonyms #-}
+module Data.ByteString.Optics
+  ( IsByteString(..)
+  , unpackedBytes
+  , unpackedChars
+  , pattern Bytes
+  , pattern Chars
+  ) where
+
+import Data.ByteString as Strict
+import Data.ByteString.Lazy as Lazy
+import Data.Word (Word8)
+import qualified Data.ByteString.Lazy.Optics as Lazy
+import qualified Data.ByteString.Strict.Optics as Strict
+
+import Optics.Core
+
+-- | Traversals for ByteStrings.
+class IsByteString t where
+  -- | 'Data.ByteString.pack' (or 'Data.ByteString.unpack') a list of bytes into
+  -- a strict or lazy 'ByteString'.
+  --
+  -- @
+  -- 'Data.ByteString.pack' x ≡ x '^.' 'packedBytes'
+  -- 'Data.ByteString.unpack' x ≡ x '^.' 're' 'packedBytes'
+  -- 'packedBytes' ≡ 're' 'unpackedBytes'
+  -- @
+  packedBytes :: Iso' [Word8] t
+
+  -- | 'Data.ByteString.Char8.pack' (or 'Data.ByteString.Char8.unpack') a list
+  -- of characters into a strict or lazy 'ByteString'.
+  --
+  -- When writing back to the 'ByteString' it is assumed that every 'Char' lies
+  -- between @'\x00'@ and @'\xff'@.
+  --
+  -- @
+  -- 'Data.ByteString.Char8.pack' x ≡ x '^.' 'packedChars'
+  -- 'Data.ByteString.Char8.unpack' x ≡ x '^.' 're' 'packedChars'
+  -- 'packedChars' ≡ 're' 'unpackedChars'
+  -- @
+  packedChars :: Iso' String t
+
+  -- | Traverse each 'Word8' in a strict or lazy 'ByteString'
+  --
+  --
+  -- This 'Traversal' walks each strict 'ByteString' chunk in a tree-like
+  -- fashion enable zippers to seek to locations more quickly and accelerate
+  -- many monoidal queries, but up to associativity (and constant factors) it is
+  -- equivalent to the much slower:
+  --
+  -- @
+  -- 'bytes' ≡ 'unpackedBytes' '.' 'traversed'
+  -- @
+  --
+  -- @
+  -- 'anyOf' 'bytes' ('==' 0x80) :: 'ByteString' -> 'Bool'
+  -- @
+  bytes :: IxTraversal' Int t Word8
+  bytes = re packedBytes % itraversed
+  {-# INLINE bytes #-}
+
+  -- | Traverse the individual bytes in a strict or lazy 'ByteString' as
+  -- characters.
+  --
+  -- When writing back to the 'ByteString' it is assumed that every 'Char' lies
+  -- between @'\x00'@ and @'\xff'@.
+  --
+  -- This 'Traversal' walks each strict 'ByteString' chunk in a tree-like
+  -- fashion enable zippers to seek to locations more quickly and accelerate
+  -- many monoidal queries, but up to associativity (and constant factors) it is
+  -- equivalent to the much slower:
+  --
+  -- @
+  -- 'chars' ≡ 'unpackedChars' '.' 'traversed'
+  -- @
+  --
+  -- @
+  -- 'anyOf' 'chars' ('==' \'c\') :: 'ByteString' -> 'Bool'
+  -- @
+  chars :: IxTraversal' Int t Char
+  chars = re packedChars % itraversed
+  {-# INLINE chars #-}
+
+-- | 'Data.ByteString.unpack' (or 'Data.ByteString.pack') a 'ByteString' into a
+-- list of bytes.
+--
+-- @
+-- 'unpackedBytes' ≡ 're' 'packedBytes'
+-- 'Data.ByteString.unpack' x ≡ x '^.' 'unpackedBytes'
+-- 'Data.ByteString.pack' x ≡  x '^.' 're' 'unpackedBytes'
+-- @
+--
+-- @
+-- 'unpackedBytes' :: 'Iso'' 'Data.ByteString.ByteString' ['Word8']
+-- 'unpackedBytes' :: 'Iso'' 'Data.ByteString.Lazy.ByteString' ['Word8']
+-- @
+unpackedBytes :: IsByteString t => Iso' t [Word8]
+unpackedBytes = re packedBytes
+{-# INLINE unpackedBytes #-}
+
+pattern Bytes :: IsByteString t => [Word8] -> t
+pattern Bytes b <- (view unpackedBytes -> b) where
+  Bytes b = review unpackedBytes b
+
+pattern Chars :: IsByteString t => [Char] -> t
+pattern Chars b <- (view unpackedChars -> b) where
+  Chars b = review unpackedChars b
+
+-- | 'Data.ByteString.Char8.unpack' (or 'Data.ByteString.Char8.pack') a list of
+-- characters into a strict (or lazy) 'ByteString'
+--
+-- When writing back to the 'ByteString' it is assumed that every 'Char' lies
+-- between @'\x00'@ and @'\xff'@.
+--
+-- @
+-- 'unpackedChars' ≡ 're' 'packedChars'
+-- 'Data.ByteString.Char8.unpack' x ≡ x '^.' 'unpackedChars'
+-- 'Data.ByteString.Char8.pack' x ≡ x '^.' 're' 'unpackedChars'
+-- @
+--
+-- @
+-- 'unpackedChars' :: 'Iso'' 'Data.ByteString.ByteString' 'String'
+-- 'unpackedChars' :: 'Iso'' 'Data.ByteString.Lazy.ByteString' 'String'
+-- @
+unpackedChars :: IsByteString t => Iso' t String
+unpackedChars = re packedChars
+{-# INLINE unpackedChars #-}
+
+instance IsByteString Strict.ByteString where
+  packedBytes = Strict.packedBytes
+  packedChars = Strict.packedChars
+  bytes = Strict.bytes
+  chars = Strict.chars
+  {-# INLINE packedBytes #-}
+  {-# INLINE packedChars #-}
+  {-# INLINE bytes #-}
+  {-# INLINE chars #-}
+
+instance IsByteString Lazy.ByteString where
+  packedBytes = Lazy.packedBytes
+  packedChars = Lazy.packedChars
+  {-# INLINE packedBytes #-}
+  {-# INLINE packedChars #-}

--- a/optics-extra/src/Data/ByteString/Optics.hs
+++ b/optics-extra/src/Data/ByteString/Optics.hs
@@ -10,7 +10,8 @@ module Data.ByteString.Optics
 
 import Data.ByteString as Strict
 import Data.ByteString.Lazy as Lazy
-import Data.Word (Word8)
+import Data.Int
+import Data.Word
 import qualified Data.ByteString.Lazy.Optics as Lazy
 import qualified Data.ByteString.Strict.Optics as Strict
 
@@ -56,9 +57,7 @@ class IsByteString t where
   -- @
   -- 'anyOf' 'bytes' ('==' 0x80) :: 'ByteString' -> 'Bool'
   -- @
-  bytes :: IxTraversal' Int t Word8
-  bytes = re packedBytes % itraversed
-  {-# INLINE bytes #-}
+  bytes :: IxTraversal' Int64 t Word8
 
   -- | Traverse the individual bytes in a strict or lazy 'ByteString' as
   -- characters.
@@ -78,9 +77,7 @@ class IsByteString t where
   -- @
   -- 'anyOf' 'chars' ('==' \'c\') :: 'ByteString' -> 'Bool'
   -- @
-  chars :: IxTraversal' Int t Char
-  chars = re packedChars % itraversed
-  {-# INLINE chars #-}
+  chars :: IxTraversal' Int64 t Char
 
 -- | 'Data.ByteString.unpack' (or 'Data.ByteString.pack') a 'ByteString' into a
 -- list of bytes.
@@ -130,8 +127,8 @@ unpackedChars = re packedChars
 instance IsByteString Strict.ByteString where
   packedBytes = Strict.packedBytes
   packedChars = Strict.packedChars
-  bytes = Strict.bytes
-  chars = Strict.chars
+  bytes       = reindex fromIntegral Strict.bytes
+  chars       = reindex fromIntegral Strict.chars
   {-# INLINE packedBytes #-}
   {-# INLINE packedChars #-}
   {-# INLINE bytes #-}
@@ -140,5 +137,9 @@ instance IsByteString Strict.ByteString where
 instance IsByteString Lazy.ByteString where
   packedBytes = Lazy.packedBytes
   packedChars = Lazy.packedChars
+  bytes       = Lazy.bytes
+  chars       = Lazy.chars
   {-# INLINE packedBytes #-}
   {-# INLINE packedChars #-}
+  {-# INLINE bytes #-}
+  {-# INLINE chars #-}

--- a/optics-extra/src/Data/ByteString/Strict/Optics.hs
+++ b/optics-extra/src/Data/ByteString/Strict/Optics.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE PatternSynonyms #-}
+module Data.ByteString.Strict.Optics
+  ( packedBytes, unpackedBytes, bytes
+  , packedChars, unpackedChars, chars
+  , pattern Bytes
+  , pattern Chars
+  ) where
+
+import Data.ByteString       as Words
+import Data.ByteString.Char8 as Char8
+import Data.Word
+
+import Optics.Core
+import Optics.Extra.Internal.ByteString
+
+-- $setup
+-- >>> :set -XOverloadedStrings
+-- >>> import Control.Lens
+-- >>> import Numeric.Lens
+
+-- | 'Data.ByteString.pack' (or 'Data.ByteString.unpack') a list of bytes into a 'ByteString'
+--
+-- @
+-- 'packedBytes' ≡ 're' 'unpackedBytes'
+-- 'Data.ByteString.pack' x ≡  x '^.' 'packedBytes'
+-- 'Data.ByteString.unpack' x ≡ x '^.' 're' 'packedBytes'
+-- @
+--
+-- >>> [104,101,108,108,111]^.packedBytes
+-- "hello"
+packedBytes :: Iso' [Word8] ByteString
+packedBytes = iso Words.pack Words.unpack
+{-# INLINE packedBytes #-}
+
+-- | 'Data.ByteString.unpack' (or 'Data.ByteString.pack') a 'ByteString' into a
+-- list of bytes.
+--
+-- @
+-- 'unpackedBytes' ≡ 're' 'packedBytes'
+-- 'Data.ByteString.unpack' x ≡ x '^.' 'unpackedBytes'
+-- 'Data.ByteString.pack' x ≡  x '^.' 're' 'unpackedBytes'
+-- @
+--
+-- >>> "hello"^.packedChars.unpackedBytes
+-- [104,101,108,108,111]
+unpackedBytes :: Iso' ByteString [Word8]
+unpackedBytes = re packedBytes
+{-# INLINE unpackedBytes #-}
+
+-- | Traverse each 'Word8' in a 'ByteString'.
+--
+-- This 'Traversal' walks the 'ByteString' in a tree-like fashion enable zippers
+-- to seek to locations in logarithmic time and accelerating many monoidal
+-- queries, but up to associativity (and constant factors) it is equivalent to
+-- the much slower:
+--
+-- @
+-- 'bytes' ≡ 'unpackedBytes' '.' 'traversed'
+-- @
+--
+-- >>> anyOf bytes (== 0x80) (Char8.pack "hello")
+-- False
+--
+-- Note that when just using this as a 'Setter', @'sets' 'Data.ByteString.map'@
+-- can be more efficient.
+bytes :: IxTraversal' Int ByteString Word8
+bytes = traversedStrictTree
+{-# INLINE bytes #-}
+
+-- | 'Data.ByteString.Char8.pack' (or 'Data.ByteString.Char8.unpack') a list of
+-- characters into a 'ByteString'
+--
+-- When writing back to the 'ByteString' it is assumed that every 'Char' lies
+-- between @'\x00'@ and @'\xff'@.
+--
+-- @
+-- 'packedChars' ≡ 're' 'unpackedChars'
+-- 'Data.ByteString.Char8.pack' x ≡ x '^.' 'packedChars'
+-- 'Data.ByteString.Char8.unpack' x ≡ x '^.' 're' 'packedChars'
+-- @
+--
+-- >>> "hello"^.packedChars.each.re (base 16 . enum).to (\x -> if Prelude.length x == 1 then '0':x else x)
+-- "68656c6c6f"
+packedChars :: Iso' String ByteString
+packedChars = iso Char8.pack Char8.unpack
+{-# INLINE packedChars #-}
+
+-- | 'Data.ByteString.Char8.unpack' (or 'Data.ByteString.Char8.pack') a list of
+-- characters into a 'ByteString'
+--
+-- When writing back to the 'ByteString' it is assumed that every 'Char' lies
+-- between @'\x00'@ and @'\xff'@.
+--
+-- @
+-- 'unpackedChars' ≡ 're' 'packedChars'
+-- 'Data.ByteString.Char8.unpack' x ≡ x '^.' 'unpackedChars'
+-- 'Data.ByteString.Char8.pack' x ≡ x '^.' 're' 'unpackedChars'
+-- @
+--
+-- >>> [104,101,108,108,111]^.packedBytes.unpackedChars
+-- "hello"
+unpackedChars :: Iso' ByteString String
+unpackedChars = re packedChars
+{-# INLINE unpackedChars #-}
+
+-- | Traverse the individual bytes in a 'ByteString' as characters.
+--
+-- When writing back to the 'ByteString' it is assumed that every 'Char' lies
+-- between @'\x00'@ and @'\xff'@.
+--
+-- This 'Traversal' walks the 'ByteString' in a tree-like fashion enable zippers
+-- to seek to locations in logarithmic time and accelerating many monoidal
+-- queries, but up to associativity (and constant factors) it is equivalent to
+-- the much slower:
+--
+-- @
+-- 'chars' = 'unpackedChars' '.' 'traverse'
+-- @
+--
+-- >>> anyOf chars (== 'h') "hello"
+-- True
+chars :: IxTraversal' Int ByteString Char
+chars = traversedStrictTree8
+{-# INLINE chars #-}
+
+pattern Bytes :: [Word8] -> ByteString
+pattern Bytes b <- (view unpackedBytes -> b) where
+  Bytes b = review unpackedBytes b
+
+pattern Chars :: [Char] -> ByteString
+pattern Chars b <- (view unpackedChars -> b) where
+  Chars b = review unpackedChars b

--- a/optics-extra/src/Data/Set/Optics.hs
+++ b/optics-extra/src/Data/Set/Optics.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
 module Data.Set.Optics
   ( setmapped
   , setOf

--- a/optics-extra/src/Data/Text/Lazy/Optics.hs
+++ b/optics-extra/src/Data/Text/Lazy/Optics.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+module Data.Text.Lazy.Optics
+  ( packed
+  , unpacked
+  , _Text
+  , text
+  , builder
+  , utf8
+  , pattern Text
+  ) where
+
+import Data.ByteString.Lazy as ByteString
+import Data.Text.Lazy as Text
+import Data.Text.Lazy.Builder
+import Data.Text.Lazy.Encoding
+
+import Optics.Core
+import Optics.Internal.Fold
+import Optics.Internal.IxFold
+import Optics.Internal.IxTraversal
+import Optics.Internal.Optic
+import Optics.Internal.Profunctor
+
+-- $setup
+-- >>> :set -XOverloadedStrings
+-- >>> import Optics.Core
+
+-- | This isomorphism can be used to 'pack' (or 'unpack') lazy 'Text'.
+--
+-- >>> "hello"^.packed -- :: Text
+-- "hello"
+--
+-- @
+-- 'pack' x ≡ x '^.' 'packed'
+-- 'unpack' x ≡ x '^.' 're' 'packed'
+-- 'packed' ≡ 're' 'unpacked'
+-- @
+packed :: Iso' String Text
+packed = iso Text.pack Text.unpack
+{-# INLINE packed #-}
+
+-- | This isomorphism can be used to 'unpack' (or 'pack') lazy 'Text'.
+--
+-- >>> "hello"^.unpacked -- :: String
+-- "hello"
+--
+-- @
+-- 'pack' x ≡ x '^.' 're' 'unpacked'
+-- 'unpack' x ≡ x '^.' 'packed'
+-- @
+--
+-- This 'Iso' is provided for notational convenience rather than out of great
+-- need, since
+--
+-- @
+-- 'unpacked' ≡ 're' 'packed'
+-- @
+unpacked :: Iso' Text String
+unpacked = Optic unpacked__
+{-# INLINE unpacked #-}
+
+-- | This is an alias for 'unpacked' that makes it clearer how to use it with
+-- @('#')@.
+--
+-- @
+-- '_Text' = 're' 'packed'
+-- @
+--
+-- >>> _Text # "hello" -- :: Text
+-- "hello"
+_Text :: Iso' Text String
+_Text = re packed
+{-# INLINE _Text #-}
+
+-- | Convert between lazy 'Text' and 'Builder' .
+--
+-- @
+-- 'fromLazyText' x ≡ x '^.' 'builder'
+-- 'toLazyText' x ≡ x '^.' 're' 'builder'
+-- @
+builder :: Iso' Text Builder
+builder = iso fromLazyText toLazyText
+{-# INLINE builder #-}
+
+-- | Traverse the individual characters in a 'Text'.
+--
+-- >>> anyOf text (=='c') "chello"
+-- True
+--
+-- @
+-- 'text' = 'unpacked' . 'traversed'
+-- @
+--
+-- When the type is unambiguous, you can also use the more general 'each'.
+--
+-- @
+-- 'text' ≡ 'each'
+-- @
+--
+-- Note that when just using this as a 'Setter', @'sets' 'Data.Text.Lazy.map'@
+-- can be more efficient.
+text :: IxTraversal' Int Text Char
+text = Optic text__
+{-# INLINE text #-}
+
+-- | Encode\/Decode a lazy 'Text' to\/from lazy 'ByteString', via UTF-8.
+--
+-- Note: This function does not decode lazily, as it must consume the entire
+-- input before deciding whether or not it fails.
+--
+-- >>> ByteString.unpack (utf8 # "☃")
+-- [226,152,131]
+utf8 :: Prism' ByteString Text
+utf8 = prism' encodeUtf8 (preview _Right . decodeUtf8')
+{-# INLINE utf8 #-}
+
+pattern Text :: String -> Text
+pattern Text a <- (view _Text -> a) where
+  Text a = review _Text a
+
+----------------------------------------
+-- Internal implementations
+
+-- | Internal implementation of 'unpacked'.
+unpacked__ :: Profunctor p => Optic__ p i i Text Text String String
+unpacked__ = dimap Text.unpack Text.pack
+{-# INLINE unpacked__ #-}
+
+-- | Internal implementation of 'text'.
+text__ :: Traversing p => Optic__ p j (Int -> j) Text Text Char Char
+text__ = unpacked__ . itraversed__
+{-# INLINE [0] text__ #-}
+
+{-# RULES
+
+"lazy text__ -> foldr"
+  forall (o :: Forget r j Char Char). text__ o
+                                    = foldring__ Text.foldr (Forget (runForget o))
+    :: Forget r (Int -> j) Text Text
+
+"lazy text__ -> ifoldr"
+  forall (o :: IxForget r j Char Char). text__ o = ifoldring__ ifoldrLazy o
+    :: IxForget r (Int -> j) Text Text
+
+"lazy text__ -> map"
+  forall (o :: FunArrow j Char Char). text__ o
+                                    = roam Text.map (FunArrow (runFunArrow o))
+    :: FunArrow (Int -> j) Text Text
+
+"lazy text__ -> imap"
+  forall (o :: IxFunArrow j Char Char). text__ o = iroam imapLazy o
+    :: IxFunArrow (Int -> j) Text Text
+
+#-}
+
+-- | Indexed fold for 'text__'.
+ifoldrLazy :: (Int -> Char -> a -> a) -> a -> Text -> a
+ifoldrLazy f z xs =
+  Text.foldr (\x g i -> i `seq` f i x (g (i + 1))) (const z) xs 0
+{-# INLINE ifoldrLazy #-}
+
+-- | Indexed setter for 'text__'.
+imapLazy :: (Int -> Char -> Char) -> Text -> Text
+imapLazy f = snd . Text.mapAccumL (\i a -> i `seq` (i + 1, f i a)) 0
+{-# INLINE imapLazy #-}

--- a/optics-extra/src/Data/Text/Lazy/Optics.hs
+++ b/optics-extra/src/Data/Text/Lazy/Optics.hs
@@ -135,8 +135,7 @@ text__ = unpacked__ . itraversed__
 {-# RULES
 
 "lazy text__ -> foldr"
-  forall (o :: Forget r j Char Char). text__ o
-                                    = foldring__ Text.foldr (Forget (runForget o))
+  forall (o :: Forget r j Char Char). text__ o = foldring__ Text.foldr (reForget o)
     :: Forget r (Int -> j) Text Text
 
 "lazy text__ -> ifoldr"
@@ -145,7 +144,7 @@ text__ = unpacked__ . itraversed__
 
 "lazy text__ -> map"
   forall (o :: FunArrow j Char Char). text__ o
-                                    = roam Text.map (FunArrow (runFunArrow o))
+                                    = roam Text.map (reFunArrow o)
     :: FunArrow (Int -> j) Text Text
 
 "lazy text__ -> imap"

--- a/optics-extra/src/Data/Text/Optics.hs
+++ b/optics-extra/src/Data/Text/Optics.hs
@@ -25,8 +25,8 @@ class IsText t where
   --
   -- @
   -- 'pack' x ≡ x '^.' 'packed'
-  -- 'unpack' x ≡ x '^.' 'from' 'packed'
-  -- 'packed' ≡ 'from' 'unpacked'
+  -- 'unpack' x ≡ x '^.' 're' 'packed'
+  -- 'packed' ≡ 're' 'unpacked'
   -- @
   packed :: Iso' String t
 
@@ -77,7 +77,7 @@ unpacked = re packed
 -- @('#')@.
 --
 -- @
--- '_Text' = 'from' 'packed'
+-- '_Text' = 're' 'packed'
 -- @
 --
 -- >>> _Text # "hello" :: Strict.Text

--- a/optics-extra/src/Data/Text/Optics.hs
+++ b/optics-extra/src/Data/Text/Optics.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE PatternSynonyms #-}
+module Data.Text.Optics
+  ( IsText(..)
+  , unpacked
+  , _Text
+  , pattern Text
+  ) where
+
+import Data.Text as Strict
+import Data.Text.Lazy as Lazy
+import Data.Text.Lazy.Builder
+
+import Optics.Core
+import qualified Data.Text.Lazy.Optics as Lazy
+import qualified Data.Text.Strict.Optics as Strict
+
+-- $setup
+-- >>> import Optics.Core
+
+-- | Traversals for strict or lazy 'Text'
+class IsText t where
+  -- | This isomorphism can be used to 'pack' (or 'unpack') strict or lazy
+  -- 'Text'.
+  --
+  -- @
+  -- 'pack' x ≡ x '^.' 'packed'
+  -- 'unpack' x ≡ x '^.' 'from' 'packed'
+  -- 'packed' ≡ 'from' 'unpacked'
+  -- @
+  packed :: Iso' String t
+
+  -- | Convert between strict or lazy 'Text' and a 'Builder'.
+  --
+  -- @
+  -- 'fromText' x ≡ x '^.' 'builder'
+  -- @
+  builder :: Iso' t Builder
+
+  -- | Traverse the individual characters in strict or lazy 'Text'.
+  --
+  -- @
+  -- 'text' = 'unpacked' . 'traversed'
+  -- @
+  text :: IxTraversal' Int t Char
+  text = unpacked % itraversed
+  {-# INLINE text #-}
+
+instance IsText String where
+  packed  = iso id id
+  text    = itraversed
+  builder = Lazy.packed % builder
+  {-# INLINE packed #-}
+  {-# INLINE text #-}
+  {-# INLINE builder #-}
+
+-- | This isomorphism can be used to 'unpack' (or 'pack') both strict or lazy
+-- 'Text'.
+--
+-- @
+-- 'unpack' x ≡ x '^.' 'unpacked'
+-- 'pack' x ≡ x '^.' 're' 'unpacked'
+-- @
+--
+-- This 'Iso' is provided for notational convenience rather than out of great
+-- need, since
+--
+-- @
+-- 'unpacked' ≡ 're' 'packed'
+-- @
+--
+unpacked :: IsText t => Iso' t String
+unpacked = re packed
+{-# INLINE unpacked #-}
+
+-- | This is an alias for 'unpacked' that makes it clearer how to use it with
+-- @('#')@.
+--
+-- @
+-- '_Text' = 'from' 'packed'
+-- @
+--
+-- >>> _Text # "hello" :: Strict.Text
+-- "hello"
+_Text :: IsText t => Iso' t String
+_Text = re packed
+{-# INLINE _Text #-}
+
+pattern Text :: IsText t => String -> t
+pattern Text a <- (view _Text -> a) where
+  Text a = review _Text a
+
+instance IsText Strict.Text where
+  packed  = Strict.packed
+  builder = Strict.builder
+  text    = Strict.text
+  {-# INLINE packed #-}
+  {-# INLINE builder #-}
+  {-# INLINE text #-}
+
+instance IsText Lazy.Text where
+  packed  = Lazy.packed
+  builder = Lazy.builder
+  text    = Lazy.text
+  {-# INLINE packed #-}
+  {-# INLINE builder #-}
+  {-# INLINE text #-}

--- a/optics-extra/src/Data/Text/Strict/Optics.hs
+++ b/optics-extra/src/Data/Text/Strict/Optics.hs
@@ -129,8 +129,7 @@ text__ = unpacked__ . itraversed__
 {-# RULES
 
 "strict text__ -> foldr"
-  forall (o :: Forget r j Char Char). text__ o
-                                    = foldring__ Strict.foldr (Forget (runForget o))
+  forall (o :: Forget r j Char Char). text__ o = foldring__ Strict.foldr (reForget o)
     :: Forget r (Int -> j) Text Text
 
 "strict text__ -> ifoldr"
@@ -138,8 +137,7 @@ text__ = unpacked__ . itraversed__
     :: IxForget r (Int -> j) Text Text
 
 "strict text__ -> map"
-  forall (o :: FunArrow j Char Char). text__ o
-                                    = roam Strict.map (FunArrow (runFunArrow o))
+  forall (o :: FunArrow j Char Char). text__ o = roam Strict.map (reFunArrow o)
     :: FunArrow (Int -> j) Text Text
 
 "strict text__ -> imap"

--- a/optics-extra/src/Data/Text/Strict/Optics.hs
+++ b/optics-extra/src/Data/Text/Strict/Optics.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE PatternSynonyms #-}
+module Data.Text.Strict.Optics
+  ( packed
+  , unpacked
+  , builder
+  , text
+  , utf8
+  , _Text
+  , pattern Text
+  ) where
+
+import Data.ByteString (ByteString)
+import Data.Text as Strict
+import Data.Text.Encoding
+import Data.Text.Lazy (toStrict)
+import Data.Text.Lazy.Builder
+
+import Optics.Core
+import Optics.Internal.Fold
+import Optics.Internal.IxFold
+import Optics.Internal.IxTraversal
+import Optics.Internal.Optic
+import Optics.Internal.Profunctor
+
+-- $setup
+-- >>> :set -XOverloadedStrings
+-- >>> import Optics.Core
+
+-- | This isomorphism can be used to 'pack' (or 'unpack') strict 'Text'.
+--
+--
+-- >>> "hello"^.packed -- :: Text
+-- "hello"
+--
+-- @
+-- 'pack' x ≡ x '^.' 'packed'
+-- 'unpack' x ≡ x '^.' 're' 'packed'
+-- 'packed' ≡ 're' 'unpacked'
+-- 'packed' ≡ 'iso' 'pack' 'unpack'
+-- @
+packed :: Iso' String Text
+packed = iso pack unpack
+{-# INLINE packed #-}
+
+-- | This isomorphism can be used to 'unpack' (or 'pack') lazy 'Text'.
+--
+-- >>> "hello"^.unpacked -- :: String
+-- "hello"
+--
+-- This 'Iso' is provided for notational convenience rather than out of great
+-- need, since
+--
+-- @
+-- 'unpacked' ≡ 're' 'packed'
+-- @
+--
+-- @
+-- 'pack' x ≡ x '^.' 're' 'unpacked'
+-- 'unpack' x ≡ x '^.' 'packed'
+-- 'unpacked' ≡ 'iso' 'unpack' 'pack'
+-- @
+unpacked :: Iso' Text String
+unpacked = Optic unpacked__
+{-# INLINE unpacked #-}
+
+-- | This is an alias for 'unpacked' that makes it more obvious how to use it
+-- with '#'
+--
+-- >> _Text # "hello" -- :: Text
+-- "hello"
+_Text :: Iso' Text String
+_Text = unpacked
+{-# INLINE _Text #-}
+
+-- | Convert between strict 'Text' and 'Builder' .
+--
+-- @
+-- 'fromText' x ≡ x '^.' 'builder'
+-- 'toStrict' ('toLazyText' x) ≡ x '^.' 're' 'builder'
+-- @
+builder :: Iso' Text Builder
+builder = iso fromText (toStrict . toLazyText)
+{-# INLINE builder #-}
+
+-- | Traverse the individual characters in strict 'Text'.
+--
+-- >>> anyOf text (=='o') "hello"
+-- True
+--
+-- When the type is unambiguous, you can also use the more general 'each'.
+--
+-- @
+-- 'text' ≡ 'unpacked' . 'traversed'
+-- 'text' ≡ 'each'
+-- @
+--
+-- Note that when just using this as a 'Setter', @'sets' 'Data.Text.map'@ can be
+-- more efficient.
+text :: IxTraversal' Int Text Char
+text = Optic text__
+{-# INLINE text #-}
+
+-- | Encode\/Decode a strict 'Text' to\/from strict 'ByteString', via UTF-8.
+--
+-- >>> utf8 # "☃"
+-- "\226\152\131"
+utf8 :: Prism' ByteString Text
+utf8 = prism' encodeUtf8 (preview _Right . decodeUtf8')
+{-# INLINE utf8 #-}
+
+pattern Text :: String -> Text
+pattern Text a <- (view _Text -> a) where
+  Text a = review _Text a
+
+----------------------------------------
+-- Internal implementations
+
+-- | Internal implementation of 'unpacked'.
+unpacked__ :: Profunctor p => Optic__ p i i Text Text String String
+unpacked__ = dimap unpack pack
+{-# INLINE unpacked__ #-}
+
+-- | Internal implementation of 'text'.
+text__ :: Traversing p => Optic__ p j (Int -> j) Text Text Char Char
+text__ = unpacked__ . itraversed__
+{-# INLINE [0] text__ #-}
+
+{-# RULES
+
+"strict text__ -> foldr"
+  forall (o :: Forget r j Char Char). text__ o
+                                    = foldring__ Strict.foldr (Forget (runForget o))
+    :: Forget r (Int -> j) Text Text
+
+"strict text__ -> ifoldr"
+  forall (o :: IxForget r j Char Char). text__ o = ifoldring__ ifoldrStrict o
+    :: IxForget r (Int -> j) Text Text
+
+"strict text__ -> map"
+  forall (o :: FunArrow j Char Char). text__ o
+                                    = roam Strict.map (FunArrow (runFunArrow o))
+    :: FunArrow (Int -> j) Text Text
+
+"strict text__ -> imap"
+  forall (o :: IxFunArrow j Char Char). text__ o = iroam imapStrict o
+    :: IxFunArrow (Int -> j) Text Text
+
+#-}
+
+-- | Indexed fold for 'text__'.
+ifoldrStrict :: (Int -> Char -> a -> a) -> a -> Text -> a
+ifoldrStrict f z xs =
+  Strict.foldr (\x g i -> i `seq` f i x (g (i + 1))) (const z) xs 0
+{-# INLINE ifoldrStrict #-}
+
+-- | Indexed setter for 'text__'.
+imapStrict :: (Int -> Char -> Char) -> Text -> Text
+imapStrict f = snd . Strict.mapAccumL (\i a -> i `seq` (i + 1, f i a)) 0
+{-# INLINE imapStrict #-}

--- a/optics-extra/src/Data/Vector/Generic/Optics.hs
+++ b/optics-extra/src/Data/Vector/Generic/Optics.hs
@@ -147,10 +147,10 @@ vectorTraverse__
 vectorTraverse__ = conjoinedTraversal__ noix withix
   where
     noix :: Applicative f => (a -> f b) -> v a -> f (w b)
-    noix f v = V.fromListN (V.length v) <$> traverse f (V.toList v)
+    noix f v = let !n = V.length v in V.fromListN n <$> traverse f (V.toList v)
 
     withix :: Applicative f => (Int -> a -> f b) -> (v a) -> f (w b)
-    withix f v = V.fromListN (V.length v) <$> itraverse f (V.toList v)
+    withix f v = let !n = V.length v in V.fromListN n <$> itraverse f (V.toList v)
 {-# INLINE [0] vectorTraverse__ #-}
 
 {-# RULES

--- a/optics-extra/src/Data/Vector/Generic/Optics.hs
+++ b/optics-extra/src/Data/Vector/Generic/Optics.hs
@@ -23,7 +23,7 @@ import Data.Vector.Generic.New (New)
 import Prelude hiding ((++), length, null, head, tail, init, last, map, reverse)
 
 import Optics.Core
-import Optics.Extra.Internal
+import Optics.Extra.Internal.Vector
 import Optics.Internal.Fold
 import Optics.Internal.IxFold
 import Optics.Internal.IxTraversal

--- a/optics-extra/src/Data/Vector/Generic/Optics.hs
+++ b/optics-extra/src/Data/Vector/Generic/Optics.hs
@@ -1,0 +1,176 @@
+-- | This module provides lenses and traversals for working with generic
+-- vectors.
+module Data.Vector.Generic.Optics
+  ( toVectorOf
+  -- * Isomorphisms
+  , forced
+  , vector
+  , asStream
+  , asStreamR
+  , cloned
+  , converted
+  -- * Lenses
+  , sliced
+  -- * Traversal of individual indices
+  , ordinals
+  , vectorIx
+  , vectorTraverse
+  ) where
+
+import Data.Vector.Fusion.Bundle (Bundle)
+import Data.Vector.Generic as V hiding (zip, filter, indexed)
+import Data.Vector.Generic.New (New)
+import Prelude hiding ((++), length, null, head, tail, init, last, map, reverse)
+
+import Optics.Core
+import Optics.Extra.Internal
+import Optics.Internal.Fold
+import Optics.Internal.IxFold
+import Optics.Internal.IxTraversal
+import Optics.Internal.Profunctor
+import Optics.Internal.Optic
+
+-- $setup
+-- >>> import Data.Vector as Vector
+
+-- | @sliced i n@ provides a 'Lens' that edits the @n@ elements starting at
+-- index @i@ from a 'Lens'.
+--
+-- This is only a valid 'Lens' if you do not change the length of the resulting
+-- 'Vector'.
+--
+-- Attempting to return a longer or shorter vector will result in violations of
+-- the 'Lens' laws.
+--
+-- >>> Vector.fromList [1..10] ^. sliced 2 5 == Vector.fromList [3,4,5,6,7]
+-- True
+--
+-- >>> (Vector.fromList [1..10] & sliced 2 5 . mapped .~ 0) == Vector.fromList [1,2,0,0,0,0,0,8,9,10]
+-- True
+sliced
+  :: Vector v a
+  => Int -- ^ @i@ starting index
+  -> Int -- ^ @n@ length
+  -> Lens' (v a) (v a)
+sliced i n = lensVL $ \f v ->
+  (\v0 -> v // zip [i..i+n-1] (V.toList v0)) <$> f (slice i n v)
+{-# INLINE sliced #-}
+
+-- | Similar to 'toListOf', but returning a 'Vector'.
+--
+-- >>> (toVectorOf both (8,15) :: Vector.Vector Int) == Vector.fromList [8,15]
+-- True
+toVectorOf
+  :: (Is k A_Fold, Vector v a)
+  => Optic' k is s a
+  -> s
+  -> v a
+toVectorOf l s = fromList (toListOf l s)
+{-# INLINE toVectorOf #-}
+
+-- | Convert a list to a 'Vector' (or back.)
+--
+-- >>> ([1,2,3] ^. vector :: Vector.Vector Int) == Vector.fromList [1,2,3]
+-- True
+--
+-- >>> Vector.fromList [0,8,15] ^. from vector
+-- [0,8,15]
+vector
+  :: (Vector v a, Vector v b)
+  => Iso [a] [b] (v a) (v b)
+vector = iso fromList V.toList
+{-# INLINE vector #-}
+
+-- | Convert a 'Vector' to a finite 'Bundle' (or back.)
+asStream
+  :: (Vector v a, Vector v b)
+  => Iso (v a) (v b) (Bundle v a) (Bundle v b)
+asStream = iso stream unstream
+{-# INLINE asStream #-}
+
+-- | Convert a 'Vector' to a finite 'Bundle' from right to left (or back.)
+asStreamR
+  :: (Vector v a, Vector v b)
+  => Iso (v a) (v b) (Bundle v a) (Bundle v b)
+asStreamR = iso streamR unstreamR
+{-# INLINE asStreamR #-}
+
+-- | Convert a 'Vector' back and forth to an initializer that when run produces
+-- a copy of the 'Vector'.
+cloned :: Vector v a => Iso' (v a) (New v a)
+cloned = iso clone new
+{-# INLINE cloned #-}
+
+-- | Convert a 'Vector' to a version that doesn't retain any extra memory.
+forced :: (Vector v a, Vector v b) => Iso (v a) (v b) (v a) (v b)
+forced = iso force force
+{-# INLINE forced #-}
+
+-- | This 'Traversal' will ignore any duplicates in the supplied list of
+-- indices.
+--
+-- >>> toListOf (ordinals [1,3,2,5,9,10]) $ Vector.fromList [2,4..40]
+-- [4,8,6,12,20,22]
+ordinals :: forall v a. Vector v a => [Int] -> IxTraversal' Int (v a) a
+ordinals is = ixTraversalVL $ \f v ->
+  (v //) <$> traverse (\i -> (,) i <$> f i (v ! i)) (ordinalNub (length v) is)
+{-# INLINE ordinals #-}
+
+-- | Like 'ix' but polymorphic in the vector type.
+vectorIx :: V.Vector v a => Int -> Traversal' (v a) a
+vectorIx i = traversalVL $ \f v ->
+  if 0 <= i && i < V.length v
+  then (\a -> v V.// [(i, a)]) <$> f (v V.! i)
+  else pure v
+{-# INLINE vectorIx #-}
+
+-- | Indexed vector traversal for a generic vector.
+vectorTraverse
+  :: forall v w a b. (V.Vector v a, V.Vector w b)
+  => IxTraversal Int (v a) (w b) a b
+vectorTraverse = Optic vectorTraverse__
+{-# INLINE vectorTraverse #-}
+
+-- | Different vector implementations are isomorphic to each other.
+converted
+  :: (Vector v a, Vector w a, Vector v b, Vector w b)
+  => Iso (v a) (v b) (w a) (w b)
+converted = iso convert convert
+{-# INLINE converted #-}
+
+----------------------------------------
+-- Internal implementations
+
+vectorTraverse__
+  :: forall p j v w a b. (Traversing p, V.Vector v a, V.Vector w b)
+  => Optic__ p j (Int -> j) (v a) (w b) a b
+vectorTraverse__ = conjoinedTraversal__ noix withix
+  where
+    noix :: Applicative f => (a -> f b) -> v a -> f (w b)
+    noix f v = V.fromListN (V.length v) <$> traverse f (V.toList v)
+
+    withix :: Applicative f => (Int -> a -> f b) -> (v a) -> f (w b)
+    withix f v = V.fromListN (V.length v) <$> itraverse f (V.toList v)
+{-# INLINE [0] vectorTraverse__ #-}
+
+{-# RULES
+
+"vectorTraverse__ -> mapped"
+  forall (o :: FunArrow j a b). vectorTraverse__ o
+                              = roam V.map (FunArrow (runFunArrow o))
+    :: (V.Vector v a, V.Vector v b) => FunArrow (Int -> j) (v a) (v b)
+
+"vectorTraverse__ -> imapped"
+  forall (o :: IxFunArrow j a b). vectorTraverse__ o = iroam V.imap o
+    :: (V.Vector v a, V.Vector v b) => IxFunArrow (Int -> j) (v a) (v b)
+
+"vectorTraverse__ -> foldr"
+  forall (o :: Forget r j a b). vectorTraverse__ o
+                              = foldring__ V.foldr (Forget (runForget o))
+    :: (V.Vector v a, V.Vector v b) => Forget r (Int -> j) (v a) (v b)
+
+"vectorTraverse__ -> ifoldr"
+  forall (o :: IxForget r j a b). vectorTraverse__ o = ifoldring__ V.ifoldr o
+    :: (V.Vector v a, V.Vector v b) => IxForget r (Int -> j) (v a) (v b)
+
+#-}

--- a/optics-extra/src/Data/Vector/Generic/Optics.hs
+++ b/optics-extra/src/Data/Vector/Generic/Optics.hs
@@ -156,8 +156,7 @@ vectorTraverse__ = conjoinedTraversal__ noix withix
 {-# RULES
 
 "vectorTraverse__ -> mapped"
-  forall (o :: FunArrow j a b). vectorTraverse__ o
-                              = roam V.map (FunArrow (runFunArrow o))
+  forall (o :: FunArrow j a b). vectorTraverse__ o = roam V.map (reFunArrow o)
     :: (V.Vector v a, V.Vector v b) => FunArrow (Int -> j) (v a) (v b)
 
 "vectorTraverse__ -> imapped"
@@ -165,8 +164,7 @@ vectorTraverse__ = conjoinedTraversal__ noix withix
     :: (V.Vector v a, V.Vector v b) => IxFunArrow (Int -> j) (v a) (v b)
 
 "vectorTraverse__ -> foldr"
-  forall (o :: Forget r j a b). vectorTraverse__ o
-                              = foldring__ V.foldr (Forget (runForget o))
+  forall (o :: Forget r j a b). vectorTraverse__ o = foldring__ V.foldr (reForget o)
     :: (V.Vector v a, V.Vector v b) => Forget r (Int -> j) (v a) (v b)
 
 "vectorTraverse__ -> ifoldr"

--- a/optics-extra/src/Data/Vector/Optics.hs
+++ b/optics-extra/src/Data/Vector/Optics.hs
@@ -1,0 +1,79 @@
+-- | This module provides lenses and traversals for working with vectors.
+module Data.Vector.Optics
+  ( toVectorOf
+  -- * Isomorphisms
+  , vector
+  , forced
+  -- * Lenses
+  , sliced
+  -- * Traversal of individual indices
+  , ordinals
+  ) where
+
+import Data.Vector as Vector hiding (zip, filter, indexed)
+import Prelude hiding ((++), length, null, head, tail, init, last, map, reverse)
+
+import Optics.Core
+import qualified Data.Vector.Generic.Optics as G
+
+-- | @sliced i n@ provides a 'Lens' that edits the @n@ elements starting at
+-- index @i@ from a 'Lens'.
+--
+-- This is only a valid 'Lens' if you do not change the length of the resulting
+-- 'Vector'.
+--
+-- Attempting to return a longer or shorter vector will result in violations of
+-- the 'Lens' laws.
+--
+-- >>> Vector.fromList [1..10] ^. sliced 2 5 == Vector.fromList [3,4,5,6,7]
+-- True
+--
+-- >>> (Vector.fromList [1..10] & sliced 2 5 . mapped .~ 0) == Vector.fromList [1,2,0,0,0,0,0,8,9,10]
+-- True
+sliced
+  :: Int -- ^ @i@ starting index
+  -> Int -- ^ @n@ length
+  -> Lens' (Vector a) (Vector a)
+sliced = G.sliced
+{-# INLINE sliced #-}
+
+-- | Similar to 'toListOf', but returning a 'Vector'.
+--
+-- >>> toVectorOf both (8,15) == Vector.fromList [8,15]
+-- True
+toVectorOf
+  :: Is k A_Fold
+  => Optic' k is s a
+  -> s
+  -> Vector a
+toVectorOf = G.toVectorOf
+{-# INLINE toVectorOf #-}
+
+-- | Convert a list to a 'Vector' (or back)
+--
+-- >>> [1,2,3] ^. vector == Vector.fromList [1,2,3]
+-- True
+--
+-- >>> [1,2,3] ^. vector . from vector
+-- [1,2,3]
+--
+-- >>> Vector.fromList [0,8,15] ^. from vector . vector == Vector.fromList [0,8,15]
+-- True
+vector :: Iso [a] [b] (Vector a) (Vector b)
+vector = G.vector
+{-# INLINE vector #-}
+
+-- | Convert a 'Vector' to a version that doesn't retain any extra
+-- memory.
+forced :: Iso (Vector a) (Vector b) (Vector a) (Vector b)
+forced = G.forced
+{-# INLINE forced #-}
+
+-- | This 'Traversal' will ignore any duplicates in the supplied list of
+-- indices.
+--
+-- >>> toListOf (ordinals [1,3,2,5,9,10]) $ Vector.fromList [2,4..40]
+-- [4,8,6,12,20,22]
+ordinals :: forall a. [Int] -> IxTraversal' Int (Vector a) a
+ordinals = G.ordinals
+{-# INLINE ordinals #-}

--- a/optics-extra/src/GHC/Generics/Optics.hs
+++ b/optics-extra/src/GHC/Generics/Optics.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PolyKinds #-}
 -- | Note: "GHC.Generics" exports a number of names that collide with "Optics"
 -- (at least 'to').
@@ -19,8 +14,7 @@
 -- from "GHC.Generics".
 --
 module GHC.Generics.Optics
-  (
-    generic
+  ( generic
   , generic1
   , _V1
   , _U1
@@ -33,9 +27,12 @@ module GHC.Generics.Optics
   ) where
 
 import qualified GHC.Generics as GHC (to, from, to1, from1)
-import GHC.Generics (Generic, Rep, Generic1, Rep1, (:+:) (..), V1, U1 (..), K1 (..), M1 (..), Par1 (..), Rec1 (..))
+import GHC.Generics (Generic, Rep, Generic1, Rep1, (:+:) (..), V1, U1 (..),
+                     K1 (..), M1 (..), Par1 (..), Rec1 (..))
 
-import Optics
+import Optics.Iso
+import Optics.Lens
+import Optics.Prism
 
 -- | Convert from the data type to its representation (or back)
 --

--- a/optics-extra/src/Optics/Each.hs
+++ b/optics-extra/src/Optics/Each.hs
@@ -1,8 +1,4 @@
-{-# LANGUAGE DefaultSignatures      #-}
-{-# LANGUAGE FlexibleInstances      #-}
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE GADTs                  #-}
-{-# LANGUAGE UndecidableInstances   #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Optics.Each
   (
   -- * Each

--- a/optics-extra/src/Optics/Each.hs
+++ b/optics-extra/src/Optics/Each.hs
@@ -7,15 +7,31 @@ module Optics.Each
 
 import Data.Array.IArray as IArray
 import Data.Array.Unboxed as Unboxed
+import Data.ByteString as SB
+import Data.ByteString.Lazy as LB
 import Data.Complex
 import Data.Functor.Identity
+import Data.HashMap.Lazy as HashMap
 import Data.IntMap as IntMap
 import Data.List.NonEmpty
 import Data.Map as Map
 import Data.Sequence as Seq
+import Data.Text as ST
+import Data.Text.Lazy as LT
+import Data.Text.Optics (text)
 import Data.Tree as Tree
+import Data.Vector.Generic.Optics (vectorTraverse)
+import Data.Vector.Primitive (Prim)
+import Data.Vector.Storable (Storable)
+import Data.Vector.Unboxed (Unbox)
+import Data.Word
+import qualified Data.Vector as Vector
+import qualified Data.Vector.Primitive as Prim
+import qualified Data.Vector.Storable as Storable
+import qualified Data.Vector.Unboxed as Unboxed
 
-import Optics.Traversal
+import Optics.Core
+import Optics.Extra.Internal.ByteString
 
 -- | Extract 'each' element of a (potentially monomorphic) container.
 --
@@ -80,6 +96,9 @@ instance (c ~ d) => Each (Map c a) (Map d b) a b
 -- | @'each' :: 'Traversal' i ('Map' c a) ('Map' c b) a b@
 instance Each (IntMap a) (IntMap b) a b
 
+-- | @'each' :: 'Traversal' ('HashMap' c a) ('HashMap' c b) a b@
+instance (c ~ d) => Each (HashMap c a) (HashMap d b) a b where
+
 -- | @'each' :: 'Traversal' i [a] [b] a b@
 instance Each [a] [b] a b
 
@@ -97,6 +116,51 @@ instance Each (Seq a) (Seq b) a b
 
 -- | @'each' :: 'Traversal' i ('Tree' a) ('Tree' b) a b@
 instance Each (Tree a) (Tree b) a b
+
+-- | @'each' :: 'Traversal' ('Vector.Vector' a) ('Vector.Vector' b) a b@
+instance Each (Vector.Vector a) (Vector.Vector b) a b where
+  each = noIx vectorTraverse
+  {-# INLINE each #-}
+
+-- | @'each' :: ('Prim' a, 'Prim' b) => 'Traversal' ('Prim.Vector' a)
+-- ('Prim.Vector' b) a b@
+instance (Prim a, Prim b) => Each (Prim.Vector a) (Prim.Vector b) a b where
+  each = noIx vectorTraverse
+  {-# INLINE each #-}
+
+-- | @'each' :: ('Storable' a, 'Storable' b) => 'Traversal' ('Storable.Vector'
+-- a) ('Storable.Vector' b) a b@
+instance (Storable a, Storable b) => Each (Storable.Vector a) (Storable.Vector b) a b where
+  each = noIx vectorTraverse
+  {-# INLINE each #-}
+
+-- | @'each' :: ('Unbox' a, 'Unbox' b) => 'Traversal' ('Unboxed.Vector' a)
+-- ('Unboxed.Vector' b) a b@
+instance (Unbox a, Unbox b) => Each (Unboxed.Vector a) (Unboxed.Vector b) a b where
+  each = noIx vectorTraverse
+  {-# INLINE each #-}
+
+-- | @'each' :: 'Traversal' 'StrictT.Text' 'StrictT.Text' 'Char' 'Char'@
+instance (a ~ Char, b ~ Char) => Each ST.Text ST.Text a b where
+  each = noIx text
+  {-# INLINE each #-}
+
+-- | @'each' :: 'Traversal' 'LazyT.Text' 'LazyT.Text' 'Char' 'Char'@
+instance (a ~ Char, b ~ Char) => Each LT.Text LT.Text a b where
+  each = noIx text
+  {-# INLINE each #-}
+
+-- | @'each' :: 'Traversal' 'StrictB.ByteString' 'StrictB.ByteString' 'Word8'
+-- 'Word8'@
+instance (a ~ Word8, b ~ Word8) => Each SB.ByteString SB.ByteString a b where
+  each = noIx traversedStrictTree
+  {-# INLINE each #-}
+
+-- | @'each' :: 'Traversal' 'LazyB.ByteString' 'LazyB.ByteString' 'Word8'
+-- 'Word8'@
+instance (a ~ Word8, b ~ Word8) => Each LB.ByteString LB.ByteString a b where
+  each = noIx traversedLazy
+  {-# INLINE each #-}
 
 -- | @'each' :: 'Ix' i => 'Traversal' i ('Array' i a) ('Array' i b) a b@
 instance (Ix i, i ~ j) => Each (Array i a) (Array j b) a b where

--- a/optics-extra/src/Optics/Extra.hs
+++ b/optics-extra/src/Optics/Extra.hs
@@ -1,0 +1,1 @@
+module Optics.Extra where

--- a/optics-extra/src/Optics/Extra/Internal.hs
+++ b/optics-extra/src/Optics/Extra/Internal.hs
@@ -1,0 +1,27 @@
+module Optics.Extra.Internal
+  ( ordinalNub
+  ) where
+
+import Data.IntSet (IntSet)
+import qualified Data.IntSet as IntSet
+
+-- | Return the the subset of given ordinals within a given bound and in order
+-- of the first occurrence seen.
+--
+-- Bound: @0 <= x < l@
+--
+-- >>> ordinalNub 3 [-1,2,1,4,2,3]
+-- [2,1]
+ordinalNub ::
+  Int   {- ^ strict upper bound -} ->
+  [Int] {- ^ ordinals           -} ->
+  [Int] {- ^ unique, in-bound ordinals, in order seen -}
+ordinalNub l xs = foldr (ordinalNubHelper l) (const []) xs IntSet.empty
+
+ordinalNubHelper :: Int -> Int -> (IntSet -> [Int]) -> (IntSet -> [Int])
+ordinalNubHelper l x next seen
+  | outOfBounds || notUnique = next seen
+  | otherwise                = x : next (IntSet.insert x seen)
+  where
+  outOfBounds = x < 0 || l <= x
+  notUnique   = x `IntSet.member` seen

--- a/optics-extra/src/Optics/Extra/Internal/ByteString.hs
+++ b/optics-extra/src/Optics/Extra/Internal/ByteString.hs
@@ -1,0 +1,296 @@
+-- | This module spends a lot of time fiddling around with 'Data.ByteString'
+-- internals to work around <http://hackage.haskell.org/trac/ghc/ticket/7556> on
+-- older Haskell Platforms and to improve constant and asymptotic factors in our
+-- performance.
+----------------------------------------------------------------------------
+module Optics.Extra.Internal.ByteString
+  ( traversedStrictTree
+  , traversedStrictTree8
+  , traversedLazy
+  , traversedLazy8
+  ) where
+
+import Data.Bits
+import Data.Char
+import Data.Int
+import Data.Word
+import Foreign.ForeignPtr
+import Foreign.Ptr
+import Foreign.Storable
+import GHC.Base (unsafeChr)
+import GHC.ForeignPtr (mallocPlainForeignPtrBytes)
+import GHC.IO (unsafeDupablePerformIO)
+import qualified Data.ByteString            as B
+import qualified Data.ByteString.Char8      as B8
+import qualified Data.ByteString.Lazy       as BL
+import qualified Data.ByteString.Lazy.Char8 as BL8
+import qualified Data.ByteString.Internal   as BI
+import qualified Data.ByteString.Unsafe     as BU
+
+import Optics.Core
+import Optics.Internal.Fold
+import Optics.Internal.IxFold
+import Optics.Internal.Optic
+import Optics.Internal.Profunctor
+
+-- | Traverse a strict 'B.ByteString' in a relatively balanced fashion, as a
+-- balanced tree with biased runs of elements at the leaves.
+traversedStrictTree :: IxTraversal' Int B.ByteString Word8
+traversedStrictTree = Optic traversedStrictTree__
+{-# INLINE traversedStrictTree #-}
+
+-- | Traverse a strict 'B.ByteString' in a relatively balanced fashion, as a
+-- balanced tree with biased runs of elements at the leaves, pretending the
+-- bytes are chars.
+traversedStrictTree8 :: IxTraversal' Int B8.ByteString Char
+traversedStrictTree8 = Optic traversedStrictTree8__
+{-# INLINE traversedStrictTree8 #-}
+
+-- | An 'IndexedTraversal' of the individual bytes in a lazy 'BL.ByteString'.
+traversedLazy :: IxTraversal' Int64 BL.ByteString Word8
+traversedLazy = Optic traversedLazy__
+{-# INLINE traversedLazy #-}
+
+-- | An 'IndexedTraversal' of the individual bytes in a lazy 'BL.ByteString'
+-- pretending the bytes are chars.
+traversedLazy8 :: IxTraversal' Int64 BL.ByteString Char
+traversedLazy8 = Optic traversedLazy8__
+{-# INLINE traversedLazy8 #-}
+
+----------------------------------------
+-- Internal implementations
+
+grain :: Int
+grain = 32
+{-# INLINE grain #-}
+
+-- | Internal version of 'traversedStrictTree'.
+traversedStrictTree__
+  :: Traversing p
+  => Optic__ p j (Int -> j) B.ByteString B.ByteString Word8 Word8
+traversedStrictTree__ = iwander $ \f bs ->
+  let len = B.length bs
+      go !i !j
+        | i + grain < j, k <- i + shiftR (j - i) 1 =
+            (\l r q -> l q >> r q) <$> go i k <*> go k j
+        | otherwise = run i j
+      run !i !j
+        | i == j    = pure (\_ -> return ())
+        | otherwise =
+          let !x = BU.unsafeIndex bs i
+          in (\y ys q -> pokeByteOff q i y >> ys q)
+               <$> f i x
+               <*> run (i + 1) j
+  in unsafeCreate len <$> go 0 len
+{-# INLINE [0] traversedStrictTree__ #-}
+
+{-# RULES
+
+"bytes -> map"
+  forall (o :: FunArrow j Word8 Word8). traversedStrictTree__ o
+                                      = roam B.map (FunArrow (runFunArrow o))
+    :: FunArrow (Int -> j) B.ByteString B.ByteString
+
+"bytes -> imap"
+  forall (o :: IxFunArrow j Word8 Word8). traversedStrictTree__ o = iroam imapB o
+    :: IxFunArrow (Int -> j) B.ByteString B.ByteString
+
+"bytes -> foldr"
+  forall (o :: Forget r j Word8 Word8). traversedStrictTree__ o
+                                      = foldring__ B.foldr (Forget (runForget o))
+    :: Forget r (Int -> j) B.ByteString B.ByteString
+
+"bytes -> ifoldr"
+  forall (o :: IxForget r j Word8 Word8). traversedStrictTree__ o
+                                        = ifoldring__ ifoldrB o
+    :: IxForget r (Int -> j) B.ByteString B.ByteString
+
+#-}
+
+-- | Indexed setter for 'traversedStrictTree__'.
+imapB :: (Int -> Word8 -> Word8) -> B.ByteString -> B.ByteString
+imapB f = snd . B.mapAccumL (\i a -> i `seq` (i + 1, f i a)) 0
+{-# INLINE imapB #-}
+
+-- | Indexed fold for 'traversedStrictTree__'.
+ifoldrB :: (Int -> Word8 -> a -> a) -> a -> B.ByteString -> a
+ifoldrB f z xs = B.foldr (\x g i -> i `seq` f i x (g (i + 1))) (const z) xs 0
+{-# INLINE ifoldrB #-}
+
+----------------------------------------
+
+-- | Internal version of 'traversedStrictTree8'.
+traversedStrictTree8__
+  :: Traversing p
+  => Optic__ p j (Int -> j) B8.ByteString B8.ByteString Char Char
+traversedStrictTree8__ = iwander $ \f bs ->
+  let len = B.length bs
+      go !i !j
+        | i + grain < j, k <- i + shiftR (j - i) 1 =
+            (\l r q -> l q >> r q) <$> go i k <*> go k j
+        | otherwise = run i j
+      run !i !j
+        | i == j    = pure (\_ -> return ())
+        | otherwise =
+          let !x = BU.unsafeIndex bs i
+          in (\y ys q -> pokeByteOff q i (c2w y) >> ys q)
+               <$> f i (w2c x)
+               <*> run (i + 1) j
+  in unsafeCreate len <$> go 0 len
+{-# INLINE [0] traversedStrictTree8__ #-}
+
+{-# RULES
+
+"chars -> map"
+  forall (o :: FunArrow j Char Char). traversedStrictTree8__ o
+                                    = roam B8.map (FunArrow (runFunArrow o))
+    :: FunArrow (Int -> j) B8.ByteString B8.ByteString
+
+"chars -> imap"
+  forall (o :: IxFunArrow j Char Char). traversedStrictTree8__ o = iroam imapB8 o
+    :: IxFunArrow (Int -> j) B8.ByteString B8.ByteString
+
+"chars -> foldr"
+  forall (o :: Forget r j Char Char). traversedStrictTree8__ o
+                                    = foldring__ B8.foldr (Forget (runForget o))
+    :: Forget r (Int -> j) B8.ByteString B8.ByteString
+
+"chars -> ifoldr"
+  forall (o :: IxForget r j Char Char). traversedStrictTree8__ o
+                                      = ifoldring__ ifoldrB8 o
+    :: IxForget r (Int -> j) B8.ByteString B8.ByteString
+
+#-}
+
+-- | Indexed setter for 'traversedStrictTree8__'.
+imapB8 :: (Int -> Char -> Char) -> B.ByteString -> B.ByteString
+imapB8 f = snd . B8.mapAccumL (\i a -> i `seq` (i + 1, f i a)) 0
+{-# INLINE imapB8 #-}
+
+-- | Indexed fold for 'traversedStrictTree8__'.
+ifoldrB8 :: (Int -> Char -> a -> a) -> a -> B.ByteString -> a
+ifoldrB8 f z xs = B8.foldr (\x g i -> i `seq` f i x (g (i + 1))) (const z) xs 0
+{-# INLINE ifoldrB8 #-}
+
+----------------------------------------
+
+-- | Internal version of 'traversedLazy'.
+traversedLazy__
+  :: Traversing p
+  => Optic__ p j (Int64 -> j) BL.ByteString BL.ByteString Word8 Word8
+traversedLazy__ = iwander $ \f lbs ->
+  let go c fcs acc =
+        let !acc' = acc + fromIntegral (B.length c)
+            rest = reindex (\x -> acc + fromIntegral x) traversedStrictTree
+        in BL.append . BL.fromStrict <$> itraverseOf rest f c <*> fcs acc'
+  in BL.foldrChunks go (\_ -> pure BL.empty) lbs 0
+{-# INLINE [1] traversedLazy__ #-}
+
+{-# RULES
+
+"sets lazy bytestring"
+  forall (o :: FunArrow j Word8 Word8). traversedLazy__ o
+                                      = roam BL.map (FunArrow (runFunArrow o))
+    :: FunArrow (Int64 -> j) BL.ByteString BL.ByteString
+
+"isets lazy bytestring"
+  forall (o :: IxFunArrow j Word8 Word8). traversedLazy__ o = iroam imapBL o
+    :: IxFunArrow (Int64 -> j) BL.ByteString BL.ByteString
+
+"gets lazy bytestring"
+  forall (o :: Forget r j Word8 Word8). traversedLazy__ o
+                                      = foldring__ BL.foldr (Forget (runForget o))
+    :: Forget r (Int64 -> j) BL.ByteString BL.ByteString
+
+"igets lazy bytestring"
+  forall (o :: IxForget r j Word8 Word8). traversedLazy__ o = ifoldring__ ifoldrBL o
+    :: IxForget r (Int64 -> j) BL.ByteString BL.ByteString
+
+#-}
+
+-- | Indexed setter for 'traversedLazy__'.
+imapBL :: (Int64 -> Word8 -> Word8) -> BL.ByteString -> BL.ByteString
+imapBL f = snd . BL.mapAccumL (\i a -> i `seq` (i + 1, f i a)) 0
+{-# INLINE imapBL #-}
+
+-- | Indexed fold for 'traversedLazy__'.
+ifoldrBL :: (Int64 -> Word8 -> a -> a) -> a -> BL.ByteString -> a
+ifoldrBL f z xs = BL.foldr (\x g i -> i `seq` f i x (g (i + 1))) (const z) xs 0
+{-# INLINE ifoldrBL #-}
+
+----------------------------------------
+
+-- | Internal version of 'traversedLazy8'.
+traversedLazy8__
+  :: Traversing p
+  => Optic__ p j (Int64 -> j) BL.ByteString BL.ByteString Char Char
+traversedLazy8__ = iwander $ \f lbs ->
+  let go c fcs acc =
+        let !acc' = acc + fromIntegral (B.length c)
+            rest = reindex (\x -> acc + fromIntegral x) traversedStrictTree8
+        in BL.append . BL.fromStrict <$> itraverseOf rest f c <*> fcs acc'
+  in BL.foldrChunks go (\_ -> pure BL.empty) lbs 0
+{-# INLINE [1] traversedLazy8__ #-}
+
+{-# RULES
+
+"sets lazy char bytestring"
+  forall (o :: FunArrow j Char Char). traversedLazy8__ o
+                                    = roam BL8.map (FunArrow (runFunArrow o))
+    :: FunArrow (Int64 -> j) BL8.ByteString BL8.ByteString
+
+"isets lazy char bytestring"
+  forall (o :: IxFunArrow j Char Char). traversedLazy8__ o = iroam imapBL8 o
+    :: IxFunArrow (Int64 -> j) BL8.ByteString BL8.ByteString
+
+"gets lazy char bytestring"
+  forall (o :: Forget r j Char Char). traversedLazy8__ o
+                                    = foldring__ BL8.foldr (Forget (runForget o))
+    :: Forget r (Int64 -> j) BL8.ByteString BL8.ByteString
+
+"igets lazy char bytestring"
+  forall (o :: IxForget r j Char Char). traversedLazy8__ o = ifoldring__ ifoldrBL8 o
+    :: IxForget r (Int64 -> j) BL.ByteString BL.ByteString
+
+#-}
+
+-- | Indexed setter for 'traversedLazy8__'.
+imapBL8 :: (Int64 -> Char -> Char) -> BL8.ByteString -> BL8.ByteString
+imapBL8 f = snd . BL8.mapAccumL (\i a -> i `seq` (i + 1, f i a)) 0
+{-# INLINE imapBL8 #-}
+
+-- | Indexed fold for 'traversedLazy8__'.
+ifoldrBL8 :: (Int64 -> Char -> a -> a) -> a -> BL8.ByteString -> a
+ifoldrBL8 f z xs = BL8.foldr (\x g i -> i `seq` f i x (g (i + 1))) (const z) xs 0
+{-# INLINE ifoldrBL8 #-}
+
+------------------------------------------------------------------------------
+-- ByteString guts
+------------------------------------------------------------------------------
+
+-- | Conversion between 'Word8' and 'Char'. Should compile to a no-op.
+w2c :: Word8 -> Char
+w2c = unsafeChr . fromIntegral
+{-# INLINE w2c #-}
+
+-- | Unsafe conversion between 'Char' and 'Word8'. This is a no-op and silently
+-- truncates to 8 bits Chars > '\255'. It is provided as convenience for
+-- ByteString construction.
+c2w :: Char -> Word8
+c2w = fromIntegral . ord
+{-# INLINE c2w #-}
+
+-- | A way of creating ByteStrings outside the IO monad. The @Int@ argument
+-- gives the final size of the ByteString. Unlike 'createAndTrim' the ByteString
+-- is not reallocated if the final size is less than the estimated size.
+unsafeCreate :: Int -> (Ptr Word8 -> IO ()) -> B.ByteString
+unsafeCreate l f = unsafeDupablePerformIO (create l f)
+{-# INLINE unsafeCreate #-}
+
+-- | Create ByteString of size @l@ and use action @f@ to fill it's contents.
+create :: Int -> (Ptr Word8 -> IO ()) -> IO B.ByteString
+create l f = do
+    fp <- mallocPlainForeignPtrBytes l
+    withForeignPtr fp $ \p -> f p
+    return $! BI.PS fp 0 l
+{-# INLINE create #-}

--- a/optics-extra/src/Optics/Extra/Internal/ByteString.hs
+++ b/optics-extra/src/Optics/Extra/Internal/ByteString.hs
@@ -88,7 +88,7 @@ traversedStrictTree__ = iwander $ \f bs ->
 
 "bytes -> map"
   forall (o :: FunArrow j Word8 Word8). traversedStrictTree__ o
-                                      = roam B.map (FunArrow (runFunArrow o))
+                                      = roam B.map (reFunArrow o)
     :: FunArrow (Int -> j) B.ByteString B.ByteString
 
 "bytes -> imap"
@@ -97,7 +97,7 @@ traversedStrictTree__ = iwander $ \f bs ->
 
 "bytes -> foldr"
   forall (o :: Forget r j Word8 Word8). traversedStrictTree__ o
-                                      = foldring__ B.foldr (Forget (runForget o))
+                                      = foldring__ B.foldr (reForget o)
     :: Forget r (Int -> j) B.ByteString B.ByteString
 
 "bytes -> ifoldr"
@@ -143,7 +143,7 @@ traversedStrictTree8__ = iwander $ \f bs ->
 
 "chars -> map"
   forall (o :: FunArrow j Char Char). traversedStrictTree8__ o
-                                    = roam B8.map (FunArrow (runFunArrow o))
+                                    = roam B8.map (reFunArrow o)
     :: FunArrow (Int -> j) B8.ByteString B8.ByteString
 
 "chars -> imap"
@@ -152,7 +152,7 @@ traversedStrictTree8__ = iwander $ \f bs ->
 
 "chars -> foldr"
   forall (o :: Forget r j Char Char). traversedStrictTree8__ o
-                                    = foldring__ B8.foldr (Forget (runForget o))
+                                    = foldring__ B8.foldr (reForget o)
     :: Forget r (Int -> j) B8.ByteString B8.ByteString
 
 "chars -> ifoldr"
@@ -190,7 +190,7 @@ traversedLazy__ = iwander $ \f lbs ->
 
 "sets lazy bytestring"
   forall (o :: FunArrow j Word8 Word8). traversedLazy__ o
-                                      = roam BL.map (FunArrow (runFunArrow o))
+                                      = roam BL.map (reFunArrow o)
     :: FunArrow (Int64 -> j) BL.ByteString BL.ByteString
 
 "isets lazy bytestring"
@@ -199,7 +199,7 @@ traversedLazy__ = iwander $ \f lbs ->
 
 "gets lazy bytestring"
   forall (o :: Forget r j Word8 Word8). traversedLazy__ o
-                                      = foldring__ BL.foldr (Forget (runForget o))
+                                      = foldring__ BL.foldr (reForget o)
     :: Forget r (Int64 -> j) BL.ByteString BL.ByteString
 
 "igets lazy bytestring"
@@ -236,7 +236,7 @@ traversedLazy8__ = iwander $ \f lbs ->
 
 "sets lazy char bytestring"
   forall (o :: FunArrow j Char Char). traversedLazy8__ o
-                                    = roam BL8.map (FunArrow (runFunArrow o))
+                                    = roam BL8.map (reFunArrow o)
     :: FunArrow (Int64 -> j) BL8.ByteString BL8.ByteString
 
 "isets lazy char bytestring"
@@ -245,7 +245,7 @@ traversedLazy8__ = iwander $ \f lbs ->
 
 "gets lazy char bytestring"
   forall (o :: Forget r j Char Char). traversedLazy8__ o
-                                    = foldring__ BL8.foldr (Forget (runForget o))
+                                    = foldring__ BL8.foldr (reForget o)
     :: Forget r (Int64 -> j) BL8.ByteString BL8.ByteString
 
 "igets lazy char bytestring"

--- a/optics-extra/src/Optics/Extra/Internal/Vector.hs
+++ b/optics-extra/src/Optics/Extra/Internal/Vector.hs
@@ -1,4 +1,4 @@
-module Optics.Extra.Internal
+module Optics.Extra.Internal.Vector
   ( ordinalNub
   ) where
 

--- a/optics-extra/src/Optics/Indexed.hs
+++ b/optics-extra/src/Optics/Indexed.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Optics.Indexed
+  ( -- * Indexed optics
+    module Optics.IxTraversal
+  , module Optics.IxFold
+  , module Optics.IxSetter
+
+  -- * Index composition and modification
+  , (<%>)
+  , (%>)
+  , (<%)
+  , reindex
+  , icompose
+  , icompose3
+  , icompose4
+  , icompose5
+  , IxOptic(..)
+
+  -- * Functors with index
+  , FunctorWithIndex (..)
+  -- ** Foldable with index
+  , FoldableWithIndex (..)
+  , itraverse_
+  , ifor_
+  -- ** Traversable with index
+  , TraversableWithIndex (..)
+  , ifor
+  ) where
+
+import Control.Applicative.Backwards
+import Control.Monad.Trans.Identity
+import Control.Monad.Trans.Reader
+import Data.Functor.Reverse
+import Data.Monoid hiding (Product, Sum)
+import qualified Data.HashMap.Lazy as HM
+import qualified Data.Vector as V
+
+import Optics.Indexed.Core
+import Optics.Internal.Indexed
+import Optics.Internal.Utils
+import Optics.IxFold
+import Optics.IxSetter
+import Optics.IxTraversal
+
+----------------------------------------
+-- Extra *WithIndex instances
+
+-- Backwards
+
+instance FunctorWithIndex i f => FunctorWithIndex i (Backwards f) where
+  imap f  = Backwards . imap f . forwards
+  {-# INLINE imap #-}
+
+instance FoldableWithIndex i f => FoldableWithIndex i (Backwards f) where
+  ifoldMap f = ifoldMap f . forwards
+  {-# INLINE ifoldMap #-}
+
+instance TraversableWithIndex i f => TraversableWithIndex i (Backwards f) where
+  itraverse f = fmap Backwards . itraverse f . forwards
+  {-# INLINE itraverse #-}
+
+-- Reverse
+
+instance FunctorWithIndex i f => FunctorWithIndex i (Reverse f) where
+  imap f = Reverse . imap f . getReverse
+  {-# INLINE imap #-}
+
+instance FoldableWithIndex i f => FoldableWithIndex i (Reverse f) where
+  ifoldMap f = getDual . ifoldMap (\i -> Dual #. f i) . getReverse
+  {-# INLINE ifoldMap #-}
+
+instance TraversableWithIndex i f => TraversableWithIndex i (Reverse f) where
+  itraverse f =
+    fmap Reverse . forwards . itraverse (\i -> Backwards . f i) . getReverse
+  {-# INLINE itraverse #-}
+
+-- HashMap
+
+instance FunctorWithIndex k (HM.HashMap k) where
+  imap = HM.mapWithKey
+instance FoldableWithIndex k (HM.HashMap k) where
+  ifoldr  = HM.foldrWithKey
+  ifoldl' = HM.foldlWithKey' . flip
+  {-# INLINE ifoldr #-}
+  {-# INLINE ifoldl' #-}
+instance TraversableWithIndex k (HM.HashMap k) where
+  itraverse = HM.traverseWithKey
+  {-# INLINE itraverse #-}
+
+-- Vector
+
+instance FunctorWithIndex Int V.Vector where
+  imap = V.imap
+  {-# INLINE imap #-}
+instance FoldableWithIndex Int V.Vector where
+  ifoldr  = V.ifoldr
+  ifoldl' = V.ifoldl' . flip
+  {-# INLINE ifoldr #-}
+  {-# INLINE ifoldl' #-}
+instance TraversableWithIndex Int V.Vector where
+  itraverse f v =
+    let !n = V.length v in V.fromListN n <$> itraverse f (V.toList v)
+  {-# INLINE itraverse #-}
+
+-- IdentityT
+
+instance FunctorWithIndex i m => FunctorWithIndex i (IdentityT m) where
+  imap f (IdentityT m) = IdentityT $ imap f m
+  {-# INLINE imap #-}
+
+instance FoldableWithIndex i m => FoldableWithIndex i (IdentityT m) where
+  ifoldMap f (IdentityT m) = ifoldMap f m
+  {-# INLINE ifoldMap #-}
+
+instance TraversableWithIndex i m => TraversableWithIndex i (IdentityT m) where
+  itraverse f (IdentityT m) = IdentityT <$> itraverse f m
+  {-# INLINE itraverse #-}
+
+-- ReaderT
+
+instance FunctorWithIndex i m => FunctorWithIndex (e, i) (ReaderT e m) where
+  imap f (ReaderT m) = ReaderT $ \k -> imap (f . (,) k) (m k)
+  {-# INLINE imap #-}

--- a/optics-extra/src/Optics/Indexed.hs
+++ b/optics-extra/src/Optics/Indexed.hs
@@ -94,8 +94,10 @@ instance FunctorWithIndex Int V.Vector where
   imap = V.imap
   {-# INLINE imap #-}
 instance FoldableWithIndex Int V.Vector where
-  ifoldr  = V.ifoldr
-  ifoldl' = V.ifoldl' . flip
+  ifoldMap f = ifoldr (\i -> mappend . f i) mempty
+  ifoldr     = V.ifoldr
+  ifoldl'    = V.ifoldl' . flip
+  {-# INLINE ifoldMap #-}
   {-# INLINE ifoldr #-}
   {-# INLINE ifoldl' #-}
 instance TraversableWithIndex Int V.Vector where

--- a/optics-extra/src/Optics/Operators/State.hs
+++ b/optics-extra/src/Optics/Operators/State.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
 module Optics.Operators.State (
     -- * State modifying optics
     (.=), (?=), (%=),

--- a/optics-th/optics-th.cabal
+++ b/optics-th/optics-th.cabal
@@ -4,7 +4,7 @@ license:       BSD3
 license-file:  LICENSE
 build-type:    Simple
 maintainer:    oleg@well-typed.com
-author:        Andrzej Rybczak
+author:        Michael Sloan, Eric Mertens, Edward Kmett, Andrzej Rybczak
 cabal-version: >=1.10
 tested-with:   ghc ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.3
 synopsis:      Optics for generics-sop, and using generics-sop

--- a/optics-th/src/Language/Haskell/TH/Optics.hs
+++ b/optics-th/src/Language/Haskell/TH/Optics.hs
@@ -1,16 +1,5 @@
 {-# LANGUAGE CPP              #-}
 {-# LANGUAGE LambdaCase       #-}
------------------------------------------------------------------------------
--- |
--- Module      :  Language.Haskell.TH.Optics
--- Copyright   :  (C) 2012-2016 Edward Kmett
--- License     :  BSD-style (see the file LICENSE)
--- Maintainer  :  Edward Kmett <ekmett@gmail.com>
--- Stability   :  experimental
--- Portability :  TemplateHaskell
---
--- Lenses, Prisms, and Traversals for working with Template Haskell
-----------------------------------------------------------------------------
 module Language.Haskell.TH.Optics
   (
   -- * Traversals

--- a/optics-th/src/Optics/TH.hs
+++ b/optics-th/src/Optics/TH.hs
@@ -1,13 +1,3 @@
------------------------------------------------------------------------------
--- |
--- Module      :  Control.Lens.TH
--- Copyright   :  (C) 2012-16 Edward Kmett, 2012-13 Michael Sloan
--- License     :  BSD-style (see the file LICENSE)
--- Maintainer  :  Edward Kmett <ekmett@gmail.com>
--- Stability   :  experimental
--- Portability :  non-portable
---
------------------------------------------------------------------------------
 module Optics.TH
   (
   -- * Constructing Lenses Automatically

--- a/optics-th/src/Optics/TH/Internal/Product.hs
+++ b/optics-th/src/Optics/TH/Internal/Product.hs
@@ -4,17 +4,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TemplateHaskell #-}
------------------------------------------------------------------------------
--- |
--- Module      :  Optics.TH.Internal.Product
--- Copyright   :  (C) 2014-2016 Edward Kmett, (C) 2014 Eric Mertens
--- License     :  BSD-style (see the file LICENSE)
--- Maintainer  :  Edward Kmett <ekmett@gmail.com>
--- Stability   :  experimental
--- Portability :  non-portable
---
------------------------------------------------------------------------------
-
 module Optics.TH.Internal.Product
   ( LensRules(..)
   , FieldNamer

--- a/optics-th/src/Optics/TH/Internal/Sum.hs
+++ b/optics-th/src/Optics/TH/Internal/Sum.hs
@@ -1,15 +1,4 @@
 {-# LANGUAGE TemplateHaskell #-}
------------------------------------------------------------------------------
--- |
--- Module      :  Optics.TH.Internal.Sum
--- Copyright   :  (C) 2014-2016 Edward Kmett and Eric Mertens
--- License     :  BSD-style (see the file LICENSE)
--- Maintainer  :  Edward Kmett <ekmett@gmail.com>
--- Stability   :  experimental
--- Portability :  non-portable
---
------------------------------------------------------------------------------
-
 module Optics.TH.Internal.Sum
   ( makePrisms
   , makeClassyPrisms

--- a/optics-th/src/Optics/TH/Internal/Utils.hs
+++ b/optics-th/src/Optics/TH/Internal/Utils.hs
@@ -1,15 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
------------------------------------------------------------------------------
--- |
--- Module      :  Optics.TH.Internal.Utils
--- Copyright   :  (C) 2013-2016 Edward Kmett and Eric Mertens
--- License     :  BSD-style (see the file LICENSE)
--- Maintainer  :  Edward Kmett <ekmett@gmail.com>
--- Stability   :  experimental
--- Portability :  non-portable
---
-----------------------------------------------------------------------------
 module Optics.TH.Internal.Utils where
 
 import Language.Haskell.TH

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -25,69 +25,60 @@ library
   default-language:   Haskell2010
   hs-source-dirs:     src
   ghc-options:        -Wall
-  build-depends:
-      array           >=0.5.1.1 && <0.6
-    , base            >=4.9     && <5
-    , containers      >=0.5.7.1 && <0.7
-    , generic-optics  >=0.1     && <1
-    , mtl             >=2.2.2   && <2.3
-    , optics-core     >=0.1     && <1
-    , optics-sop      >=0.1     && <1
-    , optics-th       >=0.1     && <1
-    , transformers    >=0.5     && <0.6
+  build-depends: array           >=0.5.1.1 && <0.6
+               , base            >=4.9     && <5
+               , containers      >=0.5.7.1 && <0.7
+               , generic-optics  >=0.1     && <1
+               , mtl             >=2.2.2   && <2.3
+               , optics-core     >=0.1     && <1
+               , optics-extra    >=0.1     && <1
+               , optics-sop      >=0.1     && <1
+               , optics-th       >=0.1     && <1
+               , transformers    >=0.5     && <0.6
 
   -- main module to land with repl
   exposed-modules:    Optics
 
-  -- type classes
-  exposed-modules:
-    Optics.Each
-
-  -- operators
-  exposed-modules:    Optics.Operators.State
-
-  -- data
-  exposed-modules:
-    Data.Set.Optics
-    GHC.Generics.Optics
-
   -- optics-core optics
-  reexported-modules:
-    Optics.AffineFold
-    , Optics.AffineTraversal
-    , Optics.Equality
-    , Optics.Fold
-    , Optics.Getter
-    , Optics.Iso
-    , Optics.IxFold
-    , Optics.IxSetter
-    , Optics.IxTraversal
-    , Optics.Lens
-    , Optics.LensyReview
-    , Optics.Optic
-    , Optics.Prism
-    , Optics.PrismaticGetter
-    , Optics.Re
-    , Optics.Review
-    , Optics.Setter
-    , Optics.Traversal
+  reexported-modules: Optics.AffineFold
+                    , Optics.AffineTraversal
+                    , Optics.Equality
+                    , Optics.Fold
+                    , Optics.Getter
+                    , Optics.Iso
+                    , Optics.IxFold
+                    , Optics.IxSetter
+                    , Optics.IxTraversal
+                    , Optics.Lens
+                    , Optics.LensyReview
+                    , Optics.Optic
+                    , Optics.Prism
+                    , Optics.PrismaticGetter
+                    , Optics.Re
+                    , Optics.Review
+                    , Optics.Setter
+                    , Optics.Traversal
 
   -- optics-core goodies
-  reexported-modules:
-      Data.Either.Optics
-    , Data.Maybe.Optics
-    , Data.Tuple.Optics
-    , Optics.Indexed
-    , Optics.Arrow
-    , Optics.Operators
-    , Optics.Passthrough
-    , Optics.View
+  reexported-modules: Data.Either.Optics
+                    , Data.Maybe.Optics
+                    , Data.Tuple.Optics
+                    , Optics.Indexed
+                    , Optics.Arrow
+                    , Optics.Operators
+                    , Optics.Passthrough
+                    , Optics.View
+
+  -- optics-extra
+  reexported-modules: Optics.Each
+                    , Optics.Operators.State
+                    , Data.Set.Optics
+                    , GHC.Generics.Optics
 
   -- optics-sop
-  reexported-modules:
-    Generics.SOP.Optics
-    , Optics.SOP.ToTuple
-    , Optics.SOP
+  reexported-modules: Generics.SOP.Optics
+                    , Optics.SOP.ToTuple
+                    , Optics.SOP
 
   -- optics-th
   reexported-modules: Language.Haskell.TH.Optics

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -4,7 +4,7 @@ license:         BSD3
 license-file:    LICENSE
 build-type:      Simple
 maintainer:      oleg@well-typed.com
-author:          Adam Gundry, Andres Löh, Andrzej Rybczak
+author:          Edward Kmett, Adam Gundry, Andres Löh, Andrzej Rybczak
 cabal-version:   1.24
 tested-with:     ghc ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.3
 synopsis:        Optics for generics-sop, and using generics-sop

--- a/optics/src/Data/Set/Optics.hs
+++ b/optics/src/Data/Set/Optics.hs
@@ -1,14 +1,4 @@
 {-# LANGUAGE FlexibleContexts #-}
------------------------------------------------------------------------------
--- |
--- Module      :  Data.Set.Optics
--- Copyright   :  (C) 2012-16 Edward Kmett
--- License     :  BSD-style (see the file LICENSE)
--- Maintainer  :  Edward Kmett <ekmett@gmail.com>
--- Stability   :  provisional
--- Portability :  portable
---
-----------------------------------------------------------------------------
 module Data.Set.Optics
   ( setmapped
   , setOf

--- a/optics/src/GHC/Generics/Optics.hs
+++ b/optics/src/GHC/Generics/Optics.hs
@@ -4,22 +4,19 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PolyKinds #-}
------------------------------------------------------------------------------
--- |
--- Module      :  GHC.Generics.Lens
--- Copyright   :  (C) 2012-16 Edward Kmett, (C) 2018 Well-Typed LLP
+-- | Note: "GHC.Generics" exports a number of names that collide with "Optics"
+-- (at least 'to').
 --
--- Note: "GHC.Generics" exports a number of names that collide with "Optics" (at least 'to').
---
--- You can use hiding or imports to mitigate this to an extent, and the following imports,
--- represent a fair compromise for user code:
+-- You can use hiding or imports to mitigate this to an extent, and the
+-- following imports, represent a fair compromise for user code:
 --
 -- @
 -- import "Optics"
 -- import "GHC.Generics" hiding (to)
 -- @
 --
--- You can use 'generic' to replace 'GHC.Generics.from' and 'GHC.Generics.to' from "GHC.Generics".
+-- You can use 'generic' to replace 'GHC.Generics.from' and 'GHC.Generics.to'
+-- from "GHC.Generics".
 --
 module GHC.Generics.Optics
   (

--- a/optics/src/Optics/Each.hs
+++ b/optics/src/Optics/Each.hs
@@ -3,16 +3,6 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs                  #-}
 {-# LANGUAGE UndecidableInstances   #-}
------------------------------------------------------------------------------
--- |
--- Module      :  Optics.Each
--- Copyright   :  (C) 2012-16 Edward Kmett
--- License     :  BSD-style (see the file LICENSE)
--- Maintainer  :  Edward Kmett <ekmett@gmail.com>
--- Stability   :  experimental
--- Portability :  non-portable
---
------------------------------------------------------------------------------
 module Optics.Each
   (
   -- * Each

--- a/optics/tests/Optics/Tests.hs
+++ b/optics/tests/Optics/Tests.hs
@@ -188,14 +188,14 @@ compL02 f g s b = set (lens f g) b s
 compR02 _ g s b = g s b
 
 compL03, compR03, compR03_ :: (s -> Either t a) -> (s -> b -> t) -> (s -> b -> t)
-compL03 f g s b = withAffineTraversal (atraversal f g) (\h _ -> h) s b
+compL03 f g s b = withAffineTraversal (atraversal f g) (\_ g' -> g') s b
 compR03 _ g s b = g s b
 compR03_ f g s b = case f s of
     Left t  -> t
     Right _ -> g s b
 
 compL04, compR04 :: (s -> Either t a) -> (s -> b -> t) -> (s -> Either t a)
-compL04 f g s = withAffineTraversal (atraversal f g) (\_ h -> h) s
+compL04 f g s = withAffineTraversal (atraversal f g) (\f' _ -> f') s
 compR04 f _ s = f s
 
 compL05, compR05 :: ((a -> b) -> s -> t) -> ((a -> b) -> s -> t)

--- a/optics/tests/Optics/Tests.hs
+++ b/optics/tests/Optics/Tests.hs
@@ -68,8 +68,8 @@ rhs03 = traverseOf (itraversed % itraversed)
 lhs04, rhs04
   :: (Applicative f, FoldableWithIndex i t, FoldableWithIndex j s)
   => (a -> f r) -> t (s a) -> f ()
-lhs04 = traverseOf_ (folded % folded)
-rhs04 = traverseOf_ (ifolded % ifolded)
+lhs04 f = traverseOf_ (folded % folded) f
+rhs04 f = traverseOf_ (ifolded % ifolded) f
 
 lhs05, lhs05b, rhs05
   :: (FunctorWithIndex i f, FunctorWithIndex j g) => (a -> b) -> f (g a) -> f (g b)
@@ -82,8 +82,8 @@ lhs06, rhs06
   => (a -> f r)
   -> (Either (t (f a, c)) b)
   -> f ()
-lhs06 = traverseOf_ (_Left % ifolded % _1 % ifolded)
-rhs06 = traverseOf_ (_Left % folded % _1 % folded)
+lhs06 f = traverseOf_ (_Left % ifolded % _1 % ifolded) f
+rhs06 f = traverseOf_ (_Left % folded % _1 % folded) f
 
 lhs07, rhs07
   :: (Applicative f, TraversableWithIndex i t, TraversableWithIndex j s)
@@ -98,8 +98,8 @@ lhs08, rhs08
   => (j -> a -> f ())
   -> t (s a)
   -> f ()
-lhs08 f = itraverseOf_ (ifolded %> ifolded) f
-rhs08 f = itraverseOf_ (folded % ifolded) f
+lhs08 f s = itraverseOf_ (ifolded %> ifolded) f s
+rhs08 f s = itraverseOf_ (folded % ifolded) f s
 
 lhs09, rhs09
   :: (FunctorWithIndex i t, FunctorWithIndex j s)


### PR DESCRIPTION
Fixes #64, fixes #81, fixes #47.

optics-core now only depends on `base`, `array` and `containers`. I left `*WithIndex` in optics-core since documentation uses `itraversed` etc. in examples and the majority of instances can be there anyway.
