### PR TITLE
Add VL affine traversal and Port Optics.At from lens

### DIFF
--- a/optics-core/src/Optics/AffineTraversal.hs
+++ b/optics-core/src/Optics/AffineTraversal.hs
@@ -26,6 +26,11 @@ type AffineTraversal s t a b = Optic An_AffineTraversal NoIx s t a b
 type AffineTraversal' s a = Optic' An_AffineTraversal NoIx s a
 
 -- | Type synonym for a type-modifying van Laarhoven affine traversal.
+--
+-- Note: this isn't exactly van Laarhoven representation as there is no
+-- @PointedFunctor@ class, but you can interpret the first argument as a
+-- dictionary of 'Pointed' class that supplies the @point@ function.
+--
 type AffineTraversalVL s t a b =
   forall f. Functor f => (forall r. r -> f r) -> (a -> f b) -> s -> f t
 
@@ -72,6 +77,5 @@ toAtraversalVL
   :: Is k An_AffineTraversal
   => Optic k is s t a b
   -> AffineTraversalVL s t a b
-toAtraversalVL o point =
-  runStarA . getOptic (toAffineTraversal o) . StarA point
+toAtraversalVL o point = runStarA . getOptic (toAffineTraversal o) . StarA point
 {-# INLINE toAtraversalVL #-}

--- a/optics-core/src/Optics/AffineTraversal.hs
+++ b/optics-core/src/Optics/AffineTraversal.hs
@@ -6,6 +6,10 @@ module Optics.AffineTraversal
   , atraversal
   , atraversal'
   , withAffineTraversal
+  , AffineTraversalVL
+  , AffineTraversalVL'
+  , atraversalVL
+  , toAtraversalVL
   , module Optics.Optic
   )
   where
@@ -21,6 +25,13 @@ type AffineTraversal s t a b = Optic An_AffineTraversal NoIx s t a b
 -- | Type synonym for a type-preserving affine traversal.
 type AffineTraversal' s a = Optic' An_AffineTraversal NoIx s a
 
+-- | Type synonym for a type-modifying van Laarhoven affine traversal.
+type AffineTraversalVL s t a b =
+  forall f. Functor f => (forall r. r -> f r) -> (a -> f b) -> s -> f t
+
+-- | Type synonym for a type-preserving van Laarhoven affine traversal.
+type AffineTraversalVL' s a = AffineTraversalVL s s a a
+
 -- | Explicitly cast an optic to an affine traversal.
 toAffineTraversal
   :: Is k An_AffineTraversal
@@ -32,10 +43,7 @@ toAffineTraversal = castOptic
 -- | Build an affine traversal from a matcher and an updater.
 atraversal :: (s -> Either t a) -> (s -> b -> t) -> AffineTraversal s t a b
 atraversal match update = Optic $
-  dimap (\s -> (match s, update s))
-        (\(etb, f) -> either id f etb)
-  . first'
-  . right'
+  visit $ \point f s -> either point (\a -> update s <$> f a) (match s)
 {-# INLINE atraversal #-}
 
 -- | Build a type-preserving affine traversal from a matcher and an updater.
@@ -52,3 +60,18 @@ withAffineTraversal
 withAffineTraversal o k =
   case getOptic (toAffineTraversal o) (AffineMarket (\_ b -> b) Right) of
     AffineMarket update match -> k match update
+{-# INLINE withAffineTraversal #-}
+
+-- | Build an affine traversal from the van Laarhoven representation.
+atraversalVL :: AffineTraversalVL s t a b -> AffineTraversal s t a b
+atraversalVL f = Optic (visit f)
+{-# INLINE atraversalVL #-}
+
+-- | Convert an affine traversal to its van Laarhoven representation.
+toAtraversalVL
+  :: Is k An_AffineTraversal
+  => Optic k is s t a b
+  -> AffineTraversalVL s t a b
+toAtraversalVL o point =
+  runStarA . getOptic (toAffineTraversal o) . StarA point
+{-# INLINE toAtraversalVL #-}

--- a/optics-core/src/Optics/Arrow.hs
+++ b/optics-core/src/Optics/Arrow.hs
@@ -59,6 +59,8 @@ instance ArrowChoice p => Choice (WrappedArrow p) where
   {-# INLINE left' #-}
   {-# INLINE right' #-}
 
+instance ArrowChoice p => Visiting (WrappedArrow p)
+
 class Arrow arr => ArrowOptic k arr where
   -- | Turn an optic into an arrow transformer.
   overA :: Optic k is s t a b -> arr a b -> arr s t

--- a/optics-core/src/Optics/Internal/Concrete.hs
+++ b/optics-core/src/Optics/Internal/Concrete.hs
@@ -1,6 +1,12 @@
-module Optics.Internal.Concrete where
+module Optics.Internal.Concrete
+  ( Exchange(..)
+  , Store(..)
+  , Market(..)
+  , AffineMarket(..)
+  ) where
 
 import Data.Bifunctor
+import Data.Functor.Identity
 
 import Optics.Internal.Profunctor
 
@@ -102,3 +108,9 @@ instance Strong (AffineMarket a b) where
     (\(c, a) -> bimap (c,) id (seta a))
   {-# INLINE first' #-}
   {-# INLINE second' #-}
+
+instance Visiting (AffineMarket a b) where
+  visit f (AffineMarket abt seta) = AffineMarket
+    (\s b -> runIdentity $ f Identity (\a -> Identity $ abt a b) s)
+    (\s -> either Right Left $ f Right (either Right Left . seta) s)
+  {-# INLINE visit #-}

--- a/optics-core/src/Optics/Internal/Optic/Types.hs
+++ b/optics-core/src/Optics/Internal/Optic/Types.hs
@@ -44,10 +44,10 @@ type family Constraints (k :: *) (p :: * -> * -> * -> *) :: Constraint where
   Constraints A_LensyReview      p = Costrong p
   Constraints A_Prism            p = Choice p
   Constraints A_PrismaticGetter  p = Cochoice p
-  Constraints An_AffineTraversal p = (Strong p, Choice p)
+  Constraints An_AffineTraversal p = Visiting p
   Constraints A_Traversal        p = Traversing p
   Constraints A_Setter           p = Mapping p
   Constraints A_Getter           p = (Bicontravariant p, Cochoice p, Strong p)
-  Constraints An_AffineFold      p = (Bicontravariant p, Cochoice p, Strong p, Choice p)
+  Constraints An_AffineFold      p = (Bicontravariant p, Cochoice p, Visiting p)
   Constraints A_Fold             p = (Bicontravariant p, Cochoice p, Traversing p)
   Constraints A_Review           p = (Bifunctor p, Choice p, Costrong p)

--- a/optics-core/src/Optics/Prism.hs
+++ b/optics-core/src/Optics/Prism.hs
@@ -11,10 +11,13 @@ module Optics.Prism
   , below
   , isn't
   , matching
+  , only
+  , nearly
   , module Optics.Optic
   )
   where
 
+import Control.Monad
 import Data.Bifunctor
 
 import Optics.Internal.Concrete
@@ -107,3 +110,38 @@ isn't k s =
 matching :: Is k A_Prism => Optic k is s t a b -> s -> Either t a
 matching o = withPrism o $ \_ match -> match
 {-# INLINE matching #-}
+
+-- | This 'Prism' compares for exact equality with a given value.
+--
+-- >>> only 4 # ()
+-- 4
+--
+-- >>> 5 ^? only 4
+-- Nothing
+only :: Eq a => a -> Prism' a ()
+only a = prism' (\() -> a) $ guard . (a ==)
+{-# INLINE only #-}
+
+-- | This 'Prism' compares for approximate equality with a given value and a
+-- predicate for testing, an example where the value is the empty list and the
+-- predicate checks that a list is empty (same as 'Optics.Empty._Empty' with the
+-- 'Optics.Empty.AsEmpty' list instance):
+--
+-- >>> nearly [] null # ()
+-- []
+-- >>> [1,2,3,4] ^? nearly [] null
+-- Nothing
+--
+-- @'nearly' [] 'Prelude.null' :: 'Prism'' [a] ()@
+--
+-- To comply with the 'Prism' laws the arguments you supply to @nearly a p@ are
+-- somewhat constrained.
+--
+-- We assume @p x@ holds iff @x ≡ a@. Under that assumption then this is a valid
+-- 'Prism'.
+--
+-- This is useful when working with a type where you can test equality for only
+-- a subset of its values, and the prism selects such a value.
+nearly :: a -> (a -> Bool) -> Prism' a ()
+nearly a p = prism' (\() -> a) $ guard . p
+{-# INLINE nearly #-}

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -21,6 +21,7 @@ library
                , base                   >= 4.9       && <5
                , bytestring             >= 0.10.8    && <0.11
                , containers             >= 0.5.7.1   && <0.7
+               , hashable               >= 1.1.1     && <1.3
                , mtl                    >= 2.2.2     && <2.3
                , text                   >= 1.2       && <1.3
                , transformers           >= 0.5       && <0.6
@@ -45,6 +46,7 @@ library
                    Data.Vector.Generic.Optics
                    Data.Vector.Optics
                    GHC.Generics.Optics
+                   Optics.At
                    Optics.Each
                    Optics.Indexed
                    Optics.Operators.State

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -47,6 +47,7 @@ library
                    Data.Vector.Optics
                    GHC.Generics.Optics
                    Optics.At
+                   Optics.Cons
                    Optics.Each
                    Optics.Indexed
                    Optics.Operators.State

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -50,6 +50,7 @@ library
                    Optics.Cons
                    Optics.Each
                    Optics.Indexed
+                   Optics.Empty
                    Optics.Operators.State
 
   default-extensions:

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -33,10 +33,14 @@ library
   -- main module to land with repl
   exposed-modules: Optics.Extra
 
+  exposed-modules: Optics.At
+                   Optics.Cons
+                   Optics.Each
+                   Optics.Empty
+                   Optics.Indexed
+                   Optics.Operators.State
 
-  exposed-modules: Optics.Extra.Internal.ByteString
-                   Optics.Extra.Internal.Vector
-                   Data.ByteString.Lazy.Optics
+  exposed-modules: Data.ByteString.Lazy.Optics
                    Data.ByteString.Optics
                    Data.ByteString.Strict.Optics
                    Data.Set.Optics
@@ -46,12 +50,10 @@ library
                    Data.Vector.Generic.Optics
                    Data.Vector.Optics
                    GHC.Generics.Optics
-                   Optics.At
-                   Optics.Cons
-                   Optics.Each
-                   Optics.Indexed
-                   Optics.Empty
-                   Optics.Operators.State
+
+  -- internal modules
+  exposed-modules: Optics.Extra.Internal.ByteString
+                   Optics.Extra.Internal.Vector
 
   default-extensions:
     BangPatterns

--- a/optics-extra/src/Optics/At.hs
+++ b/optics-extra/src/Optics/At.hs
@@ -1,0 +1,556 @@
+{-# LANGUAGE CPP #-}
+module Optics.At
+  (
+  -- * At
+    At(..)
+  , sans
+  -- * Ixed
+  , Index
+  , IxValue
+  , Ixed(ix)
+  , ixAt
+  -- * Contains
+  , Contains(..)
+  ) where
+
+import Data.Array.IArray as Array
+import Data.Array.Unboxed
+import Data.ByteString as StrictB
+import Data.ByteString.Lazy as LazyB
+import Data.Complex
+import Data.Functor.Identity
+import Data.HashMap.Lazy as HashMap
+import Data.HashSet as HashSet
+import Data.Hashable
+import Data.Int
+import Data.IntMap as IntMap
+import Data.IntSet as IntSet
+import Data.List.NonEmpty as NonEmpty
+import Data.Map as Map
+import Data.Sequence as Seq
+import Data.Set as Set
+import Data.Text as StrictT
+import Data.Text.Lazy as LazyT
+import Data.Tree
+import Data.Vector as Vector hiding (indexed)
+import Data.Vector.Primitive as Prim
+import Data.Vector.Storable as Storable
+import Data.Vector.Unboxed as Unboxed hiding (indexed)
+import Data.Word
+
+import Optics.Core
+import Optics.Operators ((<&>))
+
+type family Index (s :: *) :: *
+type instance Index (e -> a) = e
+type instance Index IntSet = Int
+type instance Index (Set a) = a
+type instance Index (HashSet a) = a
+type instance Index [a] = Int
+type instance Index (NonEmpty a) = Int
+type instance Index (Seq a) = Int
+type instance Index (a,b) = Int
+type instance Index (a,b,c) = Int
+type instance Index (a,b,c,d) = Int
+type instance Index (a,b,c,d,e) = Int
+type instance Index (a,b,c,d,e,f) = Int
+type instance Index (a,b,c,d,e,f,g) = Int
+type instance Index (a,b,c,d,e,f,g,h) = Int
+type instance Index (a,b,c,d,e,f,g,h,i) = Int
+type instance Index (IntMap a) = Int
+type instance Index (Map k a) = k
+type instance Index (HashMap k a) = k
+type instance Index (Array.Array i e) = i
+type instance Index (UArray i e) = i
+type instance Index (Vector.Vector a) = Int
+type instance Index (Prim.Vector a) = Int
+type instance Index (Storable.Vector a) = Int
+type instance Index (Unboxed.Vector a) = Int
+type instance Index (Complex a) = Int
+type instance Index (Identity a) = ()
+type instance Index (Maybe a) = ()
+type instance Index (Tree a) = [Int]
+type instance Index StrictT.Text = Int
+type instance Index LazyT.Text = Int64
+type instance Index StrictB.ByteString = Int
+type instance Index LazyB.ByteString = Int64
+
+-- $setup
+-- >>> :set -XNoOverloadedStrings
+-- >>> import Control.Lens
+-- >>> import Debug.SimpleReflect.Expr
+-- >>> import Debug.SimpleReflect.Vars as Vars hiding (f,g)
+-- >>> let f  :: Expr -> Expr; f = Debug.SimpleReflect.Vars.f
+-- >>> let g  :: Expr -> Expr; g = Debug.SimpleReflect.Vars.g
+-- >>> let f' :: Int -> Expr -> Expr; f' = Debug.SimpleReflect.Vars.f'
+-- >>> let h  :: Int -> Expr; h = Debug.SimpleReflect.Vars.h
+
+-- | This class provides a simple 'Lens' that lets you view (and modify)
+-- information about whether or not a container contains a given 'Index'.
+class Contains m where
+  -- |
+  -- >>> IntSet.fromList [1,2,3,4] ^. contains 3
+  -- True
+  --
+  -- >>> IntSet.fromList [1,2,3,4] ^. contains 5
+  -- False
+  --
+  -- >>> IntSet.fromList [1,2,3,4] & contains 3 .~ False
+  -- fromList [1,2,4]
+  contains :: Index m -> Lens' m Bool
+
+instance Contains IntSet where
+  contains k = lensVL $ \f s -> f (IntSet.member k s) <&> \b ->
+    if b then IntSet.insert k s else IntSet.delete k s
+  {-# INLINE contains #-}
+
+instance Ord a => Contains (Set a) where
+  contains k = lensVL $ \f s -> f (Set.member k s) <&> \b ->
+    if b then Set.insert k s else Set.delete k s
+  {-# INLINE contains #-}
+
+instance (Eq a, Hashable a) => Contains (HashSet a) where
+  contains k = lensVL $ \f s -> f (HashSet.member k s) <&> \b ->
+    if b then HashSet.insert k s else HashSet.delete k s
+  {-# INLINE contains #-}
+
+-- | This provides a common notion of a value at an index that is shared by both
+-- 'Ixed' and 'At'.
+type family IxValue (m :: *) :: *
+
+-- | Provides a simple 'AffineTraversal' lets you traverse the value at a given
+-- key in a 'Map' or element at an ordinal position in a list or 'Seq'.
+class Ixed m where
+  -- | /NB:/ Setting the value of this 'AffineTraversal' will only set the value
+  -- in 'at' if it is already present.
+  --
+  -- If you want to be able to insert /missing/ values, you want 'at'.
+  --
+  -- >>> Seq.fromList [a,b,c,d] & ix 2 %~ f
+  -- fromList [a,b,f c,d]
+  --
+  -- >>> Seq.fromList [a,b,c,d] & ix 2 .~ e
+  -- fromList [a,b,e,d]
+  --
+  -- >>> Seq.fromList [a,b,c,d] ^? ix 2
+  -- Just c
+  --
+  -- >>> Seq.fromList [] ^? ix 2
+  -- Nothing
+  ix :: Index m -> AffineTraversal' m (IxValue m)
+  default ix :: At m => Index m -> AffineTraversal' m (IxValue m)
+  ix = ixAt
+  {-# INLINE ix #-}
+
+-- | A definition of 'ix' for types with an 'At' instance. This is the default
+-- if you don't specify a definition for 'ix'.
+ixAt :: At m => Index m -> AffineTraversal' m (IxValue m)
+ixAt i = at i % _Just
+{-# INLINE ixAt #-}
+
+type instance IxValue (e -> a) = a
+instance Eq e => Ixed (e -> a) where
+  ix e = atraversalVL $ \_ p f -> p (f e) <&> \a e' -> if e == e' then a else f e'
+  {-# INLINE ix #-}
+
+type instance IxValue (Maybe a) = a
+instance Ixed (Maybe a) where
+  ix () = toAffineTraversal _Just
+  {-# INLINE ix #-}
+
+type instance IxValue [a] = a
+instance Ixed [a] where
+  ix k = atraversalVL (ixListVL k)
+  {-# INLINE ix #-}
+
+type instance IxValue (NonEmpty a) = a
+instance Ixed (NonEmpty a) where
+  ix k = atraversalVL $ \point f xs0 ->
+    if k < 0
+    then point xs0
+    else let go (a:|as) 0 = f a <&> (:|as)
+             go (a:|as) i = (a:|) <$> ixListVL (i - 1) point f as
+         in go xs0 k
+  {-# INLINE ix #-}
+
+type instance IxValue (Identity a) = a
+instance Ixed (Identity a) where
+  ix () = atraversalVL $ \_ f (Identity a) -> Identity <$> f a
+  {-# INLINE ix #-}
+
+type instance IxValue (Tree a) = a
+instance Ixed (Tree a) where
+  ix xs0 = atraversalVL $ \point f ->
+    let go [] (Node a as) = f a <&> \a' -> Node a' as
+        go (i:is) t@(Node a as)
+          | i < 0     = point t
+          | otherwise = Node a <$> ixListVL i point (go is) as
+    in go xs0
+  {-# INLINE ix #-}
+
+type instance IxValue (Seq a) = a
+instance Ixed (Seq a) where
+  ix i = atraversalVL $ \point f m ->
+    if 0 <= i && i < Seq.length m
+    then f (Seq.index m i) <&> \a -> Seq.update i a m
+    else point m
+  {-# INLINE ix #-}
+
+type instance IxValue (IntMap a) = a
+instance Ixed (IntMap a) where
+  ix k = atraversalVL $ \point f m ->
+    case IntMap.lookup k m of
+      Just v -> f v <&> \v' -> IntMap.insert k v' m
+      Nothing -> point m
+  {-# INLINE ix #-}
+
+type instance IxValue (Map k a) = a
+instance Ord k => Ixed (Map k a) where
+  ix k = atraversalVL $ \point f m ->
+    case Map.lookup k m of
+      Just v  -> f v <&> \v' -> Map.insert k v' m
+      Nothing -> point m
+  {-# INLINE ix #-}
+
+type instance IxValue (HashMap k a) = a
+instance (Eq k, Hashable k) => Ixed (HashMap k a) where
+  ix k = atraversalVL $ \point f m ->
+    case HashMap.lookup k m of
+      Just v  -> f v <&> \v' -> HashMap.insert k v' m
+      Nothing -> point m
+  {-# INLINE ix #-}
+
+type instance IxValue (Set k) = ()
+instance Ord k => Ixed (Set k) where
+  ix k = atraversalVL $ \point f m ->
+    if Set.member k m
+    then f () <&> \() -> Set.insert k m
+    else point m
+  {-# INLINE ix #-}
+
+type instance IxValue IntSet = ()
+instance Ixed IntSet where
+  ix k = atraversalVL $ \point f m ->
+    if IntSet.member k m
+    then f () <&> \() -> IntSet.insert k m
+    else point m
+  {-# INLINE ix #-}
+
+type instance IxValue (HashSet k) = ()
+instance (Eq k, Hashable k) => Ixed (HashSet k) where
+  ix k = atraversalVL $ \point f m ->
+    if HashSet.member k m
+    then f () <&> \() -> HashSet.insert k m
+    else point m
+  {-# INLINE ix #-}
+
+type instance IxValue (Array.Array i e) = e
+-- |
+-- @
+-- arr '!' i ≡ arr '^.' 'ix' i
+-- arr '//' [(i,e)] ≡ 'ix' i '.~' e '$' arr
+-- @
+instance Ix i => Ixed (Array.Array i e) where
+  ix i = atraversalVL $ \point f arr ->
+    if inRange (bounds arr) i
+    then f (arr Array.! i) <&> \e -> arr Array.// [(i,e)]
+    else point arr
+  {-# INLINE ix #-}
+
+type instance IxValue (UArray i e) = e
+-- |
+-- @
+-- arr '!' i ≡ arr '^.' 'ix' i
+-- arr '//' [(i,e)] ≡ 'ix' i '.~' e '$' arr
+-- @
+instance (IArray UArray e, Ix i) => Ixed (UArray i e) where
+  ix i = atraversalVL $ \point f arr ->
+    if inRange (bounds arr) i
+    then f (arr Array.! i) <&> \e -> arr Array.// [(i,e)]
+    else point arr
+  {-# INLINE ix #-}
+
+type instance IxValue (Vector.Vector a) = a
+instance Ixed (Vector.Vector a) where
+  ix i = atraversalVL $ \point f v ->
+    if 0 <= i && i < Vector.length v
+    then f (v Vector.! i) <&> \a -> v Vector.// [(i, a)]
+    else point v
+  {-# INLINE ix #-}
+
+type instance IxValue (Prim.Vector a) = a
+instance Prim a => Ixed (Prim.Vector a) where
+  ix i = atraversalVL $ \point f v ->
+    if 0 <= i && i < Prim.length v
+    then f (v Prim.! i) <&> \a -> v Prim.// [(i, a)]
+    else point v
+  {-# INLINE ix #-}
+
+type instance IxValue (Storable.Vector a) = a
+instance Storable a => Ixed (Storable.Vector a) where
+  ix i = atraversalVL $ \point f v ->
+    if 0 <= i && i < Storable.length v
+    then f (v Storable.! i) <&> \a -> v Storable.// [(i, a)]
+    else point v
+  {-# INLINE ix #-}
+
+type instance IxValue (Unboxed.Vector a) = a
+instance Unbox a => Ixed (Unboxed.Vector a) where
+  ix i = atraversalVL $ \point f v ->
+    if 0 <= i && i < Unboxed.length v
+    then f (v Unboxed.! i) <&> \a -> v Unboxed.// [(i, a)]
+    else point v
+  {-# INLINE ix #-}
+
+type instance IxValue StrictT.Text = Char
+instance Ixed StrictT.Text where
+  ix e = atraversalVL $ \point f s ->
+    case StrictT.splitAt e s of
+      (l, mr) -> case StrictT.uncons mr of
+        Nothing      -> point s
+        Just (c, xs) -> f c <&> \d -> StrictT.concat [l, StrictT.singleton d, xs]
+  {-# INLINE ix #-}
+
+type instance IxValue LazyT.Text = Char
+instance Ixed LazyT.Text where
+  ix e = atraversalVL $ \point f s ->
+    case LazyT.splitAt e s of
+      (l, mr) -> case LazyT.uncons mr of
+        Nothing      -> point s
+        Just (c, xs) -> f c <&> \d -> LazyT.append l (LazyT.cons d xs)
+  {-# INLINE ix #-}
+
+type instance IxValue StrictB.ByteString = Word8
+instance Ixed StrictB.ByteString where
+  ix e = atraversalVL $ \point f s ->
+    case StrictB.splitAt e s of
+      (l, mr) -> case StrictB.uncons mr of
+        Nothing      -> point s
+        Just (c, xs) -> f c <&> \d -> StrictB.concat [l, StrictB.singleton d, xs]
+  {-# INLINE ix #-}
+
+type instance IxValue LazyB.ByteString = Word8
+instance Ixed LazyB.ByteString where
+  -- TODO: we could be lazier, returning each chunk as it is passed
+  ix e = atraversalVL $ \point f s ->
+    case LazyB.splitAt e s of
+      (l, mr) -> case LazyB.uncons mr of
+        Nothing      -> point s
+        Just (c, xs) -> f c <&> \d -> LazyB.append l (LazyB.cons d xs)
+  {-# INLINE ix #-}
+
+-- | @'ix' :: 'Int' -> 'AffineTraversal'' (a, a) a@
+type instance IxValue (a0, a2) = a0
+instance (a0 ~ a1) => Ixed (a0, a1) where
+  ix i = atraversalVL $ \point f ~s@(a0, a1) ->
+    case i of
+      0 -> (,a1) <$> f a0
+      1 -> (a0,) <$> f a1
+      _ -> point s
+
+-- | @'ix' :: 'Int' -> 'AffineTraversal'' (a, a, a) a@
+type instance IxValue (a0, a1, a2) = a0
+instance (a0 ~ a1, a0 ~ a2) => Ixed (a0, a1, a2) where
+  ix i = atraversalVL $ \point f ~s@(a0, a1, a2) ->
+    case i of
+      0 -> (,a1,a2) <$> f a0
+      1 -> (a0,,a2) <$> f a1
+      2 -> (a0,a1,) <$> f a2
+      _ -> point s
+
+-- | @'ix' :: 'Int' -> 'AffineTraversal'' (a, a, a, a) a@
+type instance IxValue (a0, a1, a2, a3) = a0
+instance (a0 ~ a1, a0 ~ a2, a0 ~ a3) => Ixed (a0, a1, a2, a3) where
+  ix i = atraversalVL $ \point f ~s@(a0, a1, a2, a3) ->
+    case i of
+      0 -> (,a1,a2,a3) <$> f a0
+      1 -> (a0,,a2,a3) <$> f a1
+      2 -> (a0,a1,,a3) <$> f a2
+      3 -> (a0,a1,a2,) <$> f a3
+      _ -> point s
+
+-- | @'ix' :: 'Int' -> 'AffineTraversal'' (a, a, a, a, a) a@
+type instance IxValue (a0, a1, a2, a3, a4) = a0
+instance (a0 ~ a1, a0 ~ a2, a0 ~ a3, a0 ~ a4) => Ixed (a0, a1, a2, a3, a4) where
+  ix i = atraversalVL $ \point f ~s@(a0, a1, a2, a3, a4) ->
+    case i of
+      0 -> (,a1,a2,a3,a4) <$> f a0
+      1 -> (a0,,a2,a3,a4) <$> f a1
+      2 -> (a0,a1,,a3,a4) <$> f a2
+      3 -> (a0,a1,a2,,a4) <$> f a3
+      4 -> (a0,a1,a2,a3,) <$> f a4
+      _ -> point s
+
+-- | @'ix' :: 'Int' -> 'AffineTraversal'' (a, a, a, a, a, a) a@
+type instance IxValue (a0, a1, a2, a3, a4, a5) = a0
+instance
+  (a0 ~ a1, a0 ~ a2, a0 ~ a3, a0 ~ a4, a0 ~ a5
+  ) => Ixed (a0, a1, a2, a3, a4, a5) where
+  ix i = atraversalVL $ \point f ~s@(a0, a1, a2, a3, a4, a5) ->
+    case i of
+      0 -> (,a1,a2,a3,a4,a5) <$> f a0
+      1 -> (a0,,a2,a3,a4,a5) <$> f a1
+      2 -> (a0,a1,,a3,a4,a5) <$> f a2
+      3 -> (a0,a1,a2,,a4,a5) <$> f a3
+      4 -> (a0,a1,a2,a3,,a5) <$> f a4
+      5 -> (a0,a1,a2,a3,a4,) <$> f a5
+      _ -> point s
+
+-- | @'ix' :: 'Int' -> 'AffineTraversal'' (a, a, a, a, a, a, a) a@
+type instance IxValue (a0, a1, a2, a3, a4, a5, a6) = a0
+instance
+  (a0 ~ a1, a0 ~ a2, a0 ~ a3, a0 ~ a4, a0 ~ a5, a0 ~ a6
+  ) => Ixed (a0, a1, a2, a3, a4, a5, a6) where
+  ix i = atraversalVL $ \point f ~s@(a0, a1, a2, a3, a4, a5, a6) ->
+    case i of
+      0 -> (,a1,a2,a3,a4,a5,a6) <$> f a0
+      1 -> (a0,,a2,a3,a4,a5,a6) <$> f a1
+      2 -> (a0,a1,,a3,a4,a5,a6) <$> f a2
+      3 -> (a0,a1,a2,,a4,a5,a6) <$> f a3
+      4 -> (a0,a1,a2,a3,,a5,a6) <$> f a4
+      5 -> (a0,a1,a2,a3,a4,,a6) <$> f a5
+      6 -> (a0,a1,a2,a3,a4,a5,) <$> f a6
+      _ -> point s
+
+-- | @'ix' :: 'Int' -> 'AffineTraversal'' (a, a, a, a, a, a, a, a) a@
+type instance IxValue (a0, a1, a2, a3, a4, a5, a6, a7) = a0
+instance
+  (a0 ~ a1, a0 ~ a2, a0 ~ a3, a0 ~ a4, a0 ~ a5, a0 ~ a6, a0 ~ a7
+  ) => Ixed (a0, a1, a2, a3, a4, a5, a6, a7) where
+  ix i = atraversalVL $ \point f ~s@(a0, a1, a2, a3, a4, a5, a6, a7) ->
+    case i of
+      0 -> (,a1,a2,a3,a4,a5,a6,a7) <$> f a0
+      1 -> (a0,,a2,a3,a4,a5,a6,a7) <$> f a1
+      2 -> (a0,a1,,a3,a4,a5,a6,a7) <$> f a2
+      3 -> (a0,a1,a2,,a4,a5,a6,a7) <$> f a3
+      4 -> (a0,a1,a2,a3,,a5,a6,a7) <$> f a4
+      5 -> (a0,a1,a2,a3,a4,,a6,a7) <$> f a5
+      6 -> (a0,a1,a2,a3,a4,a5,,a7) <$> f a6
+      7 -> (a0,a1,a2,a3,a4,a5,a6,) <$> f a7
+      _ -> point s
+
+-- | @'ix' :: 'Int' -> 'AffineTraversal'' (a, a, a, a, a, a, a, a, a) a@
+type instance IxValue (a0, a1, a2, a3, a4, a5, a6, a7, a8) = a0
+instance
+  (a0 ~ a1, a0 ~ a2, a0 ~ a3, a0 ~ a4, a0 ~ a5, a0 ~ a6, a0 ~ a7, a0 ~ a8
+  ) => Ixed (a0, a1, a2, a3, a4, a5, a6, a7, a8) where
+  ix i = atraversalVL $ \point f ~s@(a0, a1, a2, a3, a4, a5, a6, a7, a8) ->
+    case i of
+      0 -> (,a1,a2,a3,a4,a5,a6,a7,a8) <$> f a0
+      1 -> (a0,,a2,a3,a4,a5,a6,a7,a8) <$> f a1
+      2 -> (a0,a1,,a3,a4,a5,a6,a7,a8) <$> f a2
+      3 -> (a0,a1,a2,,a4,a5,a6,a7,a8) <$> f a3
+      4 -> (a0,a1,a2,a3,,a5,a6,a7,a8) <$> f a4
+      5 -> (a0,a1,a2,a3,a4,,a6,a7,a8) <$> f a5
+      6 -> (a0,a1,a2,a3,a4,a5,,a7,a8) <$> f a6
+      7 -> (a0,a1,a2,a3,a4,a5,a6,,a8) <$> f a7
+      8 -> (a0,a1,a2,a3,a4,a5,a6,a7,) <$> f a8
+      _ -> point s
+
+-- | 'At' provides a 'Lens' that can be used to read, write or delete the value
+-- associated with a key in a 'Map'-like container on an ad hoc basis.
+--
+-- An instance of 'At' should satisfy:
+--
+-- @
+-- 'ix' k ≡ 'at' k '%' '_Just'
+-- @
+class Ixed m => At m where
+  -- |
+  -- >>> Map.fromList [(1,"world")] ^.at 1
+  -- Just "world"
+  --
+  -- >>> at 1 ?~ "hello" $ Map.empty
+  -- fromList [(1,"hello")]
+  --
+  -- /Note:/ 'Map'-like containers form a reasonable instance, but not
+  -- 'Array'-like ones, where you cannot satisfy the 'Lens' laws.
+  at :: Index m -> Lens' m (Maybe (IxValue m))
+
+-- | Delete the value associated with a key in a 'Map'-like container
+--
+-- @
+-- 'sans' k = 'at' k .~ Nothing
+-- @
+sans :: At m => Index m -> m -> m
+sans k = set (at k) Nothing
+{-# INLINE sans #-}
+
+instance At (Maybe a) where
+  at () = lensVL id
+  {-# INLINE at #-}
+
+instance At (IntMap a) where
+#if MIN_VERSION_containers(0,5,8)
+  at k = lensVL $ \f -> IntMap.alterF f k
+#else
+  at k = lensVL $ \f m ->
+    let mv = IntMap.lookup k m
+    in f mv <&> \r -> case r of
+      Nothing -> maybe m (const (IntMap.delete k m)) mv
+      Just v' -> IntMap.insert k v' m
+#endif
+  {-# INLINE at #-}
+
+instance Ord k => At (Map k a) where
+#if MIN_VERSION_containers(0,5,8)
+  at k = lensVL $ \f -> Map.alterF f k
+#else
+  at k = lensVL $ \f m ->
+    let mv = Map.lookup k m
+    in f mv <&> \r -> case r of
+      Nothing -> maybe m (const (Map.delete k m)) mv
+      Just v' -> Map.insert k v' m
+#endif
+  {-# INLINE at #-}
+
+instance (Eq k, Hashable k) => At (HashMap k a) where
+  at k = lensVL $ \f m ->
+    let mv = HashMap.lookup k m
+    in f mv <&> \r -> case r of
+      Nothing -> maybe m (const (HashMap.delete k m)) mv
+      Just v' -> HashMap.insert k v' m
+  {-# INLINE at #-}
+
+instance At IntSet where
+  at k = lensVL $ \f m ->
+    let mv = if IntSet.member k m
+             then Just ()
+             else Nothing
+    in f mv <&> \r -> case r of
+      Nothing -> maybe m (const (IntSet.delete k m)) mv
+      Just () -> IntSet.insert k m
+  {-# INLINE at #-}
+
+instance Ord k => At (Set k) where
+  at k = lensVL $ \f m ->
+    let mv = if Set.member k m
+             then Just ()
+             else Nothing
+    in f mv <&> \r -> case r of
+      Nothing -> maybe m (const (Set.delete k m)) mv
+      Just () -> Set.insert k m
+  {-# INLINE at #-}
+
+instance (Eq k, Hashable k) => At (HashSet k) where
+  at k = lensVL $ \f m ->
+    let mv = if HashSet.member k m
+             then Just ()
+             else Nothing
+    in f mv <&> \r -> case r of
+      Nothing -> maybe m (const (HashSet.delete k m)) mv
+      Just () -> HashSet.insert k m
+  {-# INLINE at #-}
+
+----------------------------------------
+-- Internal
+
+ixListVL :: Int -> AffineTraversalVL' [a] a
+ixListVL k point f xs0 =
+  if k < 0
+  then point xs0
+  else let go [] _ = point []
+           go (a:as) 0 = f a <&> (:as)
+           go (a:as) i = (a:) <$> (go as $! i - 1)
+       in go xs0 k
+{-# INLINE ixListVL #-}

--- a/optics-extra/src/Optics/Cons.hs
+++ b/optics-extra/src/Optics/Cons.hs
@@ -1,0 +1,519 @@
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+module Optics.Cons
+  (
+  -- * Cons
+    Cons(..)
+  , (<|)
+  , cons
+  , uncons
+  , _head, _tail
+  , pattern (:<)
+  -- * Snoc
+  , Snoc(..)
+  , (|>)
+  , snoc
+  , unsnoc
+  , _init, _last
+  , pattern (:>)
+  ) where
+
+import Control.Applicative (ZipList(..))
+import Data.Coerce
+import Data.Sequence hiding ((<|), (|>), (:<), (:>))
+import Data.Vector (Vector)
+import Data.Vector.Primitive (Prim)
+import Data.Vector.Storable (Storable)
+import Data.Vector.Unboxed (Unbox)
+import Data.Word
+import qualified Data.ByteString as StrictB
+import qualified Data.ByteString.Lazy as LazyB
+import qualified Data.Sequence as Seq
+import qualified Data.Text as StrictT
+import qualified Data.Text.Lazy as LazyT
+import qualified Data.Vector as Vector
+import qualified Data.Vector.Primitive as Prim
+import qualified Data.Vector.Storable as Storable
+import qualified Data.Vector.Unboxed as Unbox
+
+import Optics.Core
+
+-- $setup
+-- >>> :set -XNoOverloadedStrings
+-- >>> import Control.Lens
+-- >>> import Debug.SimpleReflect.Expr
+-- >>> import Debug.SimpleReflect.Vars as Vars hiding (f,g)
+-- >>> let f :: Expr -> Expr; f = Debug.SimpleReflect.Vars.f
+-- >>> let g :: Expr -> Expr; g = Debug.SimpleReflect.Vars.g
+
+infixr 5 <|, `cons`
+infixl 5 |>, `snoc`
+
+pattern (:<) :: forall s a. Cons s s a a => a -> s -> s
+pattern (:<) a s <- (preview _Cons -> Just (a, s)) where
+  (:<) a s = review _Cons (a, s)
+
+infixr 5 :<
+infixl 5 :>
+
+pattern (:>) :: forall s a. Snoc s s a a => s -> a -> s
+pattern (:>) s a <- (preview _Snoc -> Just (s, a)) where
+  (:>) a s = review _Snoc (a, s)
+
+------------------------------------------------------------------------------
+-- Cons
+------------------------------------------------------------------------------
+
+-- | This class provides a way to attach or detach elements on the left
+-- side of a structure in a flexible manner.
+class Cons s t a b | s -> a, t -> b, s b -> t, t a -> s where
+  -- |
+  --
+  -- @
+  -- '_Cons' :: 'Prism' [a] [b] (a, [a]) (b, [b])
+  -- '_Cons' :: 'Prism' ('Seq' a) ('Seq' b) (a, 'Seq' a) (b, 'Seq' b)
+  -- '_Cons' :: 'Prism' ('Vector' a) ('Vector' b) (a, 'Vector' a) (b, 'Vector' b)
+  -- '_Cons' :: 'Prism'' 'String' ('Char', 'String')
+  -- '_Cons' :: 'Prism'' 'StrictT.Text' ('Char', 'StrictT.Text')
+  -- '_Cons' :: 'Prism'' 'StrictB.ByteString' ('Word8', 'StrictB.ByteString')
+  -- @
+  _Cons :: Prism s t (a, s) (b, t)
+
+instance Cons [a] [b] a b where
+  _Cons = prism (uncurry (:)) $ \ aas -> case aas of
+    (a:as) -> Right (a, as)
+    []     -> Left  []
+  {-# INLINE _Cons #-}
+
+instance Cons (ZipList a) (ZipList b) a b where
+  _Cons = withPrism listCons $ \listReview listPreview -> 
+    prism (coerce listReview) (coerce listPreview) where
+
+    listCons :: Prism [a] [b] (a, [a]) (b, [b])
+    listCons = _Cons
+
+  {-# INLINE _Cons #-}
+
+instance Cons (Seq a) (Seq b) a b where
+  _Cons = prism (uncurry (Seq.<|)) $ \aas -> case viewl aas of
+    a Seq.:< as -> Right (a, as)
+    EmptyL  -> Left mempty
+  {-# INLINE _Cons #-}
+
+instance Cons StrictB.ByteString StrictB.ByteString Word8 Word8 where
+  _Cons = prism' (uncurry StrictB.cons) StrictB.uncons
+  {-# INLINE _Cons #-}
+
+instance Cons LazyB.ByteString LazyB.ByteString Word8 Word8 where
+  _Cons = prism' (uncurry LazyB.cons) LazyB.uncons
+  {-# INLINE _Cons #-}
+
+instance Cons StrictT.Text StrictT.Text Char Char where
+  _Cons = prism' (uncurry StrictT.cons) StrictT.uncons
+  {-# INLINE _Cons #-}
+
+instance Cons LazyT.Text LazyT.Text Char Char where
+  _Cons = prism' (uncurry LazyT.cons) LazyT.uncons
+  {-# INLINE _Cons #-}
+
+instance Cons (Vector a) (Vector b) a b where
+  _Cons = prism (uncurry Vector.cons) $ \v ->
+    if Vector.null v
+    then Left Vector.empty
+    else Right (Vector.unsafeHead v, Vector.unsafeTail v)
+  {-# INLINE _Cons #-}
+
+instance (Prim a, Prim b) => Cons (Prim.Vector a) (Prim.Vector b) a b where
+  _Cons = prism (uncurry Prim.cons) $ \v ->
+    if Prim.null v
+    then Left Prim.empty
+    else Right (Prim.unsafeHead v, Prim.unsafeTail v)
+  {-# INLINE _Cons #-}
+
+instance (Storable a, Storable b) => Cons (Storable.Vector a) (Storable.Vector b) a b where
+  _Cons = prism (uncurry Storable.cons) $ \v ->
+    if Storable.null v
+    then Left Storable.empty
+    else Right (Storable.unsafeHead v, Storable.unsafeTail v)
+  {-# INLINE _Cons #-}
+
+instance (Unbox a, Unbox b) => Cons (Unbox.Vector a) (Unbox.Vector b) a b where
+  _Cons = prism (uncurry Unbox.cons) $ \v ->
+    if Unbox.null v
+    then Left Unbox.empty
+    else Right (Unbox.unsafeHead v, Unbox.unsafeTail v)
+  {-# INLINE _Cons #-}
+
+-- | 'cons' an element onto a container.
+--
+-- This is an infix alias for 'cons'.
+--
+-- >>> a <| []
+-- [a]
+--
+-- >>> a <| [b, c]
+-- [a,b,c]
+--
+-- >>> a <| Seq.fromList []
+-- fromList [a]
+--
+-- >>> a <| Seq.fromList [b, c]
+-- fromList [a,b,c]
+(<|) :: Cons s s a a => a -> s -> s
+(<|) = curry (review _Cons)
+{-# INLINE (<|) #-}
+
+-- | 'cons' an element onto a container.
+--
+-- >>> cons a []
+-- [a]
+--
+-- >>> cons a [b, c]
+-- [a,b,c]
+--
+-- >>> cons a (Seq.fromList [])
+-- fromList [a]
+--
+-- >>> cons a (Seq.fromList [b, c])
+-- fromList [a,b,c]
+cons :: Cons s s a a => a -> s -> s
+cons = curry (review _Cons)
+{-# INLINE cons #-}
+
+-- | Attempt to extract the left-most element from a container, and a version of
+-- the container without that element.
+--
+-- >>> uncons []
+-- Nothing
+--
+-- >>> uncons [a, b, c]
+-- Just (a,[b,c])
+uncons :: Cons s s a a => s -> Maybe (a, s)
+uncons = preview _Cons
+{-# INLINE uncons #-}
+
+-- | An 'AffineTraversal' reading and writing to the 'head' of a /non-empty/
+-- container.
+--
+-- >>> [a,b,c]^? _head
+-- Just a
+--
+-- >>> [a,b,c] & _head .~ d
+-- [d,b,c]
+--
+-- >>> [a,b,c] & _head %~ f
+-- [f a,b,c]
+--
+-- >>> [] & _head %~ f
+-- []
+--
+-- >>> [1,2,3]^?!_head
+-- 1
+--
+-- >>> []^?_head
+-- Nothing
+--
+-- >>> [1,2]^?_head
+-- Just 1
+--
+-- >>> [] & _head .~ 1
+-- []
+--
+-- >>> [0] & _head .~ 2
+-- [2]
+--
+-- >>> [0,1] & _head .~ 2
+-- [2,1]
+--
+-- This isn't limited to lists.
+--
+-- For instance you can also 'Data.Traversable.traverse' the head of a 'Seq':
+--
+-- >>> Seq.fromList [a,b,c,d] & _head %~ f
+-- fromList [f a,b,c,d]
+--
+-- >>> Seq.fromList [] ^? _head
+-- Nothing
+--
+-- >>> Seq.fromList [a,b,c,d] ^? _head
+-- Just a
+--
+-- @
+-- '_head' :: 'AffineTraversal'' [a] a
+-- '_head' :: 'AffineTraversal'' ('Seq' a) a
+-- '_head' :: 'AffineTraversal'' ('Vector' a) a
+-- @
+_head :: Cons s s a a => AffineTraversal' s a
+_head = _Cons % _1
+{-# INLINE _head #-}
+
+-- | An 'AffineTraversal' reading and writing to the 'tail' of a /non-empty/
+-- container.
+--
+-- >>> [a,b] & _tail .~ [c,d,e]
+-- [a,c,d,e]
+--
+-- >>> [] & _tail .~ [a,b]
+-- []
+--
+-- >>> [a,b,c,d,e] & _tail.traverse %~ f
+-- [a,f b,f c,f d,f e]
+--
+-- >>> [1,2] & _tail .~ [3,4,5]
+-- [1,3,4,5]
+--
+-- >>> [] & _tail .~ [1,2]
+-- []
+--
+-- >>> [a,b,c]^?_tail
+-- Just [b,c]
+--
+-- >>> [1,2]^?!_tail
+-- [2]
+--
+-- >>> "hello"^._tail
+-- "ello"
+--
+-- >>> ""^._tail
+-- ""
+--
+-- This isn't limited to lists. For instance you can also
+-- 'Control.Traversable.traverse' the tail of a 'Seq'.
+--
+-- >>> Seq.fromList [a,b] & _tail .~ Seq.fromList [c,d,e]
+-- fromList [a,c,d,e]
+--
+-- >>> Seq.fromList [a,b,c] ^? _tail
+-- Just (fromList [b,c])
+--
+-- >>> Seq.fromList [] ^? _tail
+-- Nothing
+--
+-- @
+-- '_tail' :: 'AffineTraversal'' [a] [a]
+-- '_tail' :: 'AffineTraversal'' ('Seq' a) ('Seq' a)
+-- '_tail' :: 'AffineTraversal'' ('Vector' a) ('Vector' a)
+-- @
+_tail :: Cons s s a a => AffineTraversal' s s
+_tail = _Cons % _2
+{-# INLINE _tail #-}
+
+------------------------------------------------------------------------------
+-- Snoc
+------------------------------------------------------------------------------
+
+-- | This class provides a way to attach or detach elements on the right
+-- side of a structure in a flexible manner.
+class Snoc s t a b | s -> a, t -> b, s b -> t, t a -> s where
+  -- |
+  --
+  -- @
+  -- '_Snoc' :: 'Prism' [a] [b] ([a], a) ([b], b)
+  -- '_Snoc' :: 'Prism' ('Seq' a) ('Seq' b) ('Seq' a, a) ('Seq' b, b)
+  -- '_Snoc' :: 'Prism' ('Vector' a) ('Vector' b) ('Vector' a, a) ('Vector' b, b)
+  -- '_Snoc' :: 'Prism'' 'String' ('String', 'Char')
+  -- '_Snoc' :: 'Prism'' 'StrictT.Text' ('StrictT.Text', 'Char')
+  -- '_Snoc' :: 'Prism'' 'StrictB.ByteString' ('StrictB.ByteString', 'Word8')
+  -- @
+  _Snoc :: Prism s t (s, a) (t, b)
+
+instance Snoc [a] [b] a b where
+  _Snoc = prism (\(as,a) -> as Prelude.++ [a]) $ \aas -> if Prelude.null aas
+    then Left []
+    else Right (Prelude.init aas, Prelude.last aas)
+  {-# INLINE _Snoc #-}
+
+instance Snoc (ZipList a) (ZipList b) a b where
+  _Snoc = withPrism listSnoc $ \listReview listPreview -> 
+    prism (coerce listReview) (coerce listPreview) where
+
+    listSnoc :: Prism [a] [b] ([a], a) ([b], b)
+    listSnoc = _Snoc
+
+  {-# INLINE _Snoc #-}
+
+instance Snoc (Seq a) (Seq b) a b where
+  _Snoc = prism (uncurry (Seq.|>)) $ \aas -> case viewr aas of
+    as Seq.:> a -> Right (as, a)
+    EmptyR  -> Left mempty
+  {-# INLINE _Snoc #-}
+
+instance Snoc (Vector a) (Vector b) a b where
+  _Snoc = prism (uncurry Vector.snoc) $ \v -> if Vector.null v
+    then Left Vector.empty
+    else Right (Vector.unsafeInit v, Vector.unsafeLast v)
+  {-# INLINE _Snoc #-}
+
+instance (Prim a, Prim b) => Snoc (Prim.Vector a) (Prim.Vector b) a b where
+  _Snoc = prism (uncurry Prim.snoc) $ \v -> if Prim.null v
+    then Left Prim.empty
+    else Right (Prim.unsafeInit v, Prim.unsafeLast v)
+  {-# INLINE _Snoc #-}
+
+instance (Storable a, Storable b) => Snoc (Storable.Vector a) (Storable.Vector b) a b where
+  _Snoc = prism (uncurry Storable.snoc) $ \v -> if Storable.null v
+    then Left Storable.empty
+    else Right (Storable.unsafeInit v, Storable.unsafeLast v)
+  {-# INLINE _Snoc #-}
+
+instance (Unbox a, Unbox b) => Snoc (Unbox.Vector a) (Unbox.Vector b) a b where
+  _Snoc = prism (uncurry Unbox.snoc) $ \v -> if Unbox.null v
+    then Left Unbox.empty
+    else Right (Unbox.unsafeInit v, Unbox.unsafeLast v)
+  {-# INLINE _Snoc #-}
+
+instance Snoc StrictB.ByteString StrictB.ByteString Word8 Word8 where
+  _Snoc = prism (uncurry StrictB.snoc) $ \v -> if StrictB.null v
+    then Left StrictB.empty
+    else Right (StrictB.init v, StrictB.last v)
+  {-# INLINE _Snoc #-}
+
+instance Snoc LazyB.ByteString LazyB.ByteString Word8 Word8 where
+  _Snoc = prism (uncurry LazyB.snoc) $ \v -> if LazyB.null v
+    then Left LazyB.empty
+    else Right (LazyB.init v, LazyB.last v)
+  {-# INLINE _Snoc #-}
+
+instance Snoc StrictT.Text StrictT.Text Char Char where
+  _Snoc = prism (uncurry StrictT.snoc) $ \v -> if StrictT.null v
+    then Left StrictT.empty
+    else Right (StrictT.init v, StrictT.last v)
+  {-# INLINE _Snoc #-}
+
+instance Snoc LazyT.Text LazyT.Text Char Char where
+  _Snoc = prism (uncurry LazyT.snoc) $ \v -> if LazyT.null v
+    then Left LazyT.empty
+    else Right (LazyT.init v, LazyT.last v)
+  {-# INLINE _Snoc #-}
+
+-- | An 'AffineTraversal' reading and replacing all but the a last element of a
+-- /non-empty/ container.
+--
+-- >>> [a,b,c,d]^?_init
+-- Just [a,b,c]
+--
+-- >>> []^?_init
+-- Nothing
+--
+-- >>> [a,b] & _init .~ [c,d,e]
+-- [c,d,e,b]
+--
+-- >>> [] & _init .~ [a,b]
+-- []
+--
+-- >>> [a,b,c,d] & _init.traverse %~ f
+-- [f a,f b,f c,d]
+--
+-- >>> [1,2,3]^?_init
+-- Just [1,2]
+--
+-- >>> [1,2,3,4]^?!_init
+-- [1,2,3]
+--
+-- >>> "hello"^._init
+-- "hell"
+--
+-- >>> ""^._init
+-- ""
+--
+-- @
+-- '_init' :: 'AffineTraversal'' [a] [a]
+-- '_init' :: 'AffineTraversal'' ('Seq' a) ('Seq' a)
+-- '_init' :: 'AffineTraversal'' ('Vector' a) ('Vector' a)
+-- @
+_init :: Snoc s s a a => AffineTraversal' s s
+_init = _Snoc % _1
+{-# INLINE _init #-}
+
+-- | An 'AffineTraversal' reading and writing to the last element of a
+-- /non-empty/ container.
+--
+-- >>> [a,b,c]^?!_last
+-- c
+--
+-- >>> []^?_last
+-- Nothing
+--
+-- >>> [a,b,c] & _last %~ f
+-- [a,b,f c]
+--
+-- >>> [1,2]^?_last
+-- Just 2
+--
+-- >>> [] & _last .~ 1
+-- []
+--
+-- >>> [0] & _last .~ 2
+-- [2]
+--
+-- >>> [0,1] & _last .~ 2
+-- [0,2]
+--
+-- This 'AffineTraversal' is not limited to lists, however. We can also work
+-- with other containers, such as a 'Vector'.
+--
+-- >>> Vector.fromList "abcde" ^? _last
+-- Just 'e'
+--
+-- >>> Vector.empty ^? _last
+-- Nothing
+--
+-- >>> (Vector.fromList "abcde" & _last .~ 'Q') == Vector.fromList "abcdQ"
+-- True
+--
+-- @
+-- '_last' :: 'AffineTraversal'' [a] a
+-- '_last' :: 'AffineTraversal'' ('Seq' a) a
+-- '_last' :: 'AffineTraversal'' ('Vector' a) a
+-- @
+_last :: Snoc s s a a => AffineTraversal' s a
+_last = _Snoc % _2
+{-# INLINE _last #-}
+
+-- | 'snoc' an element onto the end of a container.
+--
+-- This is an infix alias for 'snoc'.
+--
+-- >>> Seq.fromList [] |> a
+-- fromList [a]
+--
+-- >>> Seq.fromList [b, c] |> a
+-- fromList [b,c,a]
+--
+-- >>> LazyT.pack "hello" |> '!'
+-- "hello!"
+(|>) :: Snoc s s a a => s -> a -> s
+(|>) = curry (review _Snoc)
+{-# INLINE (|>) #-}
+
+-- | 'snoc' an element onto the end of a container.
+--
+-- >>> snoc (Seq.fromList []) a
+-- fromList [a]
+--
+-- >>> snoc (Seq.fromList [b, c]) a
+-- fromList [b,c,a]
+--
+-- >>> snoc (LazyT.pack "hello") '!'
+-- "hello!"
+snoc  :: Snoc s s a a => s -> a -> s
+snoc = curry (review _Snoc)
+{-# INLINE snoc #-}
+
+-- | Attempt to extract the right-most element from a container, and a version
+-- of the container without that element.
+--
+-- >>> unsnoc (LazyT.pack "hello!")
+-- Just ("hello",'!')
+--
+-- >>> unsnoc (LazyT.pack "")
+-- Nothing
+--
+-- >>> unsnoc (Seq.fromList [b,c,a])
+-- Just (fromList [b,c],a)
+--
+-- >>> unsnoc (Seq.fromList [])
+-- Nothing
+unsnoc :: Snoc s s a a => s -> Maybe (s, a)
+unsnoc s = preview _Snoc s
+{-# INLINE unsnoc #-}

--- a/optics-extra/src/Optics/Empty.hs
+++ b/optics-extra/src/Optics/Empty.hs
@@ -1,0 +1,159 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+module Optics.Empty
+  ( AsEmpty(..)
+  , pattern Empty
+  ) where
+
+import Control.Applicative (ZipList(..))
+import Data.ByteString as StrictB
+import Data.ByteString.Lazy as LazyB
+import Data.HashMap.Lazy as HashMap
+import Data.HashSet as HashSet
+import Data.IntMap as IntMap
+import Data.IntSet as IntSet
+import Data.Map as Map
+import Data.Maybe
+import Data.Monoid
+import Data.Set as Set
+import Data.Text as StrictT
+import Data.Text.Lazy as LazyT
+import Data.Vector as Vector
+import Data.Vector.Storable as Storable
+import Data.Vector.Unboxed as Unboxed
+import qualified Data.Sequence as Seq
+
+import Optics.Core
+import Optics.Internal.Utils
+
+#if !defined(mingw32_HOST_OS) && !defined(ghcjs_HOST_OS)
+import GHC.Event
+#endif
+
+class AsEmpty a where
+  -- |
+  --
+  -- >>> isn't _Empty [1,2,3]
+  -- True
+  _Empty :: Prism' a ()
+  default _Empty :: (Monoid a, Eq a) => Prism' a ()
+  _Empty = only mempty
+  {-# INLINE _Empty #-}
+
+pattern Empty :: forall a. AsEmpty a => a
+pattern Empty <- (has _Empty -> True) where
+  Empty = review _Empty ()
+
+{- Default Monoid instances -}
+instance AsEmpty Ordering
+instance AsEmpty ()
+instance AsEmpty Any
+instance AsEmpty All
+#if !defined(mingw32_HOST_OS) && !defined(ghcjs_HOST_OS)
+instance AsEmpty Event
+#endif
+instance (Eq a, Num a) => AsEmpty (Product a)
+instance (Eq a, Num a) => AsEmpty (Sum a)
+
+instance AsEmpty (Maybe a) where
+  _Empty = _Nothing
+  {-# INLINE _Empty #-}
+
+instance AsEmpty (Last a) where
+  _Empty = nearly (Last Nothing) (isNothing .# getLast)
+  {-# INLINE _Empty #-}
+
+instance AsEmpty (First a) where
+  _Empty = nearly (First Nothing) (isNothing .# getFirst)
+  {-# INLINE _Empty #-}
+
+instance AsEmpty a => AsEmpty (Dual a) where
+  _Empty = iso getDual Dual % _Empty
+  {-# INLINE _Empty #-}
+
+instance (AsEmpty a, AsEmpty b) => AsEmpty (a, b) where
+  _Empty = prism'
+    (\() -> (review _Empty (), review _Empty ()))
+    (\(s, s') -> case matching _Empty s of
+        Right () -> case matching _Empty s' of
+          Right () -> Just ()
+          Left _   -> Nothing
+        Left _   -> Nothing)
+  {-# INLINE _Empty #-}
+
+instance (AsEmpty a, AsEmpty b, AsEmpty c) => AsEmpty (a, b, c) where
+  _Empty = prism'
+    (\() -> (review _Empty (), review _Empty (), review _Empty ()))
+    (\(s, s', s'') -> case matching _Empty s of
+        Right () -> case matching _Empty s' of
+          Right () -> case matching _Empty s'' of
+            Right () -> Just ()
+            Left _   -> Nothing
+          Left _   -> Nothing
+        Left _   -> Nothing)
+  {-# INLINE _Empty #-}
+
+instance AsEmpty [a] where
+  _Empty = nearly [] Prelude.null
+  {-# INLINE _Empty #-}
+
+instance AsEmpty (ZipList a) where
+  _Empty = nearly (ZipList []) (Prelude.null . getZipList)
+  {-# INLINE _Empty #-}
+
+instance AsEmpty (Map k a) where
+  _Empty = nearly Map.empty Map.null
+  {-# INLINE _Empty #-}
+
+instance AsEmpty (HashMap k a) where
+  _Empty = nearly HashMap.empty HashMap.null
+  {-# INLINE _Empty #-}
+
+instance AsEmpty (IntMap a) where
+  _Empty = nearly IntMap.empty IntMap.null
+  {-# INLINE _Empty #-}
+
+instance AsEmpty (Set a) where
+  _Empty = nearly Set.empty Set.null
+  {-# INLINE _Empty #-}
+
+instance AsEmpty (HashSet a) where
+  _Empty = nearly HashSet.empty HashSet.null
+  {-# INLINE _Empty #-}
+
+instance AsEmpty IntSet where
+  _Empty = nearly IntSet.empty IntSet.null
+  {-# INLINE _Empty #-}
+
+instance AsEmpty (Vector.Vector a) where
+  _Empty = nearly Vector.empty Vector.null
+  {-# INLINE _Empty #-}
+
+instance Unbox a => AsEmpty (Unboxed.Vector a) where
+  _Empty = nearly Unboxed.empty Unboxed.null
+  {-# INLINE _Empty #-}
+
+instance Storable a => AsEmpty (Storable.Vector a) where
+  _Empty = nearly Storable.empty Storable.null
+  {-# INLINE _Empty #-}
+
+instance AsEmpty (Seq.Seq a) where
+  _Empty = nearly Seq.empty Seq.null
+  {-# INLINE _Empty #-}
+
+instance AsEmpty StrictB.ByteString where
+  _Empty = nearly StrictB.empty StrictB.null
+  {-# INLINE _Empty #-}
+
+instance AsEmpty LazyB.ByteString where
+  _Empty = nearly LazyB.empty LazyB.null
+  {-# INLINE _Empty #-}
+
+instance AsEmpty StrictT.Text where
+  _Empty = nearly StrictT.empty StrictT.null
+  {-# INLINE _Empty #-}
+
+instance AsEmpty LazyT.Text where
+  _Empty = nearly LazyT.empty LazyT.null
+  {-# INLINE _Empty #-}

--- a/optics-extra/src/Optics/Extra.hs
+++ b/optics-extra/src/Optics/Extra.hs
@@ -1,1 +1,12 @@
-module Optics.Extra where
+module Optics.Extra
+  ( module Optics.Core
+  , module O
+  ) where
+
+import Optics.Core
+
+import Optics.At      as O
+import Optics.Cons    as O
+import Optics.Each    as O
+import Optics.Empty   as O
+import Optics.Indexed as O

--- a/optics/tests/Optics/Tests.hs
+++ b/optics/tests/Optics/Tests.hs
@@ -212,11 +212,11 @@ computationTests = testGroup "computation"
         ]
     , testGroup "AffineTraversal"
         -- this doesn't hold definitionally: we need law here
-        [ testCase "withAffineTraversal (atraversal f g) (\\ h _ -> h) /= g" $
+        [ testCase "withAffineTraversal (atraversal f g) (\\ _ g' -> g') /= g" $
              assertFailure' $(inspectTest $ 'compL03 === 'compR03)
-        , testCase "withAffineTraversal (atraversal f g) (\\ h _ -> h) = ..." $
-             assertSuccess $(inspectTest $ 'compL03 === 'compR03_)
-        , testCase "withAffineTraversal (atraversal f g) (\\ _ h -> h) = f" $
+        , testCase "withAffineTraversal (atraversal f g) (\\ _ g' -> g') = ..." $
+             assertSuccess $(inspectTest $ 'compL03 ==- 'compR03_)
+        , testCase "withAffineTraversal (atraversal f g) (\\ f' _ -> f') = f" $
             assertSuccess $(inspectTest $ 'compL04 === 'compR04)
         ]
 


### PR DESCRIPTION
Fixes #30.

The first commit borrows some ideas from #98 to get affine traversals in VL form which are usually easier to define than using `atraversal` and can be more efficient.