### PR TITLE
Port Zoom and Magnify from lens

### DIFF
--- a/optics-core/src/Optics/AffineFold.hs
+++ b/optics-core/src/Optics/AffineFold.hs
@@ -3,6 +3,7 @@ module Optics.AffineFold
   ( An_AffineFold
   , AffineFold
   , preview
+  , previews
   , afolding
   -- * Semigroup structure
   , afailing
@@ -25,7 +26,7 @@ toAffineFold
 toAffineFold = castOptic
 {-# INLINE toAffineFold #-}
 
--- | View through 'AffineFold'.
+-- | Retrieve the value targeted by an 'AffineFold'.
 --
 -- >>> let _Right = prism Right $ either (Left . Left) Right
 --
@@ -36,8 +37,13 @@ toAffineFold = castOptic
 -- Nothing
 --
 preview :: Is k An_AffineFold => Optic' k is s a -> s -> Maybe a
-preview o = runForgetM (getOptic (toAffineFold o) (ForgetM Just))
+preview o = previews o id
 {-# INLINE preview #-}
+
+-- | Retrieve a function of the value targeted by an 'AffineFold'.
+previews :: Is k An_AffineFold => Optic' k is s a -> (a -> r) -> s -> Maybe r
+previews o = \f -> runForgetM $ getOptic (toAffineFold o) $ ForgetM (Just . f)
+{-# INLINE previews #-}
 
 -- | Create an 'AffineFold' from a partial function.
 --

--- a/optics-core/src/Optics/Getter.hs
+++ b/optics-core/src/Optics/Getter.hs
@@ -3,6 +3,7 @@ module Optics.Getter
   , Getter
   , toGetter
   , view
+  , views
   , to
   , module Optics.Optic
   )
@@ -21,10 +22,15 @@ toGetter :: Is k A_Getter => Optic' k is s a -> Optic' A_Getter is s a
 toGetter = castOptic
 {-# INLINE toGetter #-}
 
--- | Apply a getter.
+-- | View the value pointed to by a getter.
 view :: Is k A_Getter => Optic' k is s a -> s -> a
-view o = runForget (getOptic (toGetter o) (Forget id))
+view o = views o id
 {-# INLINE view #-}
+
+-- | View the function of the value pointed to by a getter.
+views :: Is k A_Getter => Optic' k is s a -> (a -> r) -> s -> r
+views o = \f -> runForget $ getOptic (toGetter o) (Forget f)
+{-# INLINE views #-}
 
 -- | Build a getter from a function.
 to :: (s -> a) -> Getter s a

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -39,6 +39,9 @@ library
                    Optics.Empty
                    Optics.Indexed
                    Optics.Operators.State
+                   Optics.Passthrough
+                   Optics.View
+                   Optics.Zoom
 
   exposed-modules: Data.ByteString.Lazy.Optics
                    Data.ByteString.Optics
@@ -48,12 +51,11 @@ library
                    Data.Text.Strict.Optics
                    Data.Vector.Generic.Optics
                    Data.Vector.Optics
-                   Optics.Passthrough
-                   Optics.View
 
   -- internal modules
   exposed-modules: Optics.Extra.Internal.ByteString
                    Optics.Extra.Internal.Vector
+                   Optics.Extra.Internal.Zoom
 
   default-extensions:
     BangPatterns

--- a/optics-extra/src/Optics/Extra.hs
+++ b/optics-extra/src/Optics/Extra.hs
@@ -10,3 +10,5 @@ import Optics.Cons    as O
 import Optics.Each    as O
 import Optics.Empty   as O
 import Optics.Indexed as O
+import Optics.View    as O
+import Optics.Zoom    as O

--- a/optics-extra/src/Optics/Extra/Internal/Zoom.hs
+++ b/optics-extra/src/Optics/Extra/Internal/Zoom.hs
@@ -1,0 +1,127 @@
+module Optics.Extra.Internal.Zoom
+  (
+  -- * Zoom
+    Focusing(..)
+  , FocusingWith(..)
+  , May(..)
+  , Err(..)
+  -- * Magnify
+  , Effect(..)
+  , EffectRWS(..)
+  ) where
+
+import qualified Data.Semigroup as SG
+
+-- | Used by 'Optics.Zoom.Zoom' to 'Optics.Zoom.zoom' into
+-- 'Control.Monad.State.StateT'.
+newtype Focusing m c s = Focusing { unfocusing :: m (c, s) }
+
+instance Monad m => Functor (Focusing m c) where
+  fmap f (Focusing m) = Focusing $ do
+     (c, s) <- m
+     pure (c, f s)
+  {-# INLINE fmap #-}
+
+instance (Monad m, Monoid s) => Applicative (Focusing m s) where
+  pure s = Focusing $ pure (mempty, s)
+  Focusing mf <*> Focusing ms = Focusing $ do
+    (c, f) <- mf
+    (c', s) <- ms
+    pure (c `mappend` c', f s)
+  {-# INLINE pure #-}
+  {-# INLINE (<*>) #-}
+
+----------------------------------------
+
+-- | Used by 'Optics.Zoom.Zoom' to 'Optics.Zoom.zoom' into
+-- 'Control.Monad.RWS.RWST'.
+newtype FocusingWith w m c s = FocusingWith { unfocusingWith :: m (c, s, w) }
+
+instance Monad m => Functor (FocusingWith w m s) where
+  fmap f (FocusingWith m) = FocusingWith $ do
+     (c, s, w) <- m
+     pure (c, f s, w)
+  {-# INLINE fmap #-}
+
+instance (Monad m, Monoid s, Monoid w) => Applicative (FocusingWith w m s) where
+  pure s = FocusingWith $ pure (mempty, s, mempty)
+  FocusingWith mf <*> FocusingWith ms = FocusingWith $ do
+    (c, f, w) <- mf
+    (c', s, w') <- ms
+    pure (c `mappend` c', f s, w `mappend` w')
+  {-# INLINE pure #-}
+  {-# INLINE (<*>) #-}
+
+----------------------------------------
+
+-- | Make a 'Monoid' out of 'Maybe' for error handling.
+newtype May a = May { getMay :: Maybe a }
+
+instance SG.Semigroup a => SG.Semigroup (May a) where
+  May (Just a) <> May (Just b) = May $ Just (a SG.<> b)
+  _            <> _            = May Nothing
+  {-# INLINE (<>) #-}
+
+instance Monoid a => Monoid (May a) where
+  mempty = May $ Just mempty
+  May (Just a) `mappend` May (Just b) = May $ Just (a `mappend` b)
+  _            `mappend` _            = May Nothing
+  {-# INLINE mempty #-}
+  {-# INLINE mappend #-}
+
+----------------------------------------
+
+-- | Make a 'Monoid' out of 'Either' for error handling.
+newtype Err e a = Err { getErr :: Either e a }
+
+instance SG.Semigroup a => SG.Semigroup (Err e a) where
+  Err (Right a) <> Err (Right b) = Err $ Right (a SG.<> b)
+  Err (Left e)  <> _             = Err $ Left e
+  _             <> Err (Left e)  = Err $ Left e
+  {-# INLINE (<>) #-}
+
+instance Monoid a => Monoid (Err e a) where
+  mempty = Err $ Right mempty
+  Err (Right a) `mappend` Err (Right b) = Err $ Right (a `mappend` b)
+  Err (Left e)  `mappend` _             = Err $ Left e
+  _             `mappend` Err (Left e)  = Err $ Left e
+  {-# INLINE mempty #-}
+  {-# INLINE mappend #-}
+
+----------------------------------------
+
+-- | Wrap a monadic effect.
+newtype Effect m r = Effect { getEffect :: m r }
+
+instance (Monad m, SG.Semigroup r) => SG.Semigroup (Effect m r) where
+  Effect ma <> Effect mb = Effect $ (SG.<>) <$> ma <*> mb
+  {-# INLINE (<>) #-}
+
+instance (Monad m, Monoid r) => Monoid (Effect m r) where
+  mempty = Effect $ pure mempty
+  Effect ma `mappend` Effect mb = Effect $ mappend <$> ma <*> mb
+  {-# INLINE mempty #-}
+  {-# INLINE mappend #-}
+
+----------------------------------------
+
+-- | Wrap a monadic effect. Used when magnifying 'Control.Monad.RWS.RWST'.
+newtype EffectRWS w s m c = EffectRWS { getEffectRWS :: s -> m (c, s, w) }
+
+instance
+  (SG.Semigroup c, SG.Semigroup w, Monad m
+  ) => SG.Semigroup (EffectRWS w s m c) where
+  EffectRWS ma <> EffectRWS mb = EffectRWS $ \s -> do
+    (c, s', w)    <- ma s
+    (c', s'', w') <- mb s'
+    pure (c SG.<> c', s'', w SG.<> w')
+  {-# INLINE (<>) #-}
+
+instance (Monoid c, Monoid w, Monad m) => Monoid (EffectRWS w s m c) where
+  mempty  = EffectRWS $ \s -> pure (mempty, s, mempty)
+  EffectRWS ma `mappend` EffectRWS mb = EffectRWS $ \s -> do
+    (c, s', w)    <- ma s
+    (c', s'', w') <- mb s'
+    pure (c `mappend` c', s'', w `mappend` w')
+  {-# INLINE mempty #-}
+  {-# INLINE mappend #-}

--- a/optics-extra/src/Optics/View.hs
+++ b/optics-extra/src/Optics/View.hs
@@ -39,71 +39,71 @@ class ViewableOptic k r where
 
 instance ViewableOptic An_Equality r where
   type ViewResult An_Equality r = r
-  gview      = asks . view
-  gviews o f = f <$> asks (view o)
+  gview    = asks . view
+  gviews o = asks . views o
   {-# INLINE gview #-}
   {-# INLINE gviews #-}
 
 instance ViewableOptic An_Iso r where
   type ViewResult An_Iso r = r
-  gview      = asks . view
-  gviews o f = f <$> asks (view o)
+  gview    = asks . view
+  gviews o = asks . views o
   {-# INLINE gview #-}
   {-# INLINE gviews #-}
 
 instance ViewableOptic A_Lens r where
   type ViewResult A_Lens r = r
-  gview      = asks . view
-  gviews o f = f <$> asks (view o)
+  gview    = asks . view
+  gviews o = asks . views o
   {-# INLINE gview #-}
   {-# INLINE gviews #-}
 
 instance ViewableOptic A_PrismaticGetter r where
   type ViewResult A_PrismaticGetter r = r
-  gview      = asks . view
-  gviews o f = f <$> asks (view o)
+  gview    = asks . view
+  gviews o = asks . views o
   {-# INLINE gview #-}
   {-# INLINE gviews #-}
 
 instance ViewableOptic A_Getter r where
   type ViewResult A_Getter r = r
-  gview      = asks . view
-  gviews o f = f <$> asks (view o)
+  gview    = asks . view
+  gviews o = asks . views o
   {-# INLINE gview #-}
   {-# INLINE gviews #-}
 
 instance ViewableOptic A_Prism r where
   type ViewResult A_Prism r = Maybe r
-  gview      = asks . preview
-  gviews o f = fmap f <$> asks (preview o)
+  gview    = asks . preview
+  gviews o = asks . previews o
   {-# INLINE gview #-}
   {-# INLINE gviews #-}
 
 instance ViewableOptic An_AffineTraversal r where
   type ViewResult An_AffineTraversal r = Maybe r
-  gview      = asks . preview
-  gviews o f = fmap f <$> asks (preview o)
+  gview    = asks . preview
+  gviews o = asks . previews o
   {-# INLINE gview #-}
   {-# INLINE gviews #-}
 
 instance ViewableOptic An_AffineFold r where
   type ViewResult An_AffineFold r = Maybe r
-  gview      = asks . preview
-  gviews o f = fmap f <$> asks (preview o)
+  gview    = asks . preview
+  gviews o = asks . previews o
   {-# INLINE gview #-}
   {-# INLINE gviews #-}
 
 instance Monoid r => ViewableOptic A_Traversal r where
   type ViewResult A_Traversal r = r
-  gview      = asks . foldOf
-  gviews o f = asks (foldMapOf o f)
+  gview    = asks . foldOf
+  gviews o = asks . foldMapOf o
   {-# INLINE gview #-}
   {-# INLINE gviews #-}
 
 instance Monoid r => ViewableOptic A_Fold r where
   type ViewResult A_Fold r = r
-  gview      = asks . foldOf
-  gviews o f = asks (foldMapOf o f)
+  gview    = asks . foldOf
+  gviews o = asks . foldMapOf o
   {-# INLINE gview #-}
   {-# INLINE gviews #-}
 

--- a/optics-extra/src/Optics/Zoom.hs
+++ b/optics-extra/src/Optics/Zoom.hs
@@ -1,0 +1,398 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
+module Optics.Zoom
+  ( Magnify(..)
+  , Zoom(..)
+  ) where
+
+import Control.Monad.Reader
+import Control.Monad.State
+import Control.Monad.Trans.Error
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.Identity
+import Control.Monad.Trans.List
+import Control.Monad.Trans.Maybe
+import Control.Monad.Trans.RWS.Lazy as L
+import Control.Monad.Trans.RWS.Strict as S
+import Control.Monad.Trans.State.Lazy as L
+import Control.Monad.Trans.State.Strict as S
+import Control.Monad.Trans.Writer.Lazy as L
+import Control.Monad.Trans.Writer.Strict as S
+import Data.Coerce
+import Data.Monoid
+
+import Optics.Core
+import Optics.Internal.Utils
+import Optics.Extra.Internal.Zoom
+
+-- $setup
+-- >>> import Optics.Core
+-- >>> import Optics.Operators.State
+-- >>> import Control.Monad.State
+-- >>> import Data.Map as Map
+-- >>> import Debug.SimpleReflect.Expr as Expr
+-- >>> import Debug.SimpleReflect.Vars as Vars
+-- >>> let f :: Expr -> Expr; f = Debug.SimpleReflect.Vars.f
+-- >>> let g :: Expr -> Expr; g = Debug.SimpleReflect.Vars.g
+-- >>> let h :: Expr -> Expr -> Expr; h = Debug.SimpleReflect.Vars.h
+
+-- Chosen so that they have lower fixity than ('%=').
+infixr 2 `zoom`, `zoomMaybe`, `zoomMany`
+infixr 2 `magnify`, `magnifyMaybe`, `magnifyMany`
+
+------------------------------------------------------------------------------
+-- Zoom
+------------------------------------------------------------------------------
+
+-- | This class allows us to 'zoom' in, changing the 'State' supplied by many
+-- different monad transformers, potentially quite deep in a monad transformer
+-- stack.
+--
+-- Its functions can be used to run a monadic action in a larger 'State' than it
+-- was defined in, using a 'Lens'', an 'AffineTraversal'' or a 'Traversal''.
+--
+-- This is commonly used to lift actions in a simpler 'State' 'Monad' into a
+-- 'State' 'Monad' with a larger 'State' type.
+--
+-- When used with a 'Traversal'' over multiple values, the actions for each
+-- target are executed sequentially and the results are aggregated.
+--
+-- This can be used to edit pretty much any 'Monad' transformer stack with a
+-- 'State' in it!
+--
+-- >>> flip evalState (a,b) $ zoom _1 $ use equality
+-- a
+--
+-- >>> flip execState (a,b) $ zoom _1 $ equality .= c
+-- (c,b)
+--
+-- >>> flip execState [(a,b),(c,d)] $ zoomMany traversed $ _2 %= f
+-- [(a,f b),(c,f d)]
+--
+-- >>> flip unState [(a,b),(c,d)] $ zoomMany traversed $ _2 <%= f
+-- (f b <> f d <> mempty,[(a,f b),(c,f d)])
+--
+-- >>> flip evalState (a,b) $ zoomMany each (use equality)
+-- a <> b
+--
+class
+  (MonadState s m, MonadState t n
+  ) => Zoom m n s t | m -> s, n -> t, m t -> n, n s -> m where
+  zoom
+    :: Is k A_Lens
+    => Optic' k is t s
+    -> m c
+    -> n c
+
+  zoomMaybe
+    :: Is k An_AffineTraversal
+    => Optic' k is t s
+    -> m c
+    -> n (Maybe c)
+
+  zoomMany
+    :: (Is k A_Traversal, Monoid c)
+    => Optic' k is t s
+    -> m c
+    -> n c
+
+instance Monad m => Zoom (S.StateT s m) (S.StateT t m) s t where
+  zoom      o = \(S.StateT m) -> S.StateT $ stateZoom      o m
+  zoomMaybe o = \(S.StateT m) -> S.StateT $ stateZoomMaybe o m
+  zoomMany  o = \(S.StateT m) -> S.StateT $ stateZoomMany  o m
+  {-# INLINE zoom #-}
+  {-# INLINE zoomMaybe #-}
+  {-# INLINE zoomMany #-}
+
+instance Monad m => Zoom (L.StateT s m) (L.StateT t m) s t where
+  zoom      o = \(L.StateT m) -> L.StateT $ stateZoom      o m
+  zoomMaybe o = \(L.StateT m) -> L.StateT $ stateZoomMaybe o m
+  zoomMany  o = \(L.StateT m) -> L.StateT $ stateZoomMany  o m
+  {-# INLINE zoom #-}
+  {-# INLINE zoomMaybe #-}
+  {-# INLINE zoomMany #-}
+
+instance Zoom m n s t => Zoom (ReaderT e m) (ReaderT e n) s t where
+  zoom      o = \(ReaderT m) -> ReaderT (zoom      o . m)
+  zoomMaybe o = \(ReaderT m) -> ReaderT (zoomMaybe o . m)
+  zoomMany  o = \(ReaderT m) -> ReaderT (zoomMany  o . m)
+  {-# INLINE zoom #-}
+  {-# INLINE zoomMaybe #-}
+  {-# INLINE zoomMany #-}
+
+instance Zoom m n s t => Zoom (IdentityT m) (IdentityT n) s t where
+  zoom      o = \(IdentityT m) -> IdentityT (zoom      o m)
+  zoomMaybe o = \(IdentityT m) -> IdentityT (zoomMaybe o m)
+  zoomMany  o = \(IdentityT m) -> IdentityT (zoomMany  o m)
+  {-# INLINE zoom #-}
+  {-# INLINE zoomMaybe #-}
+  {-# INLINE zoomMany #-}
+
+instance (Monoid w, Monad m) => Zoom (S.RWST r w s m) (S.RWST r w t m) s t where
+  zoom      o = \(S.RWST m) -> S.RWST $ rwsZoom      o m
+  zoomMaybe o = \(S.RWST m) -> S.RWST $ rwsZoomMaybe o m
+  zoomMany  o = \(S.RWST m) -> S.RWST $ rwsZoomMany  o m
+  {-# INLINE zoom #-}
+  {-# INLINE zoomMaybe #-}
+  {-# INLINE zoomMany #-}
+
+instance (Monoid w, Monad m) => Zoom (L.RWST r w s m) (L.RWST r w t m) s t where
+  zoom      o = \(L.RWST m) -> L.RWST $ rwsZoom      o m
+  zoomMaybe o = \(L.RWST m) -> L.RWST $ rwsZoomMaybe o m
+  zoomMany  o = \(L.RWST m) -> L.RWST $ rwsZoomMany  o m
+  {-# INLINE zoom #-}
+  {-# INLINE zoomMaybe #-}
+  {-# INLINE zoomMany #-}
+
+instance (Monoid w, Zoom m n s t) => Zoom (S.WriterT w m) (S.WriterT w n) s t where
+  zoom      o = S.WriterT #.                 zoom      o .# S.runWriterT
+  zoomMaybe o = S.WriterT #. fmap shuffleW . zoomMaybe o .# S.runWriterT
+  zoomMany  o = S.WriterT #.                 zoomMany  o .# S.runWriterT
+  {-# INLINE zoom #-}
+  {-# INLINE zoomMaybe #-}
+  {-# INLINE zoomMany #-}
+
+instance (Monoid w, Zoom m n s t) => Zoom (L.WriterT w m) (L.WriterT w n) s t where
+  zoom      o = L.WriterT #.                 zoom      o .# L.runWriterT
+  zoomMaybe o = L.WriterT #. fmap shuffleW . zoomMaybe o .# L.runWriterT
+  zoomMany  o = L.WriterT #.                 zoomMany  o .# L.runWriterT
+  {-# INLINE zoom #-}
+  {-# INLINE zoomMaybe #-}
+  {-# INLINE zoomMany #-}
+
+instance Zoom m n s t => Zoom (ListT m) (ListT n) s t where
+  zoom      o = ListT #.                  zoom      o .# runListT
+  zoomMaybe o = ListT #. fmap sequenceA . zoomMaybe o .# runListT
+  zoomMany  o = ListT #.                  zoomMany  o .# runListT
+  {-# INLINE zoom #-}
+  {-# INLINE zoomMaybe #-}
+  {-# INLINE zoomMany #-}
+
+instance Zoom m n s t => Zoom (MaybeT m) (MaybeT n) s t where
+  zoom o =
+    MaybeT #. zoom o .# runMaybeT
+  zoomMaybe o =
+    MaybeT #. fmap (getMay . shuffleMay) . zoomMaybe o . fmap May .# runMaybeT
+  zoomMany o =
+    MaybeT #. fmap getMay . zoomMany o . fmap May .# runMaybeT
+  {-# INLINE zoom #-}
+  {-# INLINE zoomMaybe #-}
+  {-# INLINE zoomMany #-}
+
+instance (Error e, Zoom m n s t) => Zoom (ErrorT e m) (ErrorT e n) s t where
+  zoom o =
+    ErrorT #. zoom o .# runErrorT
+  zoomMaybe o =
+    ErrorT #. fmap (getErr . shuffleErr) . zoomMaybe o . fmap Err .# runErrorT
+  zoomMany o =
+    ErrorT #. fmap getErr . zoomMany o . fmap Err .# runErrorT
+  {-# INLINE zoom #-}
+  {-# INLINE zoomMaybe #-}
+  {-# INLINE zoomMany #-}
+
+instance Zoom m n s t => Zoom (ExceptT e m) (ExceptT e n) s t where
+  zoom o =
+    ExceptT #. zoom o .# runExceptT
+  zoomMaybe o =
+    ExceptT #. fmap (getErr . shuffleErr) . zoomMaybe o . fmap Err .# runExceptT
+  zoomMany o =
+    ExceptT #. fmap getErr . zoomMany o . fmap Err .# runExceptT
+  {-# INLINE zoom #-}
+  {-# INLINE zoomMaybe #-}
+  {-# INLINE zoomMany #-}
+
+-- TODO: instance Zoom m m a a => Zoom (ContT r m) (ContT r m) a a where
+
+----------------------------------------
+-- Zoom helpers
+
+stateZoom
+  :: (Is k A_Lens, Monad m)
+  => Optic' k is t s
+  -> (s -> m (c, s))
+  -> (t -> m (c, t))
+stateZoom o m = unfocusing #. toLensVL o (Focusing #. m)
+
+stateZoomMaybe
+  :: (Is k An_AffineTraversal, Monad m)
+  => Optic' k is t s
+  -> (s -> m (c, s))
+  -> (t -> m (Maybe c, t))
+stateZoomMaybe o m =
+     fmap (coerce :: (First c, t) -> (Maybe c, t))
+  .  unfocusing
+  #. traverseOf (toAffineTraversal o)
+                (Focusing #. over (mapped % _1) (First #. Just) . m)
+
+stateZoomMany
+  :: (Is k A_Traversal, Monad m, Monoid c)
+  => Optic' k is t s
+  -> (s -> m (c, s))
+  -> (t -> m (c, t))
+stateZoomMany o m = unfocusing #. traverseOf o (Focusing #. m)
+
+rwsZoom
+  :: (Is k A_Lens, Monad m)
+  => Optic' k is t s
+  -> (r -> s -> m (c, s, w))
+  -> (r -> t -> m (c, t, w))
+rwsZoom o m r = unfocusingWith #. toLensVL o (FocusingWith #. m r)
+
+rwsZoomMaybe
+  :: (Is k An_AffineTraversal, Monad m, Monoid w)
+  => Optic' k is t s
+  -> (r -> s -> m (c, s, w))
+  -> (r -> t -> m (Maybe c, t, w))
+rwsZoomMaybe o m r =
+     fmap (coerce :: (First c, t, w) -> (Maybe c, t, w))
+  .  unfocusingWith
+  #. traverseOf (toAffineTraversal o)
+                (FocusingWith #. over (mapped % _1) (First #. Just) . m r)
+
+rwsZoomMany
+  :: (Is k A_Traversal, Monad m, Monoid w, Monoid c)
+  => Optic' k is t s
+  -> (r -> s -> m (c, s, w))
+  -> (r -> t -> m (c, t, w))
+rwsZoomMany o m r = unfocusingWith #. traverseOf o (FocusingWith #. m r)
+
+shuffleW :: Monoid w => Maybe (c, w) -> (Maybe c, w)
+shuffleW = maybe (Nothing, mempty) (over _1 Just)
+
+shuffleMay :: Maybe (May c) -> May (Maybe c)
+shuffleMay = \case
+  Nothing      -> May (Just Nothing)
+  Just (May c) -> May (Just <$> c)
+
+shuffleErr :: Maybe (Err e c) -> Err e (Maybe c)
+shuffleErr = \case
+  Nothing       -> Err (Right Nothing)
+  Just (Err ec) -> Err (Just <$> ec)
+
+------------------------------------------------------------------------------
+-- Magnify
+------------------------------------------------------------------------------
+
+-- | This class allows us to 'magnify' part of the environment, changing the
+-- environment supplied by many different 'Monad' transformers. Unlike 'zoom'
+-- this can change the environment of a deeply nested 'Monad' transformer.
+--
+-- Its functions can be used to run a monadic action in a larger environment
+-- than it was defined in, using a 'Getter'', an 'AffineFold'' or a 'Fold''.
+--
+-- They act like 'Control.Monad.Reader.Class.local', but can in many cases
+-- change the type of the environment as well.
+--
+-- They're commonly used to lift actions in a simpler 'Reader' 'Monad' into a
+-- 'Monad' with a larger environment type.
+--
+-- When used with a 'Fold'' over multiple values, the actions for each target
+-- are executed sequentially and the results are aggregated.
+--
+-- They can be used to edit pretty much any 'Monad' transformer stack with an
+-- environment in it:
+--
+-- >>> (1,2) & magnify _2 (+1)
+-- 3
+--
+-- >>> flip runReader (1,2) $ magnify _1 ask
+-- 1
+--
+-- >>> flip runReader (1,2,[10..20]) $ magnifyMaybe (_3 % _tail) ask
+-- Just [11,12,13,14,15,16,17,18,19,20]
+--
+class
+  (MonadReader b m, MonadReader a n
+  ) => Magnify m n b a | m -> b, n -> a, m a -> n, n b -> m where
+  magnify
+    :: Is k A_Getter
+    => Optic' k is a b
+    -> m c
+    -> n c
+
+  magnifyMaybe
+    :: Is k An_AffineFold
+    => Optic' k is a b
+    -> m c
+    -> n (Maybe c)
+
+  magnifyMany
+    :: (Is k A_Fold, Monoid c)
+    => Optic' k is a b
+    -> m c
+    -> n c
+
+-- | @
+-- 'magnify'      = 'views'
+-- 'magnifyMaybe' = 'previews'
+-- 'magnifyMany'  = 'foldMapOf'
+-- @
+instance Magnify ((->) b) ((->) a) b a where
+  magnify      = views
+  magnifyMaybe = previews
+  magnifyMany  = foldMapOf
+  {-# INLINE magnify #-}
+  {-# INLINE magnifyMaybe #-}
+  {-# INLINE magnifyMany #-}
+
+instance Monad m => Magnify (ReaderT b m) (ReaderT a m) b a where
+  magnify o = \(ReaderT m) ->
+    ReaderT $ \r -> getEffect (views o (Effect #. m) r)
+  magnifyMaybe o = \(ReaderT m) ->
+    ReaderT $ \r -> traverse getEffect (previews o (Effect #. m) r)
+  magnifyMany o = \(ReaderT m) ->
+    ReaderT $ \r -> getEffect (foldMapOf o (Effect #. m) r)
+  {-# INLINE magnify #-}
+  {-# INLINE magnifyMaybe #-}
+  {-# INLINE magnifyMany #-}
+
+instance (Monad m, Monoid w) => Magnify (S.RWST b w s m) (S.RWST a w s m) b a where
+  magnify      o = \(S.RWST m) -> S.RWST $ rwsMagnify      o m
+  magnifyMaybe o = \(S.RWST m) -> S.RWST $ rwsMagnifyMaybe o m
+  magnifyMany  o = \(S.RWST m) -> S.RWST $ rwsMagnifyMany  o m
+  {-# INLINE magnify #-}
+  {-# INLINE magnifyMaybe #-}
+  {-# INLINE magnifyMany #-}
+
+instance (Monad m, Monoid w) => Magnify (L.RWST b w s m) (L.RWST a w s m) b a where
+  magnify      o = \(L.RWST m) -> L.RWST $ rwsMagnify      o m
+  magnifyMaybe o = \(L.RWST m) -> L.RWST $ rwsMagnifyMaybe o m
+  magnifyMany  o = \(L.RWST m) -> L.RWST $ rwsMagnifyMany  o m
+  {-# INLINE magnify #-}
+  {-# INLINE magnifyMaybe #-}
+  {-# INLINE magnifyMany #-}
+
+instance Magnify m n b a => Magnify (IdentityT m) (IdentityT n) b a where
+  magnify      o = \(IdentityT m) -> IdentityT (magnify      o m)
+  magnifyMaybe o = \(IdentityT m) -> IdentityT (magnifyMaybe o m)
+  magnifyMany  o = \(IdentityT m) -> IdentityT (magnifyMany  o m)
+  {-# INLINE magnify #-}
+  {-# INLINE magnifyMaybe #-}
+  {-# INLINE magnifyMany #-}
+
+----------------------------------------
+-- Magnify helpers
+
+rwsMagnify
+  :: Is k A_Getter
+  => Optic' k is a b
+  -> (b -> s -> f (c, s, w))
+  -> (a -> s -> f (c, s, w))
+rwsMagnify o m = getEffectRWS #. views o (EffectRWS #. m)
+
+rwsMagnifyMaybe
+  :: (Is k An_AffineFold, Applicative m, Monoid w)
+  => Optic' k is a b
+  -> (b -> s -> m (c, s, w))
+  -> (a -> s -> m (Maybe c, s, w))
+rwsMagnifyMaybe o m r s = maybe
+  (pure (Nothing, s, mempty))
+  (\e -> over (mapped % _1) Just $ getEffectRWS e s)
+  (previews o (EffectRWS #. m) r)
+
+rwsMagnifyMany
+  :: (Is k A_Fold, Monad m, Monoid w, Monoid c)
+  => Optic' k is a b
+  -> (b -> s -> m (c, s, w))
+  -> (a -> s -> m (c, s, w))
+rwsMagnifyMany o m = getEffectRWS #. foldMapOf o (EffectRWS #. m)

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -173,7 +173,7 @@ module Optics
   -- noIx (ifolded % simple)
   --   :: FoldableWithIndex i f => Optic A_Fold NoIx (f b) (f b) b b
   --
-  -- 'unIx' can erase all indices
+  -- 'noIx' can erase all indices
   --
   -- >>> :t noIx (ifolded % ifolded)
   -- noIx (ifolded % ifolded)
@@ -225,8 +225,14 @@ module Optics
   -- * Empty
   , module Optics.Empty
 
-  -- ** OverloadedLabels 
+  -- * View
+  , module Optics.View
 
+  -- * Zoom
+  , module Optics.Zoom
+
+  -- ** OverloadedLabels 
+  , module Optics.Labels
 
   -- * Optics for concrete base types
   , module P
@@ -255,7 +261,6 @@ import Optics.Fold            as O
 import Optics.Equality        as O
 import Optics.AffineTraversal as O
 import Optics.AffineFold      as O
-import Optics.View            as O
 
 -- Optics utilities
 import Optics.At
@@ -263,8 +268,10 @@ import Optics.Cons
 import Optics.Each
 import Optics.Empty
 import Optics.Indexed
+import Optics.Labels
 import Optics.Re
-import Optics.Labels ()
+import Optics.View
+import Optics.Zoom
 
 -- Optics for concrete base types
 


### PR DESCRIPTION
Fixes #103.

There are three variations of both functions:
- `zoom`/`magnify` for `Lens`/`Getter`
- `zoomMaybe`/`magnifyMaybe` for `AffineTraversal`/`AffineFold`
- `zoomMany`/`magnifyMany` for `Traversal`/`Fold`
