### PR TITLE
Add strict versions of (i)over and (i)set

### DIFF
--- a/optics-core/src/Optics/Internal/Profunctor.hs
+++ b/optics-core/src/Optics/Internal/Profunctor.hs
@@ -60,15 +60,18 @@ instance Applicative Identity' where
 --
 wrapIdentity' :: a -> Identity' a
 wrapIdentity' a = Identity' (a `seq` ()) a
+{-# INLINE wrapIdentity' #-}
 
 unwrapIdentity' :: Identity' a -> a
 unwrapIdentity' (Identity' () a) = a
+{-# INLINE unwrapIdentity' #-}
 
 ----------------------------------------
 
 -- | Unwrap 'StarA'.
 runStarA :: StarA f i a b -> a -> f b
 runStarA (StarA _ k) = k
+{-# INLINE runStarA #-}
 
 -- | Repack 'Star' to change its index type.
 reStar :: Star f i a b -> Star f j a b

--- a/optics-core/src/Optics/IxSetter.hs
+++ b/optics-core/src/Optics/IxSetter.hs
@@ -6,7 +6,9 @@ module Optics.IxSetter
   , FunctorWithIndex(..)
   , toIxSetter
   , iover
+  , iover'
   , iset
+  , iset'
   , isets
   , conjoinedSets
   , imapped
@@ -38,6 +40,16 @@ iover
 iover o f = runIxFunArrow (getOptic (toIxSetter o) (IxFunArrow f)) id
 {-# INLINE iover #-}
 
+-- | Apply an indexed setter as a modifier, strictly.
+iover'
+  :: (Is k A_Setter, CheckIndices "iover'" 1 i is)
+  => Optic k is s t a b
+  -> (i -> a -> b) -> s -> t
+iover' o f = unwrapUnit' . runIxStar star id
+  where
+    star = getOptic (toIxSetter o) $ IxStar (\i -> wrapUnit' . f i)
+{-# INLINE iover' #-}
+
 -- | Apply an indexed setter.
 iset
   :: (Is k A_Setter, CheckIndices "iset" 1 i is)
@@ -45,6 +57,14 @@ iset
   -> (i -> b) -> s -> t
 iset o f = iover o (\i _ -> f i)
 {-# INLINE iset #-}
+
+-- | Apply an indexed setter, strictly.
+iset'
+  :: (Is k A_Setter, CheckIndices "iset'" 1 i is)
+  => Optic k is s t a b
+  -> (i -> b) -> s -> t
+iset' o f = iover' o (\i _ -> f i)
+{-# INLINE iset' #-}
 
 -- | Build an indexed setter from a function to modify the element(s).
 isets

--- a/optics-core/src/Optics/IxSetter.hs
+++ b/optics-core/src/Optics/IxSetter.hs
@@ -45,9 +45,9 @@ iover'
   :: (Is k A_Setter, CheckIndices "iover'" 1 i is)
   => Optic k is s t a b
   -> (i -> a -> b) -> s -> t
-iover' o f = unwrapUnit' . runIxStar star id
+iover' o f = unwrapIdentity' . runIxStar star id
   where
-    star = getOptic (toIxSetter o) $ IxStar (\i -> wrapUnit' . f i)
+    star = getOptic (toIxSetter o) $ IxStar (\i -> wrapIdentity' . f i)
 {-# INLINE iover' #-}
 
 -- | Apply an indexed setter.

--- a/optics-core/src/Optics/Setter.hs
+++ b/optics-core/src/Optics/Setter.hs
@@ -61,7 +61,9 @@ over'
   :: Is k A_Setter
   => Optic k is s t a b
   -> (a -> b) -> s -> t
-over' o f = unwrapUnit' . runStar (getOptic (toSetter o) $ Star (wrapUnit' . f))
+over' o f = unwrapIdentity' . runStar star
+  where
+    star = getOptic (toSetter o) $ Star (wrapIdentity' . f)
 {-# INLINE over' #-}
 
 -- | Apply a setter.

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -324,6 +324,7 @@ import Data.Either.Optics as P
 --
 -- * Composition operator is '%'
 -- * 'view' is /smart/
+-- * 'set'' is a strict version of 'set', not 'set' for type-preserving optics
 -- * None of operators is exported from main module
 -- * All ordinary optics are index-preserving by default
 -- * Indexed optics interface is different (let's expand in own section, when the implementation is stabilised)


### PR DESCRIPTION
Addresses (1) and (2) of #115.

Should we have infix versions of `over'` and `set'` (`%!~` and `!~`)?