### PR TITLE
WIP: Docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,8 @@ optics
 ------
 
 [![Build Status](https://travis-ci.org/well-typed/optics.svg?branch=master)](https://travis-ci.org/well-typed/optics)
+[![Hackage](https://img.shields.io/hackage/v/optics.svg)](https://hackage.haskell.org/package/optics)
 
-Documentation in progress! For now, you can look at the [slides from the Haskell eXchange talk](Talk.pdf).
+This package provides optics (as in the @lens@ package) but encapsulates them in
+an abstract interface. See the Haddocks for the main Optics module for the
+documentation.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ optics
 [![Build Status](https://travis-ci.org/well-typed/optics.svg?branch=master)](https://travis-ci.org/well-typed/optics)
 [![Hackage](https://img.shields.io/hackage/v/optics.svg)](https://hackage.haskell.org/package/optics)
 
-This package provides optics (as in the @lens@ package) but encapsulates them in
-an abstract interface. See the Haddocks for the main Optics module for the
+This package provides optics (as in the
+[lens](http://hackage.haskell.org/package/lens) package) but encapsulates them
+in an abstract interface. See the Haddocks for the main `Optics` module for the
 documentation.

--- a/optics-core/src/Data/Map/Optics.hs
+++ b/optics-core/src/Data/Map/Optics.hs
@@ -78,7 +78,7 @@ toMapOf
 toMapOf o = ifoldMapOf o M.singleton
 {-# INLINE toMapOf #-}
 
--- | Strict version of 'at' for 'M.Map'.
+-- | Strict version of 'Optics.At.Core.at' for 'M.Map'.
 at' :: Ord k => k -> Lens' (M.Map k a) (Maybe a)
 at' k = lensVL $ \f s ->
 #if MIN_VERSION_containers(0,5,8)

--- a/optics-core/src/Data/Set/Optics.hs
+++ b/optics-core/src/Data/Set/Optics.hs
@@ -11,9 +11,9 @@ import Optics.Setter
 -- | This 'Setter' can be used to change the type of a 'Set' by mapping the
 -- elements to new values.
 --
--- Sadly, you can't create a valid 'Traversal' for a 'Set', but you can
--- manipulate it by reading using 'Optics.folded' and reindexing it via
--- 'setmapped'.
+-- Sadly, you can't create a valid 'Optics.Traversal.Traversal' for a
+-- 'Set', but you can manipulate it by reading using
+-- 'Optics.Fold.folded' and reindexing it via 'setmapped'.
 --
 -- >>> over setmapped (+1) (fromList [1,2,3,4])
 -- fromList [2,3,4,5]

--- a/optics-core/src/GHC/Generics/Optics.hs
+++ b/optics-core/src/GHC/Generics/Optics.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PolyKinds #-}
 -- | Note: "GHC.Generics" exports a number of names that collide with "Optics"
--- (at least 'to').
+-- (at least 'GHC.Generics.to').
 --
 -- You can use hiding or imports to mitigate this to an extent, and the
 -- following imports, represent a fair compromise for user code:

--- a/optics-core/src/Optics/AffineFold.hs
+++ b/optics-core/src/Optics/AffineFold.hs
@@ -1,4 +1,8 @@
--- | An 'AffineFold' is a 'Optics.Fold.Fold' that contains at most one
+-- |
+-- Module: Optics.AffineFold
+-- Description: A 'Optics.Fold.Fold' that contains at most one element.
+--
+-- An 'AffineFold' is a 'Optics.Fold.Fold' that contains at most one
 -- element, or a 'Optics.Getter.Getter' where the function may be
 -- partial.
 --

--- a/optics-core/src/Optics/AffineFold.hs
+++ b/optics-core/src/Optics/AffineFold.hs
@@ -1,12 +1,33 @@
--- | TODO: what's affine fold.
+-- | An 'AffineFold' is a 'Optics.Fold.Fold' that contains at most one
+-- element, or a 'Optics.Getter.Getter' where the function may be
+-- partial.
+--
 module Optics.AffineFold
-  ( An_AffineFold
-  , AffineFold
+  (
+  -- * Formation
+    AffineFold
+
+  -- * Introduction
+  , afolding
+
+  -- * Elimination
   , preview
   , previews
-  , afolding
+
+  -- * Computation
+  -- |
+  --
+  -- @
+  -- 'preview' ('afolding' f) ≡ f
+  -- @
+
   -- * Semigroup structure
   , afailing
+
+  -- * Subtyping
+  , An_AffineFold
+
+  -- * Re-exports
   , module Optics.Optic
   ) where
 
@@ -62,7 +83,7 @@ afolding f = Optic (contrabimap (\s -> maybe (Left s) Right (f s)) Left . right'
 -- >>> preview (ix 42 % re _Left `afailing` ix 2 % re _Right) [0,1,2,3]
 -- Just (Right 2)
 --
--- /Note:/ There is no 'summing' equivalent, because @asumming = afailing@.
+-- /Note:/ There is no 'Optics.Fold.summing' equivalent, because @asumming = afailing@.
 --
 afailing
   :: (Is k An_AffineFold, Is l An_AffineFold)

--- a/optics-core/src/Optics/AffineTraversal.hs
+++ b/optics-core/src/Optics/AffineTraversal.hs
@@ -1,14 +1,39 @@
+-- | An 'AffineTraversal' is a 'Optics.Traversal.Traversal' that
+-- applies to at most one element.
+--
+-- These arise most frequently as the composition of a
+-- 'Optics.Lens.Lens' with a 'Optics.Prism.Prism'.
+--
 module Optics.AffineTraversal
-  ( An_AffineTraversal
-  , AffineTraversal
+  (
+  -- * Formation
+    AffineTraversal
   , AffineTraversal'
-  , toAffineTraversal
+
+  -- * Introduction
   , atraversal
+
+  -- * Elimination
   , withAffineTraversal
+
+  -- * Computation
+  -- |
+  --
+  -- @
+  -- 'withAffineTraversal' ('atraversal' f g) k = k f g
+  -- @
+
+  -- * Subtyping
+  , An_AffineTraversal
+  , toAffineTraversal
+
+  -- * van Laarhoven encoding
   , AffineTraversalVL
   , AffineTraversalVL'
   , atraversalVL
   , toAtraversalVL
+
+  -- * Re-exports
   , module Optics.Optic
   )
   where
@@ -26,9 +51,18 @@ type AffineTraversal' s a = Optic' An_AffineTraversal NoIx s a
 
 -- | Type synonym for a type-modifying van Laarhoven affine traversal.
 --
--- Note: this isn't exactly van Laarhoven representation as there is no
--- @PointedFunctor@ class, but you can interpret the first argument as a
--- dictionary of 'Pointed' class that supplies the @point@ function.
+-- Note: this isn't exactly van Laarhoven representation as there is
+-- no @Pointed@ class (which would be a superclass of 'Applicative'
+-- that contains 'pure' but not '<*>'). You can interpret the first
+-- argument as a dictionary of @Pointed@ that supplies the @point@
+-- function (i.e. the implementation of 'pure').
+--
+-- A 'Optics.Traversal.TraversalVL' has 'Applicative' available and
+-- hence can combine the effects arising from multiple elements using
+-- '<*>'. In contrast, an 'AffineTraversalVL' has no way to combine
+-- effects from multiple elements, so it must act on at most one
+-- element.  (It can act on none at all thanks to the availability of
+-- @point@.)
 --
 type AffineTraversalVL s t a b =
   forall f. Functor f => (forall r. r -> f r) -> (a -> f b) -> s -> f t
@@ -55,7 +89,7 @@ atraversal match update = Optic $
   . right'
 {-# INLINE atraversal #-}
 
--- With with an affine traversal as a matcher and an updater.
+-- | Work with an affine traversal as a matcher and an updater.
 withAffineTraversal
   :: Is k An_AffineTraversal
   => Optic k is s t a b

--- a/optics-core/src/Optics/AffineTraversal.hs
+++ b/optics-core/src/Optics/AffineTraversal.hs
@@ -1,4 +1,8 @@
--- | An 'AffineTraversal' is a 'Optics.Traversal.Traversal' that
+-- |
+-- Module: Optics.AffineTraversal
+-- Description: A 'Optics.Traversal.Traversal' that applies to at most one element.
+--
+-- An 'AffineTraversal' is a 'Optics.Traversal.Traversal' that
 -- applies to at most one element.
 --
 -- These arise most frequently as the composition of a

--- a/optics-core/src/Optics/At/Core.hs
+++ b/optics-core/src/Optics/At/Core.hs
@@ -1,14 +1,41 @@
 {-# LANGUAGE CPP #-}
+-- |
+-- Module: Optics.At.Core
+-- Description: Optics for 'Map' and 'Set'-like containers.
+--
+-- This module provides optics for 'Map' and 'Set'-like containers, including an
+-- 'AffineTraversal' to traverse a key in a map or an element of a sequence:
+--
+-- >>> preview (ix 1) ['a','b','c']
+-- Just 'b'
+--
+-- a 'Lens' to get, set or delete a key in a map:
+--
+-- >>> set (at 0) (Just 'b') (Map.fromList [(0, 'a')])
+-- fromList [(0,'b')]
+--
+-- and a 'Lens' to insert or remove an element of a set:
+--
+-- >>> IntSet.fromList [1,2,3,4] & contains 3 .~ False
+-- fromList [1,2,4]
+--
+-- The @Optics.At@ module from @optics-extra@ provides additional instances of
+-- the classes defined here.
+--
 module Optics.At.Core
   (
-  -- * At
-    At(..)
-  , sans
-  -- * Ixed
-  , Index
+    -- * Type families
+    Index
   , IxValue
+
+    -- * Ixed
   , Ixed(ix)
   , ixAt
+
+    -- * At
+  , At(..)
+  , sans
+
   -- * Contains
   , Contains(..)
   ) where
@@ -30,6 +57,9 @@ import Optics.AffineTraversal
 import Optics.Lens
 import Optics.Setter
 
+-- | Type family that takes a key-value container type and returns the type of
+-- keys (indices) into the container, for example @'Index' ('Map' k a) ~ k@.
+-- This is shared by 'Ixed', 'At' and 'Contains'.
 type family Index (s :: *) :: *
 type instance Index (e -> a) = e
 type instance Index IntSet = Int
@@ -66,6 +96,7 @@ type instance Index (Tree a) = [Int]
 
 -- | This class provides a simple 'Lens' that lets you view (and modify)
 -- information about whether or not a container contains a given 'Index'.
+-- Instances are provided for 'Set'-like containers only.
 class Contains m where
   -- |
   -- >>> IntSet.fromList [1,2,3,4] ^. contains 3
@@ -88,8 +119,9 @@ instance Ord a => Contains (Set a) where
     if b then Set.insert k s else Set.delete k s
   {-# INLINE contains #-}
 
--- | This provides a common notion of a value at an index that is shared by both
--- 'Ixed' and 'At'.
+-- | Type family that takes a key-value container type and returns the type of
+-- values stored in the container, for example @'IxValue' ('Map' k a) ~ a@. This
+-- is shared by both 'Ixed' and 'At'.
 type family IxValue (m :: *) :: *
 
 -- | Provides a simple 'AffineTraversal' lets you traverse the value at a given

--- a/optics-core/src/Optics/At/Core.hs
+++ b/optics-core/src/Optics/At/Core.hs
@@ -197,8 +197,8 @@ instance Ixed IntSet where
 type instance IxValue (Array.Array i e) = e
 -- |
 -- @
--- arr '!' i ≡ arr '^.' 'ix' i
--- arr '//' [(i,e)] ≡ 'ix' i '.~' e '$' arr
+-- arr 'Array.!' i ≡ arr 'Optics.Operators.^.' 'ix' i
+-- arr '//' [(i,e)] ≡ 'ix' i 'Optics.Operators..~' e '$' arr
 -- @
 instance Ix i => Ixed (Array.Array i e) where
   ix i = atraversalVL $ \point f arr ->
@@ -210,8 +210,8 @@ instance Ix i => Ixed (Array.Array i e) where
 type instance IxValue (UArray i e) = e
 -- |
 -- @
--- arr '!' i ≡ arr '^.' 'ix' i
--- arr '//' [(i,e)] ≡ 'ix' i '.~' e '$' arr
+-- arr 'Array.!' i ≡ arr 'Optics.Operators.^.' 'ix' i
+-- arr '//' [(i,e)] ≡ 'ix' i 'Optics.Operators..~' e '$' arr
 -- @
 instance (IArray UArray e, Ix i) => Ixed (UArray i e) where
   ix i = atraversalVL $ \point f arr ->
@@ -351,7 +351,7 @@ class Ixed m => At m where
 -- | Delete the value associated with a key in a 'Map'-like container
 --
 -- @
--- 'sans' k = 'at' k .~ Nothing
+-- 'sans' k = 'at' k 'Optics.Operators..~' Nothing
 -- @
 sans :: At m => Index m -> m -> m
 sans k = set (at k) Nothing

--- a/optics-core/src/Optics/Coerce.hs
+++ b/optics-core/src/Optics/Coerce.hs
@@ -1,3 +1,16 @@
+-- | This module defines operations to 'coerce' the type parameters of optics to
+-- a representationally equal type.  For example, if we have
+--
+-- > newtype MkInt = MkInt Int
+--
+-- and
+--
+-- > l :: Lens' S Int
+--
+-- then
+--
+-- > coerceA @Int @MkInt l :: Lens' S MkInt
+--
 module Optics.Coerce
   ( coerceS
   , coerceT
@@ -11,7 +24,9 @@ import Data.Coerce
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
 
--- | 'coerceS'' with type arguments rearranged for TypeApplications.
+-- | Lift 'coerce' to the @s@ parameter of an optic.
+--
+-- This is 'coerceS'' with type arguments rearranged for TypeApplications.
 coerceS
   :: (Coercible s s', CoercibleOptic k)
   => Optic k is s  t a b
@@ -19,7 +34,9 @@ coerceS
 coerceS = coerceS'
 {-# INLINE coerceS #-}
 
--- | 'coerceT'' with type arguments rearranged for TypeApplications.
+-- | Lift 'coerce' to the @t@ parameter of an optic.
+--
+-- This is 'coerceT'' with type arguments rearranged for TypeApplications.
 coerceT
   :: (Coercible t t', CoercibleOptic k)
   => Optic k is s t  a b
@@ -27,7 +44,9 @@ coerceT
 coerceT = coerceT'
 {-# INLINE coerceT #-}
 
--- | 'coerceA'' with type arguments rearranged for TypeApplications.
+-- | Lift 'coerce' to the @a@ parameter of an optic.
+--
+-- This is 'coerceA'' with type arguments rearranged for TypeApplications.
 coerceA
   :: (Coercible a a', CoercibleOptic k)
   => Optic k is s t a  b
@@ -35,7 +54,9 @@ coerceA
 coerceA = coerceA'
 {-# INLINE coerceA #-}
 
--- | 'coerceB'' with type arguments rearranged for TypeApplications.
+-- | Lift 'coerce' to the @b@ parameter of an optic.
+--
+-- This is 'coerceB'' with type arguments rearranged for TypeApplications.
 coerceB
   :: (Coercible b b', CoercibleOptic k)
   => Optic k is s t a b
@@ -43,10 +64,19 @@ coerceB
 coerceB = coerceB'
 {-# INLINE coerceB #-}
 
+-- | Class for optics that makes it possible to lift 'coerce' through the type
+-- parameters of the optic.
 class CoercibleOptic k where
+  -- | Lift 'coerce' to the @s@ parameter of an optic.
   coerceS' :: Coercible s s' => Optic k is s t a b -> Optic k is s' t a b
+
+  -- | Lift 'coerce' to the @t@ parameter of an optic.
   coerceT' :: Coercible t t' => Optic k is s t a b -> Optic k is s t' a b
+
+  -- | Lift 'coerce' to the @a@ parameter of an optic.
   coerceA' :: Coercible a a' => Optic k is s t a b -> Optic k is s t a' b
+
+  -- | Lift 'coerce' to the @b@ parameter of an optic.
   coerceB' :: Coercible b b' => Optic k is s t a b -> Optic k is s t a b'
 
 instance CoercibleOptic An_Iso where

--- a/optics-core/src/Optics/Core.hs
+++ b/optics-core/src/Optics/Core.hs
@@ -8,23 +8,26 @@
 -- TODO: motivation behind @optics@
 --
 module Optics.Core
-  ( module O
+  (
+  -- * Kinds of optic
+    module O
+
+  -- * Indexed optics
+  , module I
+
+  -- * Operators
+  , module P
+
+  -- * Optics for basic data types
   , module D
   )
   where
 
 import Optics.AffineFold                       as O
 import Optics.AffineTraversal                  as O
-import Optics.Arrow                            as O
-import Optics.At.Core                          as O
-import Optics.Coerce                           as O
-import Optics.Cons.Core                        as O
-import Optics.Each.Core                        as O
-import Optics.Empty.Core                       as O
 import Optics.Equality                         as O
 import Optics.Fold                             as O
 import Optics.Getter                           as O
-import Optics.Indexed.Core                     as O
 import Optics.Iso                              as O
 import Optics.IxAffineFold                     as O
 import Optics.IxAffineTraversal                as O
@@ -35,10 +38,19 @@ import Optics.Lens                             as O
 import Optics.LensyReview                      as O
 import Optics.Prism                            as O
 import Optics.PrismaticGetter                  as O
-import Optics.Re                               as O
 import Optics.Review                           as O
 import Optics.Setter                           as O
 import Optics.Traversal                        as O
+
+import Optics.Indexed.Core                     as I
+
+import Optics.Arrow                            as P
+import Optics.At.Core                          as P
+import Optics.Coerce                           as P
+import Optics.Cons.Core                        as P
+import Optics.Each.Core                        as P
+import Optics.Empty.Core                       as P
+import Optics.Re                               as P
 
 import Data.Either.Optics                      as D
 import Data.Maybe.Optics                       as D

--- a/optics-core/src/Optics/Core.hs
+++ b/optics-core/src/Optics/Core.hs
@@ -1,11 +1,10 @@
 -- |
 --
 -- Module: Optics.Core
--- Description: The core @optics@ functionality re-exported.
+-- Description: The core optics functionality re-exported.
 --
--- Introduction...
---
--- TODO: motivation behind @optics@
+-- See the @Optics@ module in the main @optics@ package for overview
+-- documentation.
 --
 module Optics.Core
   (
@@ -15,7 +14,7 @@ module Optics.Core
   -- * Indexed optics
   , module I
 
-  -- * Operators
+  -- * Combinators
   , module P
 
   -- * Optics for basic data types

--- a/optics-core/src/Optics/Equality.hs
+++ b/optics-core/src/Optics/Equality.hs
@@ -1,3 +1,9 @@
+-- |
+-- Module: Optics.Equality
+-- Description: A proof of type equality.
+--
+-- An @'Equality' S T A B@ is a proof that @S@ is equal to @A@ and @T@ is equal
+-- to @B@.
 module Optics.Equality
   (
   -- * Formation
@@ -9,9 +15,20 @@ module Optics.Equality
   , simple
 
   -- * Elimination
-  , withEquality
+  -- | There are no optic kinds below 'Equality' in the subtyping poset, so the
+  -- elimination forms are not polymorphic in the optic kind.
   , Identical(..)
   , runEquality
+
+  -- * Computation
+  -- |
+  --
+  -- @
+  -- 'runEquality' 'equality' ≡ 'Identical'
+  -- @
+
+  -- * Additional elimination forms
+  , withEquality
 
   -- * Subtyping
   , An_Equality

--- a/optics-core/src/Optics/Equality.hs
+++ b/optics-core/src/Optics/Equality.hs
@@ -1,12 +1,22 @@
 module Optics.Equality
-  ( An_Equality
-  , Equality
+  (
+  -- * Formation
+    Equality
   , Equality'
+
+  -- * Introduction
   , equality
   , simple
+
+  -- * Elimination
   , withEquality
   , Identical(..)
   , runEquality
+
+  -- * Subtyping
+  , An_Equality
+
+  -- * Re-exports
   , module Optics.Optic
   )
   where

--- a/optics-core/src/Optics/Fold.hs
+++ b/optics-core/src/Optics/Fold.hs
@@ -428,8 +428,7 @@ sumOf :: (Is k A_Fold, Num a) => Optic' k is s a -> s -> a
 sumOf o = foldlOf' o (+) 0
 {-# INLINE sumOf #-}
 
--- | The sum of a collection of actions, generalizing 'concatOf'.
--- TODO: we don't yet have 'concatOf'!
+-- | The sum of a collection of actions.
 --
 -- >>> asumOf both ("hello","world")
 -- "helloworld"
@@ -444,7 +443,7 @@ asumOf :: (Is k A_Fold, Alternative f) => Optic' k is s (f a) -> s -> f a
 asumOf o = foldrOf o (<|>) empty
 {-# INLINE asumOf #-}
 
--- | The sum of a collection of actions, generalizing 'concatOf'.
+-- | The sum of a collection of actions.
 --
 -- >>> msumOf both ("hello","world")
 -- "helloworld"

--- a/optics-core/src/Optics/Fold.hs
+++ b/optics-core/src/Optics/Fold.hs
@@ -1,4 +1,8 @@
--- | A @'Fold' S A@ has the ability to extract some number of elements
+-- |
+-- Module: Optics.Fold
+-- Description: Extracts elements from a container.
+--
+-- A @'Fold' S A@ has the ability to extract some number of elements
 -- of type @A@ from a container of type @S@.  For example, 'toListOf'
 -- can be used to obtain the contained elements as a list. Unlike a
 -- 'Optics.Traversal.Traversal', there is no way to set or update
@@ -33,21 +37,13 @@ module Optics.Fold
   -- 'traverseOf_' ('mkFold' f) ≡ f
   -- @
 
-  -- * Folds
+  -- * Additional introduction forms
   , folded
   , folding
   , foldring
   , unfolded
 
-  -- * Combinators
-  , filtered
-  , backwards_
-
-  -- * Semigroup structure
-  , summing
-  , failing
-
-  -- * Using folds
+  -- * Additional elimination forms
   , has
   , hasn't
   , headOf
@@ -71,6 +67,14 @@ module Optics.Fold
   , findOf
   , findMOf
   , lookupOf
+
+  -- * Combinators
+  , filtered
+  , backwards_
+
+  -- * Semigroup structure
+  , summing
+  , failing
 
   -- * Subtyping
   , A_Fold
@@ -146,7 +150,7 @@ toListOf o = foldrOf o (:) []
 
 ----------------------------------------
 
--- | Traverse over all of the targets of a 'Fold, computing an
+-- | Traverse over all of the targets of a 'Fold', computing an
 -- 'Applicative'-based answer, but unlike 'Optics.Traversal.traverseOf' do not
 -- construct a new structure. 'traverseOf_' generalizes
 -- 'Data.Foldable.traverse_' to work over any 'Fold'.

--- a/optics-core/src/Optics/Getter.hs
+++ b/optics-core/src/Optics/Getter.hs
@@ -1,10 +1,39 @@
+-- | A 'Getter' is simply a function considered as an 'Optic'.
+--
+-- Given a function @f :: S -> A@, we can convert it into a
+-- @'Getter' S A@ using 'to', and convert back to a function using 'view'.
+--
+-- This is typically useful not when you have functions/'Getter's
+-- alone, but when you are composing multiple 'Optic's to produce a
+-- 'Getter'.
+--
 module Optics.Getter
-  ( A_Getter
-  , Getter
-  , toGetter
+  (
+  -- * Formation
+   Getter
+
+  -- * Introduction
+  , to
+
+  -- * Elimination
   , view
   , views
-  , to
+
+  -- * Computation
+  -- |
+  --
+  -- @
+  -- 'view' ('to' f) = f
+  -- @
+
+  -- * Well-formedness
+  -- | A 'Getter' is not subject to any laws.
+
+  -- * Subtyping
+  , A_Getter
+  , toGetter
+
+  -- * Re-exports
   , module Optics.Optic
   )
   where

--- a/optics-core/src/Optics/Getter.hs
+++ b/optics-core/src/Optics/Getter.hs
@@ -1,6 +1,6 @@
 -- |
 -- Module: Optics.Getter
--- Description: A 'Getter' is simply a function considered as an 'Optic'.
+-- Description: A function considered as an 'Optic'.
 --
 -- A 'Getter' is simply a function considered as an 'Optic'.
 --

--- a/optics-core/src/Optics/Getter.hs
+++ b/optics-core/src/Optics/Getter.hs
@@ -1,4 +1,8 @@
--- | A 'Getter' is simply a function considered as an 'Optic'.
+-- |
+-- Module: Optics.Getter
+-- Description: A 'Getter' is simply a function considered as an 'Optic'.
+--
+-- A 'Getter' is simply a function considered as an 'Optic'.
 --
 -- Given a function @f :: S -> A@, we can convert it into a
 -- @'Getter' S A@ using 'to', and convert back to a function using 'view'.
@@ -23,7 +27,7 @@ module Optics.Getter
   -- |
   --
   -- @
-  -- 'view' ('to' f) = f
+  -- 'view' ('to' f) ≡ f
   -- @
 
   -- * Well-formedness

--- a/optics-core/src/Optics/Indexed/Core.hs
+++ b/optics-core/src/Optics/Indexed/Core.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE DataKinds #-}
+-- | TODO: discuss indexed optics in general
 module Optics.Indexed.Core
-  ( (<%>)
+  (
+  -- * Composition of indexed optics
+    (<%>)
   , (%>)
   , (<%)
   , reindexed
@@ -9,6 +12,10 @@ module Optics.Indexed.Core
   , icompose4
   , icompose5
   , IxOptic(..)
+
+  -- * Constraints
+  , HasSingleIndex
+  , NonEmptyIndices
   ) where
 
 import Optics.Internal.Indexed
@@ -134,7 +141,7 @@ class IxOptic k s t a b where
   -- when used without indices. Useful for defining indexed optics that are as
   -- efficient as their unindexed equivalents when used without indices.
   --
-  -- /Note:/ @conjoined f g@ is well-defined if and only if @f ≡ noIx g@.
+  -- /Note:/ @'conjoined' f g@ is well-defined if and only if @f ≡ 'noIx' g@.
   conjoined
     :: is `HasSingleIndex` i
     => Optic k NoIx s t a b

--- a/optics-core/src/Optics/Indexed/Core.hs
+++ b/optics-core/src/Optics/Indexed/Core.hs
@@ -1,9 +1,19 @@
 {-# LANGUAGE DataKinds #-}
--- | TODO: discuss indexed optics in general
+-- |
+-- Module: Optics.Indexed.Core
+-- Description: Core definitions for indexed optics.
+--
+-- This module defines basic functionality for indexed optics.  See the "Indexed
+-- optics" section of the overview documentation in the @Optics@ module of the
+-- main @optics@ package for more details.
+--
 module Optics.Indexed.Core
   (
+  -- * Class for optic kinds that can be indexed
+    IxOptic(..)
+
   -- * Composition of indexed optics
-    (<%>)
+  , (<%>)
   , (%>)
   , (<%)
   , reindexed
@@ -11,7 +21,6 @@ module Optics.Indexed.Core
   , icompose3
   , icompose4
   , icompose5
-  , IxOptic(..)
 
   -- * Constraints
   , HasSingleIndex

--- a/optics-core/src/Optics/Indexed/Core.hs
+++ b/optics-core/src/Optics/Indexed/Core.hs
@@ -123,6 +123,7 @@ icompose5 = icomposeN
 ----------------------------------------
 -- IxOptic
 
+-- | Class for optic kinds that can have indices.
 class IxOptic k s t a b where
   -- | Convert an indexed optic to its unindexed equivalent.
   noIx

--- a/optics-core/src/Optics/Internal/Bi.hs
+++ b/optics-core/src/Optics/Internal/Bi.hs
@@ -1,14 +1,22 @@
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | Classes for co- and contravariant bifunctors.
+--
+-- This module is intended for internal use only, and may change without warning
+-- in subsequent releases.
 module Optics.Internal.Bi where
 
 import Data.Void
 
 import Optics.Internal.Profunctor
 
+-- | Class for (covariant) bifunctors.
 class Bifunctor p where
   bimap  :: (a -> b) -> (c -> d) -> p i a c -> p i b d
   first  :: (a -> b)             -> p i a c -> p i b c
   second ::             (c -> d) -> p i a c -> p i a d
 
+-- | Class for contravariant bifunctors.
 class Bicontravariant p where
   contrabimap  :: (b -> a) -> (d -> c) -> p i a c -> p i b d
   contrafirst  :: (b -> a)             -> p i a c -> p i b c
@@ -48,10 +56,14 @@ instance Bicontravariant (IxForgetM r) where
 
 ----------------------------------------
 
+-- | If @p@ is a 'Profunctor' and a 'Bifunctor' then its left parameter must be
+-- phantom.
 lphantom :: (Profunctor p, Bifunctor p) => p i a c -> p i b c
 lphantom = first absurd . lmap absurd
 {-# INLINE lphantom #-}
 
+-- | If @p@ is a 'Profunctor' and 'Bicontravariant' then its right parameter
+-- must be phantom.
 rphantom :: (Profunctor p, Bicontravariant p) => p i c a -> p i c b
 rphantom = rmap absurd . contrasecond absurd
 {-# INLINE rphantom #-}

--- a/optics-core/src/Optics/Internal/Concrete.hs
+++ b/optics-core/src/Optics/Internal/Concrete.hs
@@ -1,3 +1,9 @@
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | Concrete representation types for certain optics.
+--
+-- This module is intended for internal use only, and may change without warning
+-- in subsequent releases.
 module Optics.Internal.Concrete
   ( Exchange(..)
   , Store(..)

--- a/optics-core/src/Optics/Internal/Fold.hs
+++ b/optics-core/src/Optics/Internal/Fold.hs
@@ -1,3 +1,9 @@
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | Internal implementation details of folds.
+--
+-- This module is intended for internal use only, and may change without warning
+-- in subsequent releases.
 module Optics.Internal.Fold where
 
 import Data.Functor

--- a/optics-core/src/Optics/Internal/Fold.hs
+++ b/optics-core/src/Optics/Internal/Fold.hs
@@ -9,7 +9,7 @@ import Optics.Internal.Bi
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
 
--- | Internal implementation of 'mkFold'.
+-- | Internal implementation of 'Optics.Fold.mkFold'.
 mkFold__
   :: (Bicontravariant p, Traversing p)
   => (forall f. Applicative f => (a -> f u) -> s -> f v)
@@ -17,14 +17,14 @@ mkFold__
 mkFold__ f = rphantom . wander f . rphantom
 {-# INLINE mkFold__ #-}
 
--- | Internal implementation of 'folded'.
+-- | Internal implementation of 'Optics.Fold.folded'.
 folded__
   :: (Bicontravariant p, Traversing p, Foldable f)
   => Optic__ p i i (f a) (f b) a b
 folded__ = mkFold__ traverse_
 {-# INLINE folded__ #-}
 
--- | Internal implementation of 'foldring'.
+-- | Internal implementation of 'Optics.Fold.foldring'.
 foldring__
   :: (Bicontravariant p, Traversing p)
   => (forall f. Applicative f => (a -> f u -> f u) -> f v -> s -> f w)

--- a/optics-core/src/Optics/Internal/Indexed.hs
+++ b/optics-core/src/Optics/Internal/Indexed.hs
@@ -2,6 +2,11 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK not-home #-}
+
+-- | Internal implementation details of indexed optics.
+--
+-- This module is intended for internal use only, and may change without warning
+-- in subsequent releases.
 module Optics.Internal.Indexed where
 
 import Control.Applicative

--- a/optics-core/src/Optics/Internal/Indexed.hs
+++ b/optics-core/src/Optics/Internal/Indexed.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_HADDOCK not-home #-}
 module Optics.Internal.Indexed where
 
 import Control.Applicative
@@ -128,7 +129,7 @@ indexing l iafb s =
 
 ----------------------------------------
 
--- | Internal implementation of 'conjoined'.
+-- | Internal implementation of 'Optics.Indexed.Core.conjoined'.
 conjoined__
   :: (Constraints k p, Visiting p, is `HasSingleIndex` i)
   => Optic k NoIx s t a b
@@ -262,7 +263,7 @@ instance TraversableWithIndex () Maybe where
 
 -- Seq
 
--- | The position in the 'Seq' is available as the index.
+-- | The position in the 'Seq.Seq' is available as the index.
 instance FunctorWithIndex Int Seq.Seq where
   imap = Seq.mapWithIndex
   {-# INLINE imap #-}

--- a/optics-core/src/Optics/Internal/IxFold.hs
+++ b/optics-core/src/Optics/Internal/IxFold.hs
@@ -9,7 +9,7 @@ import Optics.Internal.Profunctor
 import Optics.Internal.Optic
 import Optics.Internal.Fold
 
--- | Internal implementation of 'mkIxFold'.
+-- | Internal implementation of 'Optics.IxFold.mkIxFold'.
 mkIxFold__
   :: (Bicontravariant p, Traversing p)
   => (forall f. Applicative f => (i -> a -> f u) -> s -> f v)
@@ -17,14 +17,14 @@ mkIxFold__
 mkIxFold__ f = rphantom . iwander f . rphantom
 {-# INLINE mkIxFold__ #-}
 
--- | Internal implementation of 'ifolded'.
+-- | Internal implementation of 'Optics.IxFold.ifolded'.
 ifolded__
   :: (Bicontravariant p, Traversing p, FoldableWithIndex i f)
   => Optic__ p j (i -> j) (f a) t a b
 ifolded__ = conjoined' (mkFold__ traverse_) (mkIxFold__ itraverse_)
 {-# INLINE ifolded__ #-}
 
--- | Internal implementation of 'ifoldring'.
+-- | Internal implementation of 'Optics.IxFold.ifoldring'.
 ifoldring__
   :: (Bicontravariant p, Traversing p)
   => (forall f. Applicative f => (i -> a -> f u -> f u) -> f v -> s -> f w)

--- a/optics-core/src/Optics/Internal/IxFold.hs
+++ b/optics-core/src/Optics/Internal/IxFold.hs
@@ -1,3 +1,9 @@
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | Internal implementation details of indexed folds.
+--
+-- This module is intended for internal use only, and may change without warning
+-- in subsequent releases.
 module Optics.Internal.IxFold where
 
 import Data.Functor

--- a/optics-core/src/Optics/Internal/IxSetter.hs
+++ b/optics-core/src/Optics/Internal/IxSetter.hs
@@ -4,7 +4,7 @@ import Optics.Internal.Indexed
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
 
--- | Internal implementation of 'imapped'.
+-- | Internal implementation of 'Optics.IxSetter.imapped'.
 imapped__
   :: (Mapping p, FunctorWithIndex i f)
   => Optic__ p j (i -> j) (f a) (f b) a b

--- a/optics-core/src/Optics/Internal/IxSetter.hs
+++ b/optics-core/src/Optics/Internal/IxSetter.hs
@@ -1,3 +1,9 @@
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | Internal implementation details of indexed setters.
+--
+-- This module is intended for internal use only, and may change without warning
+-- in subsequent releases.
 module Optics.Internal.IxSetter where
 
 import Optics.Internal.Indexed

--- a/optics-core/src/Optics/Internal/IxTraversal.hs
+++ b/optics-core/src/Optics/Internal/IxTraversal.hs
@@ -8,7 +8,7 @@ import Optics.Internal.Optic
 import Optics.Internal.Profunctor
 import Optics.Internal.Setter
 
--- | Internal implementation of 'itraversed'.
+-- | Internal implementation of 'Optics.IxTraversal.itraversed'.
 itraversed__
   :: (Traversing p, TraversableWithIndex i f)
   => Optic__ p j (i -> j) (f a) (f b) a b

--- a/optics-core/src/Optics/Internal/IxTraversal.hs
+++ b/optics-core/src/Optics/Internal/IxTraversal.hs
@@ -1,3 +1,9 @@
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | Internal implementation details of indexed traversals.
+--
+-- This module is intended for internal use only, and may change without warning
+-- in subsequent releases.
 module Optics.Internal.IxTraversal where
 
 import Optics.Internal.Fold

--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -56,13 +56,13 @@ type WithIx i = '[i]
 
 -- | Wrapper newtype for the whole family of vaguely lens-like things.
 --
--- The first parameter @k@ identifies the particular flavour
--- (e.g. 'A_Lens' or 'A_Traversal').
+-- The first parameter @k@ identifies the particular optic kind (e.g. 'A_Lens'
+-- or 'A_Traversal').
 --
--- The parameter @is@ is a list of types available as indices.  This
--- will typically be 'NoIx' for unindexed optics, or 'WithIx' for
--- optics with a single index. See "Optics.Indexed.Core" for
--- discussion of indexed optics.
+-- The parameter @is@ is a list of types available as indices.  This will
+-- typically be 'NoIx' for unindexed optics, or 'WithIx' for optics with a
+-- single index. See the "Indexed optics" section of the overview documentation
+-- in the @Optics@ module of the main @optics@ package for more details.
 --
 -- The parameters @s@ and @t@ represent the "big" structure,
 -- whereas @a@ and @b@ represent the "small" structure.

--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -51,13 +51,16 @@ type WithIx i = '[i]
 
 -- | Wrapper newtype for the whole family of vaguely lens-like things.
 --
--- The first type parameter @k@ identifies the particular flavour
+-- The first parameter @k@ identifies the particular flavour
 -- (e.g. 'A_Lens' or 'A_Traversal').
 --
--- The type parameters @s@ and @t@ represent the "big" structure,
--- whereas @a@ and @b@ represent the "small" structure.
+-- The parameter @is@ is a list of types available as indices.  This
+-- will typically be 'NoIx' for unindexed optics, or 'WithIx' for
+-- optics with a single index. See "Optics.Indexed.Core" for
+-- discussion of indexed optics.
 --
--- TODO: explain indices
+-- The parameters @s@ and @t@ represent the "big" structure,
+-- whereas @a@ and @b@ represent the "small" structure.
 --
 newtype Optic (k :: *) (is :: [*]) s t a b =
   Optic { getOptic :: forall p j. Optic_ k p j (Curry is j) s t a b }

--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -96,8 +96,6 @@ data IsProxy (k :: *) (l :: *) (p :: * -> * -> * -> *) =
 --
 -- This is the identity function, modulo some constraint jiggery-pokery.
 --
--- TODO: add a graph
---
 castOptic
   :: forall k l is s t a b
   .  Is k l
@@ -125,6 +123,10 @@ o % o' = castOptic o %% castOptic o'
 {-# INLINE (%) #-}
 
 -- | Compose two optics of the same flavour.
+--
+-- Normally you can simply use ('%') instead, but this may be useful to help
+-- type inference if the type of one of the optics is otherwise
+-- under-constrained.
 infixr 9 %%
 (%%) :: forall k is js ks s t u v a b. ks ~ Append is js
      => Optic k is s t u v

--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_HADDOCK not-home #-}
+
 -- | Core optic types and subtyping machinery.
 --
 -- This module contains the core 'Optic' types, and the underlying
@@ -10,6 +12,9 @@
 -- various different flavours of optics.
 --
 -- The composition operator for optics is also defined here.
+--
+-- This module is intended for internal use only, and may change without
+-- warning in subsequent releases.
 --
 module Optics.Internal.Optic
   ( Optic(..)

--- a/optics-core/src/Optics/Internal/Optic/Subtyping.hs
+++ b/optics-core/src/Optics/Internal/Optic/Subtyping.hs
@@ -12,11 +12,11 @@ import GHC.TypeLits (ErrorMessage(..), TypeError)
 
 import Optics.Internal.Optic.Types
 
--- | Subtyping relationship between flavours of optics.
+-- | Subtyping relationship between kinds of optics.
 --
--- An instance of @Is k l@ represents that any @Optic k@ can be used as an
--- @Optic l@. For example, we have an @Is A_Lens A_Traversal@ instance, but not
--- @Is A_Traversal A_Lens@.
+-- An instance of @'Is' k l@ means that any @'Optics.Optic.Optic' k@ can be used
+-- as an @'Optics.Optic.Optic' l@. For example, we have an @'Is' 'A_Lens'
+-- 'A_Traversal'@ instance, but not @'Is' 'A_Traversal' 'A_Lens'@.
 --
 -- This class needs instances for all possible combinations of tags.
 --
@@ -32,7 +32,7 @@ instance {-# OVERLAPPABLE #-} TypeError ('ShowType k
                                         ) => Is k l where
   implies = error "unreachable"
 
--- | Every flavour of optic can be used as itself.
+-- | Every kind of optic can be used as itself.
 instance Is k k where
   implies _ = id
 
@@ -103,7 +103,7 @@ instance Is A_Traversal        A_Setter           where implies _ = id
 
 ----------------------------------------
 
--- | Computes the least upper bound of two optics flavours.
+-- | Computes the least upper bound of two optics kinds.
 --
 -- @Join k l@ represents the least upper bound of an @Optic k@ and an @Optic
 -- l@. This means in particular that composition of an @Optic k@ and an @Optic
@@ -283,7 +283,7 @@ type family Join (k :: *) (l :: *) where
 
   -- END GENERATED CONTENT
 
-  -- Every optics flavour can be joined with itself.
+  -- Every optic kinds can be joined with itself.
   Join k k = k
 
   -- Everything else is a type error.

--- a/optics-core/src/Optics/Internal/Optic/Subtyping.hs
+++ b/optics-core/src/Optics/Internal/Optic/Subtyping.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_HADDOCK not-home #-}
+
 -- | Instances to implement the subtyping hierarchy between optics.
 --
+-- This module is intended for internal use only, and may change without warning
+-- in subsequent releases.
 module Optics.Internal.Optic.Subtyping where
 
 import GHC.TypeLits (ErrorMessage(..), TypeError)

--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -1,9 +1,14 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | This module is intended for internal use only, and may change without
+-- warning in subsequent releases.
 module Optics.Internal.Optic.TypeLevel where
 
 import GHC.TypeLits
 
+-- | Show a type surrounded by quote marks.
 type family QuoteType (x :: *) :: ErrorMessage where
   QuoteType x = 'Text "‘" ':<>: 'ShowType x ':<>: 'Text "’"
 
@@ -24,9 +29,14 @@ type family Append (xs :: [*]) (ys :: [*]) :: [*] where
   Append xs        '[] = xs -- needed for (<%)
   Append (x ': xs) ys  = x ': Append xs ys
 
+-- | Class that is inhabited by all type-level lists @xs@, providing the ability
+-- to compose a function under @'Curry' xs@.
 class CurryCompose xs where
+  -- | Compose a function under @'Curry' xs@.  This generalises @('.')@ (aka
+  -- 'fmap' for @(->)@) to work for curried functions with one argument for each
+  -- type in the list.
   composeN :: (i -> j) -> Curry xs i -> Curry xs j
-    
+
 instance CurryCompose '[] where
   composeN = id
   {-# INLINE composeN #-}

--- a/optics-core/src/Optics/Internal/Optic/Types.hs
+++ b/optics-core/src/Optics/Internal/Optic/Types.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 module Optics.Internal.Optic.Types where
 
 import GHC.Exts (Constraint)

--- a/optics-core/src/Optics/Internal/Optic/Types.hs
+++ b/optics-core/src/Optics/Internal/Optic/Types.hs
@@ -1,4 +1,7 @@
 {-# OPTIONS_HADDOCK not-home #-}
+
+-- | This module is intended for internal use only, and may change without
+-- warning in subsequent releases.
 module Optics.Internal.Optic.Types where
 
 import GHC.Exts (Constraint)

--- a/optics-core/src/Optics/Internal/Profunctor.hs
+++ b/optics-core/src/Optics/Internal/Profunctor.hs
@@ -1,3 +1,9 @@
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | Definitions of concrete profunctors and profunctor classes.
+--
+-- This module is intended for internal use only, and may change without warning
+-- in subsequent releases.
 module Optics.Internal.Profunctor where
 
 import Data.Coerce (Coercible, coerce)

--- a/optics-core/src/Optics/Internal/Setter.hs
+++ b/optics-core/src/Optics/Internal/Setter.hs
@@ -1,3 +1,9 @@
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | Internal implementation details of setters.
+--
+-- This module is intended for internal use only, and may change without warning
+-- in subsequent releases.
 module Optics.Internal.Setter where
 
 import Optics.Internal.Profunctor

--- a/optics-core/src/Optics/Internal/Setter.hs
+++ b/optics-core/src/Optics/Internal/Setter.hs
@@ -3,7 +3,7 @@ module Optics.Internal.Setter where
 import Optics.Internal.Profunctor
 import Optics.Internal.Optic
 
--- | Internal implementation of 'mapped'.
+-- | Internal implementation of 'Optics.Setter.mapped'.
 mapped__
   :: (Mapping p, Functor f)
   => Optic__ p i i (f a) (f b) a b

--- a/optics-core/src/Optics/Internal/Tagged.hs
+++ b/optics-core/src/Optics/Internal/Tagged.hs
@@ -1,7 +1,12 @@
+{-# OPTIONS_HADDOCK not-home #-}
+
 -- | Taken from the tagged package.
 --
 -- We include this here, at least for now, with the goal
 -- that we only depend on base.
+--
+-- This module is intended for internal use only, and may change without warning
+-- in subsequent releases.
 --
 module Optics.Internal.Tagged where
 

--- a/optics-core/src/Optics/Internal/Traversal.hs
+++ b/optics-core/src/Optics/Internal/Traversal.hs
@@ -5,7 +5,7 @@ import Optics.Internal.Profunctor
 import Optics.Internal.Fold
 import Optics.Internal.Setter
 
--- | Internal implementation of 'traversed'.
+-- | Internal implementation of 'Optics.Traversal.traversed'.
 traversed__
   :: (Traversing p, Traversable f)
   => Optic__ p i i (f a) (f b) a b

--- a/optics-core/src/Optics/Internal/Traversal.hs
+++ b/optics-core/src/Optics/Internal/Traversal.hs
@@ -1,3 +1,9 @@
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | Internal implementation details of traversals.
+--
+-- This module is intended for internal use only, and may change without warning
+-- in subsequent releases.
 module Optics.Internal.Traversal where
 
 import Optics.Internal.Optic

--- a/optics-core/src/Optics/Internal/Utils.hs
+++ b/optics-core/src/Optics/Internal/Utils.hs
@@ -1,3 +1,7 @@
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | This module is intended for internal use only, and may change without warning
+-- in subsequent releases.
 module Optics.Internal.Utils where
 
 import Data.Coerce
@@ -9,11 +13,17 @@ data Context a b t = Context (b -> t) a
 data IxContext i a b t = IxContext (i -> b -> t) a
   deriving Functor
 
+-- | Composition operator where the first argument must be an identity
+-- function up to representational equivalence (e.g. a newtype wrapper
+-- or unwrapper), and will be ignored at runtime.
 (#.) :: Coercible b c => (b -> c) -> (a -> b) -> (a -> c)
 (#.) _f = coerce
 infixl 8 .#
 {-# INLINE (#.) #-}
 
+-- | Composition operator where the second argument must be an
+-- identity function up to representational equivalence (e.g. a
+-- newtype wrapper or unwrapper), and will be ignored at runtime.
 (.#) :: Coercible a b => (b -> c) -> (a -> b) -> (a -> c)
 (.#) f _g = coerce f
 infixr 9 #.

--- a/optics-core/src/Optics/Internal/Utils.hs
+++ b/optics-core/src/Optics/Internal/Utils.hs
@@ -21,10 +21,10 @@ infixr 9 #.
 
 ----------------------------------------
 
--- | Helper for 'traverseOf_' and the like for better efficiency than the
--- foldr-based version.
+-- | Helper for 'Optics.Fold.traverseOf_' and the like for better
+-- efficiency than the foldr-based version.
 --
--- Note that the argument 'a' of the result should not be used.
+-- Note that the argument @a@ of the result should not be used.
 newtype Traversed f a = Traversed (f a)
 
 runTraversed :: Functor f => Traversed f a -> f ()
@@ -43,7 +43,7 @@ instance Applicative f => Monoid (Traversed f a) where
 
 ----------------------------------------
 
--- | Helper for 'failing' family to visit the first traversal only once.
+-- | Helper for 'Optics.Fold.failing' family to visit the first fold only once.
 data OrT f a = OrT !Bool (f a)
   deriving Functor
 

--- a/optics-core/src/Optics/Iso.hs
+++ b/optics-core/src/Optics/Iso.hs
@@ -1,4 +1,8 @@
--- | An 'Iso'(morphism) expresses the fact that two types have the
+-- |
+-- Module: Optics.Iso
+-- Description: Translates between types with the same structure.
+--
+-- An 'Iso'morphism expresses the fact that two types have the
 -- same structure, and hence can be converted from one to the other in
 -- either direction.
 --
@@ -7,10 +11,8 @@ module Optics.Iso
   -- * Formation
     Iso
   , Iso'
-  , An_Iso
 
   -- * Introduction
-  , toIso
   , iso
 
   -- * Elimination
@@ -22,12 +24,24 @@ module Optics.Iso
   -- 'Optics.Getter.view'   :: 'Iso' s t a b -> s -> a
   -- 'Optics.Review.review' :: 'Iso' s t a b -> b -> t
   -- @
-  , withIso
-  , au
-  , under
 
-  -- * Isomorphisms
-  , mapping
+  -- * Computation
+  -- |
+  --
+  -- @
+  -- 'Optics.Getter.view'   ('iso' f g) ≡ f
+  -- 'Optics.Review.review' ('iso' f g) ≡ g
+  -- @
+
+  -- * Well-formedness
+  -- | The functions translating back and forth must be mutually inverse:
+  --
+  -- @
+  -- 'Optics.Getter.view' i . 'Optics.Getter.review' i ≡ 'id'
+  -- 'Optics.Getter.review' i . 'Optics.Getter.view' i ≡ 'id'
+  -- @
+
+  -- * Additional introduction forms
   , coerced
   , coerced'
   , coerced1
@@ -37,12 +51,22 @@ module Optics.Iso
   , involuted
   , Swapped(..)
 
+  -- * Additional elimination forms
+  , withIso
+  , au
+  , under
+
   -- * Combinators
   -- | The 'Optics.Re.re' combinator can be used to reverse an 'Iso':
   --
   -- @
   -- 'Optics.Re.re' :: 'Iso' s t a b -> 'Iso' b a t s
   -- @
+  , mapping
+
+  -- * Subtyping
+  , An_Iso
+  , toIso
 
   -- * Re-exports
   , module Optics.Optic
@@ -91,7 +115,7 @@ withIso o k = case getOptic (toIso o) (Exchange id id) of
 -- type:
 --
 -- @
--- au :: Iso s t a b -> ((b -> t) -> e -> s) -> e -> a
+-- au :: 'Iso' s t a b -> ((b -> t) -> e -> s) -> e -> a
 -- @
 au :: (Is k An_Iso, Functor f) => Optic k is s t a b -> ((b -> t) -> f s) -> f a
 au k = withIso k $ \sa bt f -> sa <$> f bt

--- a/optics-core/src/Optics/Iso.hs
+++ b/optics-core/src/Optics/Iso.hs
@@ -1,12 +1,31 @@
+-- | An 'Iso'(morphism) expresses the fact that two types have the
+-- same structure, and hence can be converted from one to the other in
+-- either direction.
+--
 module Optics.Iso
-  ( An_Iso
-  , Iso
+  (
+  -- * Formation
+    Iso
   , Iso'
+  , An_Iso
+
+  -- * Introduction
   , toIso
   , iso
+
+  -- * Elimination
+  -- | An 'Iso' is a 'Optics.Getter.Getter' and an
+  -- 'Optics.Review.Review', therefore you can specialise types to
+  -- obtain:
+  --
+  -- @
+  -- 'Optics.Getter.view'   :: 'Iso' s t a b -> s -> a
+  -- 'Optics.Review.review' :: 'Iso' s t a b -> b -> t
+  -- @
   , withIso
   , au
   , under
+
   -- * Isomorphisms
   , mapping
   , coerced
@@ -17,6 +36,14 @@ module Optics.Iso
   , flipped
   , involuted
   , Swapped(..)
+
+  -- * Combinators
+  -- | The 'Optics.Re.re' combinator can be used to reverse an 'Iso':
+  --
+  -- @
+  -- 'Optics.Re.re' :: 'Iso' s t a b -> 'Iso' b a t s
+  -- @
+
   -- * Re-exports
   , module Optics.Optic
   )
@@ -142,7 +169,7 @@ curried = iso curry uncurry
 -- @
 --
 -- @
--- 'uncurried' = 're' 'curried'
+-- 'uncurried' = 'Optics.Re.re' 'curried'
 -- @
 --
 -- >>> (view uncurried (+)) (1,2)

--- a/optics-core/src/Optics/IxAffineFold.hs
+++ b/optics-core/src/Optics/IxAffineFold.hs
@@ -1,12 +1,27 @@
+-- | An 'IxAffineFold' is an indexed version of an
+-- 'Optics.AffineFold.AffineFold'.  See "Optics.Indexed.Core" for a
+-- discussion of indexed optics in general.
+--
 module Optics.IxAffineFold
-  ( An_AffineFold
-  , IxAffineFold
-  , toIxAffineFold
+  (
+  -- * Formation
+    IxAffineFold
+
+  -- * Introduction
+  , iafolding
+
+  -- * Elimination
   , ipreview
   , ipreviews
-  , iafolding
+
   -- * Semigroup structure
   , iafailing
+
+  -- * Subtyping
+  , An_AffineFold
+  , toIxAffineFold
+
+  -- * Re-exports
   , module Optics.Optic
   ) where
 
@@ -55,7 +70,7 @@ iafolding g = Optic
 
 -- | Try the first 'IxAffineFold'. If it returns no entry, try the second one.
 --
--- /Note:/ There is no 'isumming' equivalent, because @iasumming = iafailing@.
+-- /Note:/ There is no 'Optics.IxFold.isumming' equivalent, because @iasumming = iafailing@.
 iafailing
   :: (Is k An_AffineFold, Is l An_AffineFold,
       is1 `HasSingleIndex` i, is2 `HasSingleIndex` i)

--- a/optics-core/src/Optics/IxAffineFold.hs
+++ b/optics-core/src/Optics/IxAffineFold.hs
@@ -1,6 +1,9 @@
--- | An 'IxAffineFold' is an indexed version of an
--- 'Optics.AffineFold.AffineFold'.  See "Optics.Indexed.Core" for a
--- discussion of indexed optics in general.
+-- |
+-- Module: Optics.IxAffineFold
+-- Description: An indexed version of an 'Optics.AffineFold.AffineFold'.
+--
+-- An 'IxAffineFold' is an indexed version of an 'Optics.AffineFold.AffineFold'.
+-- See "Optics.Indexed.Core" for a discussion of indexed optics in general.
 --
 module Optics.IxAffineFold
   (
@@ -13,6 +16,13 @@ module Optics.IxAffineFold
   -- * Elimination
   , ipreview
   , ipreviews
+
+  -- * Computation
+  -- |
+  --
+  -- @
+  -- 'ipreview' ('iafolding' f) ≡ f
+  -- @
 
   -- * Semigroup structure
   , iafailing

--- a/optics-core/src/Optics/IxAffineFold.hs
+++ b/optics-core/src/Optics/IxAffineFold.hs
@@ -3,7 +3,9 @@
 -- Description: An indexed version of an 'Optics.AffineFold.AffineFold'.
 --
 -- An 'IxAffineFold' is an indexed version of an 'Optics.AffineFold.AffineFold'.
--- See "Optics.Indexed.Core" for a discussion of indexed optics in general.
+-- See the "Indexed optics" section of the overview documentation in the
+-- @Optics@ module of the main @optics@ package for more details on indexed
+-- optics.
 --
 module Optics.IxAffineFold
   (

--- a/optics-core/src/Optics/IxAffineTraversal.hs
+++ b/optics-core/src/Optics/IxAffineTraversal.hs
@@ -3,8 +3,9 @@
 -- Description: An indexed version of an 'Optics.AffineTraversal.AffineTraversal'.
 --
 -- An 'IxAffineTraversal' is an indexed version of an
--- 'Optics.AffineTraversal.AffineTraversal'.  See "Optics.Indexed.Core" for a
--- discussion of indexed optics in general.
+-- 'Optics.AffineTraversal.AffineTraversal'.  See the "Indexed optics" section
+-- of the overview documentation in the @Optics@ module of the main @optics@
+-- package for more details on indexed optics.
 --
 module Optics.IxAffineTraversal
   (

--- a/optics-core/src/Optics/IxAffineTraversal.hs
+++ b/optics-core/src/Optics/IxAffineTraversal.hs
@@ -1,12 +1,25 @@
+-- | An 'IxAffineTraversal' is an indexed version of an
+-- 'Optics.AffineTraversal.AffineTraversal'.  See
+-- "Optics.Indexed.Core" for a discussion of indexed optics in
+-- general.
+--
 module Optics.IxAffineTraversal
-  ( An_AffineTraversal
-  , IxAffineTraversal
+  (
+  -- * Formation
+    IxAffineTraversal
   , IxAffineTraversal'
-  , toIxAffineTraversal
+
+  -- * Van Laarhoven representation
   , IxAffineTraversalVL
   , IxAffineTraversalVL'
   , ixAtraversalVL
   , toIxAtraversalVL
+
+  -- * Subtyping
+  , An_AffineTraversal
+  , toIxAffineTraversal
+
+  -- * Re-exports
   , module Optics.Optic
   ) where
 
@@ -23,9 +36,11 @@ type IxAffineTraversal' i s a = Optic' An_AffineTraversal (WithIx i) s a
 
 -- | Type synonym for a type-modifying van Laarhoven indexed affine traversal.
 --
--- Note: this isn't exactly van Laarhoven representation as there is no
--- @PointedFunctor@ class, but you can interpret the first argument as a
--- dictionary of 'Pointed' class that supplies the @point@ function.
+-- Note: this isn't exactly van Laarhoven representation as there is
+-- no @Pointed@ class (which would be a superclass of 'Applicative'
+-- that contains 'pure' but not '<*>'). You can interpret the first
+-- argument as a dictionary of @Pointed@ that supplies the @point@
+-- function (i.e. the implementation of 'pure').
 --
 type IxAffineTraversalVL i s t a b =
   forall f. Functor f => (forall r. r -> f r) -> (i -> a -> f b) -> s -> f t

--- a/optics-core/src/Optics/IxAffineTraversal.hs
+++ b/optics-core/src/Optics/IxAffineTraversal.hs
@@ -1,7 +1,10 @@
--- | An 'IxAffineTraversal' is an indexed version of an
--- 'Optics.AffineTraversal.AffineTraversal'.  See
--- "Optics.Indexed.Core" for a discussion of indexed optics in
--- general.
+-- |
+-- Module: Optics.IxAffineTraversal
+-- Description: An indexed version of an 'Optics.AffineTraversal.AffineTraversal'.
+--
+-- An 'IxAffineTraversal' is an indexed version of an
+-- 'Optics.AffineTraversal.AffineTraversal'.  See "Optics.Indexed.Core" for a
+-- discussion of indexed optics in general.
 --
 module Optics.IxAffineTraversal
   (

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -1,26 +1,27 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
+-- | An 'IxFold' is an indexed version of an 'Optics.Fold.Fold'.  See
+-- "Optics.Indexed.Core" for a discussion of indexed optics in
+-- general.
+--
 module Optics.IxFold
-  ( A_Fold
-  , IxFold
-  , toIxFold
+  (
+  -- * Formation
+    IxFold
+
+  -- * Introduction
   , mkIxFold
+  , ifolded
+  , ifolding
+  , ifoldring
+
+  -- * Elimination
   , ifoldMapOf
   , ifoldrOf
   , ifoldlOf'
   , itoListOf
   , itraverseOf_
   , iforOf_
-  -- * Folds
-  , ifolded
-  , ifolding
-  , ifoldring
-  , ifiltered
-  , ibackwards_
-  -- * Semigroup structure
-  , isumming
-  , ifailing
-  -- * Special folds
   , iheadOf
   , ilastOf
   , ianyOf
@@ -28,6 +29,21 @@ module Optics.IxFold
   , inoneOf
   , ifindOf
   , ifindMOf
+
+  -- * Combinators
+  , ifiltered
+  , ibackwards_
+
+  -- * Semigroup structure
+  , isumming
+  , ifailing
+
+  -- * Subtyping
+  , A_Fold
+  , toIxFold
+
+  -- * Re-exports
+  , FoldableWithIndex(..)
   , module Optics.Optic
   ) where
 

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
--- | An 'IxFold' is an indexed version of an 'Optics.Fold.Fold'.  See
--- "Optics.Indexed.Core" for a discussion of indexed optics in
--- general.
+-- |
+-- Module: Optics.IxFold
+-- Description: An indexed version of an 'Optics.Fold.Fold'.
+--
+-- An 'IxFold' is an indexed version of an 'Optics.Fold.Fold'.  See
+-- "Optics.Indexed.Core" for a discussion of indexed optics in general.
 --
 module Optics.IxFold
   (
@@ -11,9 +14,6 @@ module Optics.IxFold
 
   -- * Introduction
   , mkIxFold
-  , ifolded
-  , ifolding
-  , ifoldring
 
   -- * Elimination
   , ifoldMapOf
@@ -22,6 +22,13 @@ module Optics.IxFold
   , itoListOf
   , itraverseOf_
   , iforOf_
+
+  -- * Additional introduction forms
+  , ifolded
+  , ifolding
+  , ifoldring
+
+  -- * Additional elimination forms
   , iheadOf
   , ilastOf
   , ianyOf
@@ -126,6 +133,14 @@ itoListOf o = ifoldrOf o (\i -> (:) . (i, )) []
 
 ----------------------------------------
 
+-- | Traverse over all of the targets of an 'IxFold', computing an
+-- 'Applicative'-based answer, but unlike 'Optics.IxTraversal.itraverseOf' do
+-- not construct a new structure.
+--
+-- >>> itraverseOf_ each (curry print) ("hello","world")
+-- (0,"hello")
+-- (1,"world")
+--
 itraverseOf_
   :: (Is k A_Fold, Applicative f, is `HasSingleIndex` i)
   => Optic' k is s a

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -4,8 +4,9 @@
 -- Module: Optics.IxFold
 -- Description: An indexed version of an 'Optics.Fold.Fold'.
 --
--- An 'IxFold' is an indexed version of an 'Optics.Fold.Fold'.  See
--- "Optics.Indexed.Core" for a discussion of indexed optics in general.
+-- An 'IxFold' is an indexed version of an 'Optics.Fold.Fold'. See the "Indexed
+-- optics" section of the overview documentation in the @Optics@ module of the
+-- main @optics@ package for more details on indexed optics.
 --
 module Optics.IxFold
   (

--- a/optics-core/src/Optics/IxSetter.hs
+++ b/optics-core/src/Optics/IxSetter.hs
@@ -1,16 +1,30 @@
 {-# LANGUAGE DataKinds #-}
+-- | An 'IxSetter' is an indexed version of an 'Optics.Setter.Setter'.
+-- See "Optics.Indexed.Core" for a discussion of indexed optics in
+-- general.
+--
 module Optics.IxSetter
-  ( A_Setter
-  , IxSetter
+  (
+  -- * Formation
+    IxSetter
   , IxSetter'
-  , FunctorWithIndex(..)
-  , toIxSetter
-  , iover
-  , iover'
-  , iset
-  , iset'
+
+  -- * Introduction
   , isets
   , imapped
+
+  -- * Elimination
+  , iset
+  , iset'
+  , iover
+  , iover'
+
+  -- * Subtyping
+  , A_Setter
+  , toIxSetter
+
+  -- * Re-exports
+  , FunctorWithIndex(..)
   , module Optics.Optic
   ) where
 

--- a/optics-core/src/Optics/IxSetter.hs
+++ b/optics-core/src/Optics/IxSetter.hs
@@ -3,8 +3,9 @@
 -- Module: Optics.IxSetter
 -- Description: An indexed version of an 'Optics.Setter.Setter'.
 --
--- An 'IxSetter' is an indexed version of an 'Optics.Setter.Setter'.  See
--- "Optics.Indexed.Core" for a discussion of indexed optics in general.
+-- An 'IxSetter' is an indexed version of an 'Optics.Setter.Setter'. See the
+-- "Indexed optics" section of the overview documentation in the @Optics@ module
+-- of the main @optics@ package for more details on indexed optics.
 --
 module Optics.IxSetter
   (

--- a/optics-core/src/Optics/IxSetter.hs
+++ b/optics-core/src/Optics/IxSetter.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE DataKinds #-}
--- | An 'IxSetter' is an indexed version of an 'Optics.Setter.Setter'.
--- See "Optics.Indexed.Core" for a discussion of indexed optics in
--- general.
+-- |
+-- Module: Optics.IxSetter
+-- Description: An indexed version of an 'Optics.Setter.Setter'.
+--
+-- An 'IxSetter' is an indexed version of an 'Optics.Setter.Setter'.  See
+-- "Optics.Indexed.Core" for a discussion of indexed optics in general.
 --
 module Optics.IxSetter
   (
@@ -11,12 +14,39 @@ module Optics.IxSetter
 
   -- * Introduction
   , isets
-  , imapped
 
   -- * Elimination
+  , iover
+
+  -- * Computation
+  -- |
+  --
+  -- @
+  -- 'iover' ('isets' f) ≡ f
+  -- @
+
+  -- * Well-formedness
+  -- |
+  --
+  -- * __PutPut__: Setting twice is the same as setting once:
+  --
+  --     @
+  --     'Optics.Setter.iset' l v' ('Optics.Setter.iset' l v s) ≡ 'Optics.Setter.iset' l v' s
+  --     @
+  --
+  -- * __Functoriality__: 'IxSetter's must preserve identities and composition:
+  --
+  --     @
+  --     'iover' s ('const' 'id') ≡ 'id'
+  --     'iover' s f '.' 'iover' s g ≡ 'iover' s (\i -> f i '.' g i)
+  --     @
+
+  -- * Additional introduction forms
+  , imapped
+
+  -- * Additional elimination forms
   , iset
   , iset'
-  , iover
   , iover'
 
   -- * Subtyping
@@ -68,6 +98,11 @@ iover' o = \f ->
 {-# INLINE iover' #-}
 
 -- | Apply an indexed setter.
+--
+-- @
+-- 'iset' o f ≡ 'iover' o (\i _ -> f i)
+-- @
+--
 iset
   :: (Is k A_Setter, is `HasSingleIndex` i)
   => Optic k is s t a b
@@ -91,6 +126,10 @@ isets f = Optic (iroam f)
 {-# INLINE isets #-}
 
 -- | Indexed setter via the 'FunctorWithIndex' class.
+--
+-- @
+-- 'iover' 'imapped' ≡ 'imap'
+-- @
 imapped :: FunctorWithIndex i f => IxSetter i (f a) (f b) a b
 imapped = Optic imapped__
 {-# INLINE imapped #-}

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE DataKinds #-}
--- | An 'IxTraversal' is an indexed version of an
--- 'Optics.Traversal.Traversal'.  See "Optics.Indexed.Core" for a
--- discussion of indexed optics in general.
+-- |
+-- Module: Optics.IxTraversal
+-- Description: An indexed version of an 'Optics.Traversal.Traversal'.
+--
+-- An 'IxTraversal' is an indexed version of an 'Optics.Traversal.Traversal'.
+-- See "Optics.Indexed.Core" for a discussion of indexed optics in general.
 --
 module Optics.IxTraversal
   (
@@ -11,6 +14,27 @@ module Optics.IxTraversal
 
   -- * Introduction
   , ixTraversalVL
+
+  -- * Elimination
+  , itraverseOf
+
+  -- * Computation
+  -- |
+  --
+  -- @
+  -- 'itraverseOf' ('ixTraversalVL' f) ≡ f
+  -- @
+
+  -- * Well-formedness
+  -- |
+  --
+  -- @
+  -- 'itraverseOf' o ('const' 'pure') ≡ 'pure'
+  -- 'fmap' ('itraverseOf' o f) . 'itraverseOf' o g ≡ 'Data.Functor.Compose.getCompose' . 'itraverseOf' o (\\ i -> 'Data.Functor.Compose.Compose' . 'fmap' (f i) . g i)
+  -- @
+  --
+
+  -- * Additional introduction forms
   , itraversed
   , ignored
   , elementsOf
@@ -18,8 +42,7 @@ module Optics.IxTraversal
   , elementOf
   , element
 
-  -- * Elimination
-  , itraverseOf
+  -- * Additional elimination forms
   , iforOf
   , imapAccumLOf
   , imapAccumROf
@@ -158,7 +181,7 @@ iscanr1Of o f = fst . imapAccumROf o step Nothing
 {-# INLINE iscanr1Of #-}
 
 -- | Try to map a function which uses the index over this 'IxTraversal',
--- retuning Nothing if the 'IxTraversal' has no targets.
+-- returning 'Nothing' if the 'IxTraversal' has no targets.
 ifailover
   :: (Is k A_Traversal, is `HasSingleIndex` i)
   => Optic k is s t a b
@@ -170,7 +193,7 @@ ifailover o = \f s ->
      else Nothing
 {-# INLINE ifailover #-}
 
--- | Version of 'ifailover' strict in the application of @f@.
+-- | Version of 'ifailover' strict in the application of the function.
 ifailover'
   :: (Is k A_Traversal, is `HasSingleIndex` i)
   => Optic k is s t a b
@@ -186,6 +209,10 @@ ifailover' o = \f s ->
 -- Traversals
 
 -- | Indexed traversal via the 'TraversableWithIndex' class.
+--
+-- @
+-- 'itraverseOf' 'itraversed' ≡ 'itraverse'
+-- @
 --
 -- >>> iover (itraversed <%> itraversed) (,) ["ab", "cd"]
 -- [[((0,0),'a'),((0,1),'b')],[((1,0),'c'),((1,1),'d')]]

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -4,7 +4,9 @@
 -- Description: An indexed version of an 'Optics.Traversal.Traversal'.
 --
 -- An 'IxTraversal' is an indexed version of an 'Optics.Traversal.Traversal'.
--- See "Optics.Indexed.Core" for a discussion of indexed optics in general.
+-- See the "Indexed optics" section of the overview documentation in the
+-- @Optics@ module of the main @optics@ package for more details on indexed
+-- optics.
 --
 module Optics.IxTraversal
   (

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -1,11 +1,24 @@
 {-# LANGUAGE DataKinds #-}
+-- | An 'IxTraversal' is an indexed version of an
+-- 'Optics.Traversal.Traversal'.  See "Optics.Indexed.Core" for a
+-- discussion of indexed optics in general.
+--
 module Optics.IxTraversal
-  ( A_Traversal
-  , IxTraversal
+  (
+  -- * Formation
+    IxTraversal
   , IxTraversal'
-  , TraversableWithIndex(..)
-  , toIxTraversal
+
+  -- * Introduction
   , ixTraversalVL
+  , itraversed
+  , ignored
+  , elementsOf
+  , elements
+  , elementOf
+  , element
+
+  -- * Elimination
   , itraverseOf
   , iforOf
   , imapAccumLOf
@@ -14,16 +27,17 @@ module Optics.IxTraversal
   , iscanr1Of
   , ifailover
   , ifailover'
-  -- * Traversals
-  , itraversed
-  , ignored
+
   -- * Combinators
   , ibackwards
-  , elementsOf
-  , elements
-  , elementOf
-  , element
   , ipartsOf
+
+  -- * Subtyping
+  , A_Traversal
+  , toIxTraversal
+
+  -- * Re-exports
+  , TraversableWithIndex(..)
   , module Optics.Optic
   ) where
 
@@ -85,7 +99,7 @@ iforOf
 iforOf = flip . itraverseOf
 {-# INLINE iforOf #-}
 
--- | Generalizes 'Data.Traversable.mapAccumL' to an arbitrary 'IXTraversal'.
+-- | Generalizes 'Data.Traversable.mapAccumL' to an arbitrary 'IxTraversal'.
 --
 -- 'imapAccumLOf' accumulates state from left to right.
 --

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -84,6 +84,10 @@ ixTraversalVL t = Optic (iwander t)
 
 ----------------------------------------
 
+-- | Map each element of a structure targeted by a 'IxTraversal' (supplying the
+-- index), evaluate these actions from left to right, and collect the results.
+--
+-- This yields the van Laarhoven representation of an indexed traversal.
 itraverseOf
   :: (Is k A_Traversal, Applicative f, is `HasSingleIndex` i)
   => Optic k is s t a b
@@ -212,7 +216,7 @@ ibackwards o = Optic $ conjoined__ (backwards o) $ ixTraversalVL $ \f ->
   forwards #. itraverseOf o (\i -> Backwards #. f i)
 {-# INLINE ibackwards #-}
 
--- Traverse selected elements of a 'Traversal' where their ordinal positions
+-- | Traverse selected elements of a 'Traversal' where their ordinal positions
 -- match a predicate.
 elementsOf
   :: Is k A_Traversal

--- a/optics-core/src/Optics/Lens.hs
+++ b/optics-core/src/Optics/Lens.hs
@@ -1,4 +1,8 @@
--- | A 'Lens' is a generalised or first-class field.
+-- |
+-- Module: Optics.Lens
+-- Description: A 'Lens' is a generalised or first-class field.
+--
+-- A 'Lens' is a generalised or first-class field.
 --
 -- If we have a value @s :: S@, and a @l :: 'Lens'' S A@, we can /get/
 -- the "field value" of type @A@ using @'Optics.Getter.view' l s@.  We
@@ -32,9 +36,6 @@ module Optics.Lens
 
   -- * Introduction
   , lens
-  , chosen
-  , devoid
-  , united
 
   -- * Elimination
   -- | A 'Lens' is a 'Optics.Setter.Setter' and a
@@ -44,17 +45,15 @@ module Optics.Lens
   -- @
   -- 'Optics.Getter.view' :: 'Lens' i s t a b -> s -> a
   -- 'Optics.Setter.set'  :: 'Lens' i s t a b -> b -> s -> t
-  -- 'Optics.Setter.over' :: 'Lens' i s t a b -> (a -> b) -> s -> t
   -- @
   --
-  , withLens
 
   -- * Computation
   -- |
   --
   -- @
-  -- 'Optics.Getter.view' ('lens' f g)   s = f s
-  -- 'Optics.Setter.set'  ('lens' f g) a s = g s a
+  -- 'Optics.Getter.view' ('lens' f g)   s ≡ f s
+  -- 'Optics.Setter.set'  ('lens' f g) a s ≡ g s a
   -- @
 
   -- * Well-formedness
@@ -63,27 +62,38 @@ module Optics.Lens
   -- * __GetPut__: You get back what you put in:
   --
   --     @
-  --     'Optics.Getter.view' l ('Optics.Setter.set' l v s) = v
+  --     'Optics.Getter.view' l ('Optics.Setter.set' l v s) ≡ v
   --     @
   --
   -- * __PutGet__: Putting back what you got doesn’t change anything:
   --
   --     @
-  --     'Optics.Setter.set' l ('Optics.Getter.view' l s) s = s
+  --     'Optics.Setter.set' l ('Optics.Getter.view' l s) s ≡ s
   --     @
   --
   -- * __PutPut__: Setting twice is the same as setting once:
   --
   --     @
-  --     'Optics.Setter.set' l v' ('Optics.Setter.set' l v s) = 'Optics.Setter.set' l v' s
+  --     'Optics.Setter.set' l v' ('Optics.Setter.set' l v s) ≡ 'Optics.Setter.set' l v' s
   --     @
   --
+
+  -- * Additional introduction forms
+  , chosen
+  , devoid
+  , united
+
+  -- * Additional elimination forms
+  , withLens
 
   -- * Subtyping
   , A_Lens
   , toLens
 
   -- * van Laarhoven encoding
+  -- | The van Laarhoven encoding of lenses is isomorphic to the profunctor
+  -- encoding used internally by @optics@, but converting back and forth may
+  -- have a performance penalty.
   , LensVL
   , LensVL'
   , lensVL
@@ -120,7 +130,8 @@ toLens :: Is k A_Lens => Optic k is s t a b -> Optic A_Lens is s t a b
 toLens = castOptic
 {-# INLINE toLens #-}
 
--- | Build a lens from a getter and a setter.
+-- | Build a lens from a getter and a setter, which must respect the
+-- well-formedness laws.
 lens :: (s -> a) -> (s -> b -> t) -> Lens s t a b
 lens get set = Optic $
   -- Do not define lens in terms of lensVL, mixing profunctor-style definitions
@@ -132,6 +143,10 @@ lens get set = Optic $
 {-# INLINE lens #-}
 
 -- | Work with a lens as a getter and a setter.
+--
+-- @
+-- 'withLens' ('lens' f g) k ≡ k f g
+-- @
 withLens
   :: Is k A_Lens
   => Optic k is s t a b

--- a/optics-core/src/Optics/Lens.hs
+++ b/optics-core/src/Optics/Lens.hs
@@ -1,22 +1,25 @@
--- | 'Lens' is a generalised or first-class *field*.
+-- | A 'Lens' is a generalised or first-class field.
 --
--- If we have a value @s :: S@, and a @l :: 'Lens'' S A@,
--- we can /get/ the "field value" of type @A@ using 'view'.
--- We can also /update/ (or /put/ or /set/) the value using 'over' (or 'set').
+-- If we have a value @s :: S@, and a @l :: 'Lens'' S A@, we can /get/
+-- the "field value" of type @A@ using @'Optics.Getter.view' l s@.  We
+-- can also /update/ (or /put/ or /set/) the value using
+-- 'Optics.Setter.over' (or 'Optics.Setter.set').
+--
+-- For example, given the following definitions:
 --
 -- >>> data Human = Human { _name :: String, _location :: String } deriving Show
 -- >>> let human = Human "Bob" "London"
 --
--- We can make a 'Lens' for @_name@ field:
+-- we can make a 'Lens' for @_name@ field:
 --
 -- >>> let name = lens _name $ \s x -> s { _name = x }
 --
--- Which we can use as a 'Getter'
+-- which we can use as a 'Optics.Getter.Getter':
 --
 -- >>> view name human
 -- "Bob"
 --
--- or a 'Setter'
+-- or a 'Optics.Setter.Setter':
 --
 -- >>> set name "Robert" human
 -- Human {_name = "Robert", _location = "London"}
@@ -24,31 +27,34 @@
 module Optics.Lens
   (
   -- * Formation
-    A_Lens
-  , Lens
+    Lens
   , Lens'
 
   -- * Introduction
   , lens
-  , withLens
-  , toLens
+  , chosen
+  , devoid
+  , united
 
   -- * Elimination
-  -- | 'Lens' is a 'Setter' and a 'Getter', therefore you can
+  -- | A 'Lens' is a 'Optics.Setter.Setter' and a
+  -- 'Optics.Getter.Getter', therefore you can specialise types to
+  -- obtain:
   --
   -- @
-  -- 'view' :: 'Lens' i s t a b -> s -> a
-  -- 'set'  :: 'Lens' i s t a b -> b -> s -> t
-  -- 'over' :: 'Lens' i s t a b -> (a -> b) -> s -> t
+  -- 'Optics.Getter.view' :: 'Lens' i s t a b -> s -> a
+  -- 'Optics.Setter.set'  :: 'Lens' i s t a b -> b -> s -> t
+  -- 'Optics.Setter.over' :: 'Lens' i s t a b -> (a -> b) -> s -> t
   -- @
   --
+  , withLens
 
   -- * Computation
   -- |
   --
   -- @
-  -- 'view' ('lens' f g)   s = f s
-  -- 'set'  ('lens' f g) a s = g s a
+  -- 'Optics.Getter.view' ('lens' f g)   s = f s
+  -- 'Optics.Setter.set'  ('lens' f g) a s = g s a
   -- @
 
   -- * Well-formedness
@@ -57,21 +63,25 @@ module Optics.Lens
   -- * __GetPut__: You get back what you put in:
   --
   --     @
-  --     view l (set l v s) = v
+  --     'Optics.Getter.view' l ('Optics.Setter.set' l v s) = v
   --     @
   --
   -- * __PutGet__: Putting back what you got doesn’t change anything:
   --
   --     @
-  --     set l (view l s) s = s
+  --     'Optics.Setter.set' l ('Optics.Getter.view' l s) s = s
   --     @
   --
   -- * __PutPut__: Setting twice is the same as setting once:
   --
   --     @
-  --     set l v' (set l v s) = set l v' s
+  --     'Optics.Setter.set' l v' ('Optics.Setter.set' l v s) = 'Optics.Setter.set' l v' s
   --     @
   --
+
+  -- * Subtyping
+  , A_Lens
+  , toLens
 
   -- * van Laarhoven encoding
   , LensVL
@@ -79,11 +89,6 @@ module Optics.Lens
   , lensVL
   , toLensVL
   , withLensVL
-
-  -- * Lenses
-  , chosen
-  , devoid
-  , united
 
   -- * Re-exports
   , module Optics.Optic

--- a/optics-core/src/Optics/Lens.hs
+++ b/optics-core/src/Optics/Lens.hs
@@ -1,6 +1,6 @@
 -- |
 -- Module: Optics.Lens
--- Description: A 'Lens' is a generalised or first-class field.
+-- Description: A generalised or first-class field.
 --
 -- A 'Lens' is a generalised or first-class field.
 --

--- a/optics-core/src/Optics/LensyReview.hs
+++ b/optics-core/src/Optics/LensyReview.hs
@@ -1,7 +1,19 @@
+-- | A 'LensyReview' is a 'Optics.Review.Review' produced by calling
+-- 'Optics.Re.re' on a 'Optics.Lens.Lens'.  It is essentially
+-- equivalent to a 'Optics.Review.Review', and is distinguished merely
+-- so that @'Optics.Re.re' . 'Optics.Re.re'@ on a 'Optics.Lens.Lens'
+-- returns a 'Optics.Lens.Lens'.
+--
 module Optics.LensyReview
-  ( A_LensyReview
-  , LensyReview
+  (
+  -- * Formation
+    LensyReview
   , LensyReview'
+
+  -- * Subtyping
+  , A_LensyReview
+
+  -- * Re-exports
   , module Optics.Optic
   ) where
 

--- a/optics-core/src/Optics/LensyReview.hs
+++ b/optics-core/src/Optics/LensyReview.hs
@@ -1,4 +1,8 @@
--- | A 'LensyReview' is a 'Optics.Review.Review' produced by calling
+-- |
+-- Module: Optics.LensyReview
+-- Description: A 'Optics.Review.Review' produced by 'Optics.Re.re' on a 'Optics.Lens.Lens'.
+--
+-- A 'LensyReview' is a 'Optics.Review.Review' produced by calling
 -- 'Optics.Re.re' on a 'Optics.Lens.Lens'.  It is essentially
 -- equivalent to a 'Optics.Review.Review', and is distinguished merely
 -- so that @'Optics.Re.re' . 'Optics.Re.re'@ on a 'Optics.Lens.Lens'

--- a/optics-core/src/Optics/Operators.hs
+++ b/optics-core/src/Optics/Operators.hs
@@ -1,4 +1,8 @@
--- | Defines some infix operators for optics operations.
+-- |
+-- Module: Optics.Operators
+-- Description: Definitions of infix operators for optics.
+--
+-- Defines some infix operators for optics operations.
 --
 -- These are not exported by default from "Optics.Core".
 -- They have to be imported separately.

--- a/optics-core/src/Optics/Operators.hs
+++ b/optics-core/src/Optics/Operators.hs
@@ -1,6 +1,6 @@
 -- | Defines some infix operators for optics operations.
 --
--- These are not exported by default from 'Optics'.
+-- These are not exported by default from "Optics.Core".
 -- They have to be imported separately.
 --
 module Optics.Operators

--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -1,21 +1,38 @@
 {-# LANGUAGE CPP #-}
+-- |
+-- Module: Optics.Optic
+-- Description: Common abstraction for all kinds of optics.
+--
+-- This module defines the common 'Optic' type, the subtyping relationships
+-- between different kinds of optics, and composition of optics.
+--
+-- See the @Optics@ module in the main @optics@ package for overview
+-- documentation.
+--
 module Optics.Optic
   ( Optic
   , Optic'
-  , NoIx
-  , WithIx
-  , Is
+
+  -- * Subtyping
   , castOptic
+  , Is
   , Join
+
+  -- * Composition
   , (%)
   , (%%)
+
   -- * Labels
   , LabelOptic(..)
   , LabelOptic'
-  -- * Misc
+
+  -- * Indexed optics
+  , NoIx
+  , WithIx
   , Append
   , NonEmptyIndices
   , HasSingleIndex
+
     -- * Base re-exports
   , (&)
   , (<&>)

--- a/optics-core/src/Optics/Prism.hs
+++ b/optics-core/src/Optics/Prism.hs
@@ -1,18 +1,46 @@
+-- | A 'Prism' generalises the notion of a constructor (just as a
+-- 'Optics.Lens.Lens' generalises the notion of a field).
+--
 module Optics.Prism
-  ( A_Prism
-  , Prism
+  (
+  -- * Formation
+    Prism
   , Prism'
-  , toPrism
+
+  -- * Introduction
   , prism
   , prism'
+  , only
+  , nearly
+
+  -- * Elimination
+  -- | A 'Prism' is a 'Optics.Review.Review', therefore you can
+  -- specialise types to obtain:
+  --
+  -- @
+  -- 'Optics.Review.review' :: 'Prism' i s t a b -> b -> t
+  -- @
   , withPrism
+  , isn't
+  , matching
+
+  -- * Combinators
   , aside
   , without
   , below
-  , isn't
-  , matching
-  , only
-  , nearly
+
+  -- * Computation
+  -- |
+  --
+  -- @
+  -- 'withPrism' ('prism' f g) k = k f g
+  -- @
+
+  -- * Subtyping
+  , A_Prism
+  , toPrism
+
+  -- * Re-exports
   , module Optics.Optic
   )
   where
@@ -47,6 +75,7 @@ prism' :: (b -> s) -> (s -> Maybe a) -> Prism s s a b
 prism' bs sma = prism bs (\s -> maybe (Left s) Right (sma s))
 {-# INLINE prism' #-}
 
+-- | Work with a 'Prism' as a constructor and a matcher.
 withPrism
   :: Is k A_Prism
   => Optic k is s t a b
@@ -83,7 +112,7 @@ without k =
     Right u -> bimap Right Right (uevc u)
 {-# INLINE without #-}
 
--- | 'lift' a 'Prism' through a 'Traversable' functor, giving a Prism that
+-- | Lift a 'Prism' through a 'Traversable' functor, giving a 'Prism' that
 -- matches only if all the elements of the container match the 'Prism'.
 below
   :: (Is k A_Prism, Traversable f)

--- a/optics-core/src/Optics/Prism.hs
+++ b/optics-core/src/Optics/Prism.hs
@@ -1,4 +1,8 @@
--- | A 'Prism' generalises the notion of a constructor (just as a
+-- |
+-- Module: Optics.Prism
+-- Description: A generalised or first-class constructor.
+--
+-- A 'Prism' generalises the notion of a constructor (just as a
 -- 'Optics.Lens.Lens' generalises the notion of a field).
 --
 module Optics.Prism
@@ -9,32 +13,47 @@ module Optics.Prism
 
   -- * Introduction
   , prism
-  , prism'
-  , only
-  , nearly
 
   -- * Elimination
-  -- | A 'Prism' is a 'Optics.Review.Review', therefore you can
-  -- specialise types to obtain:
+  -- | A 'Prism' is an 'Optics.Review.Review' and an
+  -- 'Optics.AffineFold.AffineFold', therefore you can specialise types to
+  -- obtain:
   --
   -- @
-  -- 'Optics.Review.review' :: 'Prism' i s t a b -> b -> t
+  -- 'Optics.Review.review'  :: 'Prism' s t a b -> b -> t
+  -- 'Optics.AffineFold.preview' :: 'Prism'' s a -> s -> 'Maybe' a
   -- @
-  , withPrism
-  , isn't
   , matching
-
-  -- * Combinators
-  , aside
-  , without
-  , below
 
   -- * Computation
   -- |
   --
   -- @
-  -- 'withPrism' ('prism' f g) k = k f g
+  -- 'Optics.Review.review'   ('prism' f g) ≡ f
+  -- 'matching' ('prism' f g) ≡ g
   -- @
+
+  -- * Well-formedness
+  -- |
+  --
+  -- @
+  -- 'Optics.AffineFold.preview' o ('Optics.Review.review' o b) ≡ 'Just' b
+  -- 'Optics.AffineFold.preview' o s ≡ 'Just' a  =>  'Optics.Review.review' o a ≡ s
+  -- @
+
+  -- * Additional introduction forms
+  , prism'
+  , only
+  , nearly
+
+  -- * Additional elimination forms
+  , withPrism
+  , isn't
+
+  -- * Combinators
+  , aside
+  , without
+  , below
 
   -- * Subtyping
   , A_Prism
@@ -64,7 +83,8 @@ toPrism :: Is k A_Prism => Optic k is s t a b -> Optic A_Prism is s t a b
 toPrism = castOptic
 {-# INLINE toPrism #-}
 
--- | Build a prism from a constructor and a matcher.
+-- | Build a prism from a constructor and a matcher, which must respect the
+-- well-formedness laws.
 prism :: (b -> t) -> (s -> Either t a) -> Prism s t a b
 prism construct match = Optic $ dimap match (either id construct) . right'
 {-# INLINE prism #-}
@@ -136,6 +156,10 @@ isn't k s =
 
 -- | Retrieve the value targeted by a 'Prism' or return the original value while
 -- allowing the type to change if it does not match.
+--
+-- @
+-- 'Optics.AffineFold.preview' o ≡ 'either' ('const' 'Nothing') 'id' . 'matching' o
+-- @
 matching :: Is k A_Prism => Optic k is s t a b -> s -> Either t a
 matching o = withPrism o $ \_ match -> match
 {-# INLINE matching #-}

--- a/optics-core/src/Optics/PrismaticGetter.hs
+++ b/optics-core/src/Optics/PrismaticGetter.hs
@@ -1,4 +1,8 @@
--- | A 'PrismaticGetter' is a 'Optics.Getter.Getter' produces by
+-- |
+-- Module: Optics.PrismaticGetter
+-- Description: A 'Optics.Getter.Getter' produced by 'Optics.Re.re' on a 'Optics.Prism.Prism'.
+--
+-- A 'PrismaticGetter' is a 'Optics.Getter.Getter' produced by
 -- calling 'Optics.Re.re' on a 'Optics.Prism.Prism'.  It is
 -- essentially equivalent to a 'Optics.Getter.Getter', and is
 -- distinguished merely so that @'Optics.Re.re' . 'Optics.Re.re'@ on a

--- a/optics-core/src/Optics/PrismaticGetter.hs
+++ b/optics-core/src/Optics/PrismaticGetter.hs
@@ -1,7 +1,16 @@
+-- | A 'PrismaticGetter' is a 'Optics.Getter.Getter' produces by
+-- calling 'Optics.Re.re' on a 'Optics.Prism.Prism'.  It is
+-- essentially equivalent to a 'Optics.Getter.Getter', and is
+-- distinguished merely so that @'Optics.Re.re' . 'Optics.Re.re'@ on a
+-- 'Optics.Prism.Prism' returns a 'Optics.Prism.Prism'.
+--
 module Optics.PrismaticGetter
-  ( A_PrismaticGetter
-  , PrismaticGetter
+  ( -- * Formation
+    PrismaticGetter
   , PrismaticGetter'
+  , A_PrismaticGetter
+
+  -- * Re-exports
   , module Optics.Optic
   ) where
 

--- a/optics-core/src/Optics/Re.hs
+++ b/optics-core/src/Optics/Re.hs
@@ -10,9 +10,13 @@ import Optics.Internal.Profunctor
 
 class ReversibleOptic k where
   type ReversedOptic k :: *
-  -- | Reverses optics, turning around 'Equality' into 'Equality', 'Iso' into
-  -- 'Iso', 'Prism' into 'PrismaticGetter' (and back), 'Lens' into 'LensyReview'
-  -- (and back) and 'Getter' into 'Review' (and back).
+  -- | Reverses optics, turning around 'Optics.Equality.Equality' into
+  -- 'Optics.Equality.Equality', 'Optics.Iso.Iso' into
+  -- 'Optics.Iso.Iso', 'Optics.Prism.Prism' into
+  -- 'Optics.PrismaticGetter.PrismaticGetter' (and back),
+  -- 'Optics.Lens.Lens' into 'Optics.LensyReview.LensyReview' (and
+  -- back) and 'Optics.Getter.Getter' into 'Optics.Review.Review' (and
+  -- back).
   re :: Optic k NoIx s t a b -> Optic (ReversedOptic k) NoIx b a t s
 
 instance ReversibleOptic An_Equality where

--- a/optics-core/src/Optics/Review.hs
+++ b/optics-core/src/Optics/Review.hs
@@ -1,4 +1,8 @@
--- | A 'Review' is a backwards 'Optics.Getter.Getter', i.e. a
+-- |
+-- Module: Optics.Review
+-- Description: A backwards 'Optics.Getter.Getter', i.e. a function.
+--
+-- A 'Review' is a backwards 'Optics.Getter.Getter', i.e. a
 -- @'Review' T B@ is just a function @B -> T@.
 --
 module Optics.Review

--- a/optics-core/src/Optics/Review.hs
+++ b/optics-core/src/Optics/Review.hs
@@ -1,9 +1,29 @@
+-- | A 'Review' is a backwards 'Optics.Getter.Getter', i.e. a
+-- @'Review' T B@ is just a function @B -> T@.
+--
 module Optics.Review
-  ( A_Review
-  , Review
-  , toReview
-  , review
+  (
+  -- * Formation
+    Review
+
+  -- * Introduction
   , unto
+
+  -- * Elimination
+  , review
+
+  -- * Computation
+  -- |
+  --
+  -- @
+  -- 'review' ('unto' f) = f
+  -- @
+
+  -- * Subtyping
+  , A_Review
+  , toReview
+
+  -- * Re-exports
   , module Optics.Optic
   )
   where
@@ -31,7 +51,7 @@ review :: Is k A_Review => Optic' k is t b -> b -> t
 review o = unTagged #. getOptic (toReview o) .# Tagged
 {-# INLINE review #-}
 
--- | An analogue of 'to' for review.
+-- | An analogue of 'Optics.Getter.to' for reviews.
 unto :: (b -> t) -> Review t b
 unto f = Optic (lphantom . rmap f)
 {-# INLINE unto #-}

--- a/optics-core/src/Optics/Setter.hs
+++ b/optics-core/src/Optics/Setter.hs
@@ -1,14 +1,41 @@
+-- | A @'Setter' S T A B@ has the ability to lift a function of type
+-- @A -> B@ 'over' a function of type @S -> T@, applying the function
+-- to update all the @A@s contained in @S@.  This can be used to 'set'
+-- all the @A@s to a single value (by lifting a constant function).
+--
+-- This can be seen as a generalisation of 'fmap', where the type @S@
+-- does not need to be a type constructor with @A@ as its last
+-- parameter.
+--
 module Optics.Setter
-  ( A_Setter
-  , Setter
+  (
+  -- * Formation
+    Setter
   , Setter'
-  , toSetter
-  , over
-  , over'
-  , set
-  , set'
+
+  -- * Introduction
   , sets
   , mapped
+
+  -- * Elimination
+  , set
+  , set'
+  , over
+  , over'
+
+  -- * Subtyping
+  , A_Setter
+  , toSetter
+
+  -- * Computation
+  -- |
+  --
+  -- @
+  -- 'over' ('sets' f) g s = f g s
+  -- 'set' ('sets' f) v s = f ('const' v) s
+  -- @
+
+  -- * Re-exports
   , module Optics.Optic
   ) where
 
@@ -41,12 +68,14 @@ over o = \f -> runFunArrow $ getOptic (toSetter o) (FunArrow f)
 
 -- | Apply a setter as a modifier, strictly.
 --
+-- TODO DOC: what exactly is the strictness property?
+--
 -- Example:
 --
 -- @
 --  f :: Int -> (Int, a) -> (Int, a)
 --  f k acc
---    | k > 0     = f (k - 1) $ over' _1 (+1) acc
+--    | k > 0     = f (k - 1) $ 'over'' 'Data.Tuple.Optics._1' (+1) acc
 --    | otherwise = acc
 -- @
 --
@@ -79,6 +108,9 @@ set o = over o . const
 {-# INLINE set #-}
 
 -- | Apply a setter, strictly.
+--
+-- TODO DOC: what exactly is the strictness property?
+--
 set'
   :: Is k A_Setter
   => Optic k is s t a b
@@ -93,7 +125,8 @@ sets
 sets f = Optic (roam f)
 {-# INLINE sets #-}
 
--- | Setter via the 'Functor' class.
+-- | Create a 'Setter' for a 'Functor'.  Observe that @'over'
+-- 'mapped'@ is just 'fmap'.
 mapped :: Functor f => Setter (f a) (f b) a b
 mapped = Optic mapped__
 {-# INLINE mapped #-}

--- a/optics-core/src/Optics/Setter.hs
+++ b/optics-core/src/Optics/Setter.hs
@@ -1,4 +1,8 @@
--- | A @'Setter' S T A B@ has the ability to lift a function of type
+-- |
+-- Module: Optics.Setter
+-- Description: A 'Setter' applies an update to all contained values.
+--
+-- A @'Setter' S T A B@ has the ability to lift a function of type
 -- @A -> B@ 'over' a function of type @S -> T@, applying the function
 -- to update all the @A@s contained in @S@.  This can be used to 'set'
 -- all the @A@s to a single value (by lifting a constant function).
@@ -15,25 +19,39 @@ module Optics.Setter
 
   -- * Introduction
   , sets
-  , mapped
 
   -- * Elimination
   , set
-  , set'
   , over
-  , over'
-
-  -- * Subtyping
-  , A_Setter
-  , toSetter
 
   -- * Computation
   -- |
   --
   -- @
-  -- 'over' ('sets' f) g s = f g s
-  -- 'set' ('sets' f) v s = f ('const' v) s
+  -- 'set'  ('sets' f) v s ≡ f ('const' v) s
+  -- 'over' ('sets' f) g s ≡ f g s
   -- @
+
+  -- * Well-formedness
+  -- |
+  --
+  -- * __Functoriality__: 'Setter's must preserve identities and composition:
+  --
+  --    @
+  --    'over' s 'id' ≡ 'id'
+  --    'over' s f '.' 'over' s g ≡ 'over' s (f '.' g)
+  --    @
+
+  -- * Additional introduction forms
+  , mapped
+
+  -- * Additional elimination forms
+  , set'
+  , over'
+
+  -- * Subtyping
+  , A_Setter
+  , toSetter
 
   -- * Re-exports
   , module Optics.Optic
@@ -118,7 +136,8 @@ set'
 set' o = over' o . const
 {-# INLINE set' #-}
 
--- | Build a setter from a function to modify the element(s).
+-- | Build a setter from a function to modify the element(s), which must respect
+-- the well-formedness laws.
 sets
   :: ((a -> b) -> s -> t)
   -> Setter s t a b

--- a/optics-core/src/Optics/Setter.hs
+++ b/optics-core/src/Optics/Setter.hs
@@ -1,6 +1,6 @@
 -- |
 -- Module: Optics.Setter
--- Description: A 'Setter' applies an update to all contained values.
+-- Description: Applies an update to all contained values.
 --
 -- A @'Setter' S T A B@ has the ability to lift a function of type
 -- @A -> B@ 'over' a function of type @S -> T@, applying the function
@@ -21,31 +21,36 @@ module Optics.Setter
   , sets
 
   -- * Elimination
-  , set
   , over
 
   -- * Computation
   -- |
   --
   -- @
-  -- 'set'  ('sets' f) v s ≡ f ('const' v) s
-  -- 'over' ('sets' f) g s ≡ f g s
+  -- 'over' ('sets' f) ≡ f
   -- @
 
   -- * Well-formedness
   -- |
   --
+  -- * __PutPut__: Setting twice is the same as setting once:
+  --
+  --     @
+  --     'Optics.Setter.set' l v' ('Optics.Setter.set' l v s) ≡ 'Optics.Setter.set' l v' s
+  --     @
+  --
   -- * __Functoriality__: 'Setter's must preserve identities and composition:
   --
-  --    @
-  --    'over' s 'id' ≡ 'id'
-  --    'over' s f '.' 'over' s g ≡ 'over' s (f '.' g)
-  --    @
+  --     @
+  --     'over' s 'id' ≡ 'id'
+  --     'over' s f '.' 'over' s g ≡ 'over' s (f '.' g)
+  --     @
 
   -- * Additional introduction forms
   , mapped
 
   -- * Additional elimination forms
+  , set
   , set'
   , over'
 
@@ -114,6 +119,10 @@ over' o = \f ->
 
 -- | Apply a setter.
 --
+-- @
+-- 'set' o v ≡ 'over' o ('const' v)
+-- @
+--
 -- >>> let _1  = lens fst $ \(_,y) x -> (x, y)
 -- >>> set _1 'x' ('y', 'z')
 -- ('x','z')
@@ -144,8 +153,12 @@ sets
 sets f = Optic (roam f)
 {-# INLINE sets #-}
 
--- | Create a 'Setter' for a 'Functor'.  Observe that @'over'
--- 'mapped'@ is just 'fmap'.
+-- | Create a 'Setter' for a 'Functor'.
+--
+-- @
+-- 'over' 'mapped' ≡ 'fmap'
+-- @
+--
 mapped :: Functor f => Setter (f a) (f b) a b
 mapped = Optic mapped__
 {-# INLINE mapped #-}

--- a/optics-core/src/Optics/Traversal.hs
+++ b/optics-core/src/Optics/Traversal.hs
@@ -1,5 +1,9 @@
--- | A 'Traversal' lifts an effectful operation on elements to act on
--- structures containing those elements.
+-- |
+-- Module: Optics.Traversal
+-- Description: Lifts an effectful operation on elements to act on structures.
+--
+-- A 'Traversal' lifts an effectful operation on elements to act on structures
+-- containing those elements.
 --
 -- That is, given a function @op :: A -> F B@ where @F@ is
 -- 'Applicative', a @'Traversal' S T A B@ can produce a function @S ->
@@ -13,6 +17,7 @@
 --
 -- A close relative is the 'Optics.AffineTraversal.AffineTraversal',
 -- which is a 'Traversal' that acts on at most one value.
+--
 module Optics.Traversal
   (
   -- * Formation
@@ -20,12 +25,30 @@ module Optics.Traversal
   , Traversal'
 
   -- * Introduction
-  -- | A 'Traversal' can be constructed by applying 'traversalVL' to
-  -- the van Laarhoven encoding.
-  , traversed
+  , traversalVL
 
   -- * Elimination
   , traverseOf
+
+  -- * Computation
+  -- |
+  --
+  -- @
+  -- 'traverseOf' ('traversalVL' f) ≡ f
+  -- @
+
+  -- * Well-formedness
+  -- |
+  --
+  -- @
+  -- 'traverseOf' o 'pure' ≡ 'pure'
+  -- 'fmap' ('traverseOf' o f) . 'traverseOf' o g ≡ 'Data.Functor.Compose.getCompose' . 'traverseOf' o ('Data.Functor.Compose.Compose' . 'fmap' f . g)
+  -- @
+
+  -- * Additional introduction forms
+  , traversed
+
+  -- * Additional elimination forms
   , forOf
   , sequenceOf
   , transposeOf
@@ -35,14 +58,6 @@ module Optics.Traversal
   , scanl1Of
   , failover
   , failover'
-
-  -- * Computation
-  -- |
-  --
-  -- @
-  -- 'traverseOf' 'traversed' = 'traverse'
-  -- 'traverseOf' ('traversalVL' f) = f
-  -- @
 
     -- * Combinators
   , backwards
@@ -59,7 +74,6 @@ module Optics.Traversal
   -- converts a 'Traversal' to a 'TraversalVL'.
   , TraversalVL
   , TraversalVL'
-  , traversalVL
 
   -- * Re-exports
   , module Optics.Optic
@@ -263,7 +277,9 @@ failover' o = \f s ->
 
 -- | Construct a 'Traversal' via the 'Traversable' class.
 --
--- Observe that @'traverseOf' 'traversed' = 'traverse'@.
+-- @
+-- 'traverseOf' 'traversed' = 'traverse'
+-- @
 --
 traversed :: Traversable t => Traversal (t a) (t b) a b
 traversed = Optic traversed__

--- a/optics-core/src/Optics/Traversal.hs
+++ b/optics-core/src/Optics/Traversal.hs
@@ -1,12 +1,29 @@
+-- | A 'Traversal' lifts an effectful operation on elements to act on
+-- structures containing those elements.
+--
+-- That is, given a function @op :: A -> F B@ where @F@ is
+-- 'Applicative', a @'Traversal' S T A B@ can produce a function @S ->
+-- F T@ that applies @op@ to all the @A@s contained in the @S@.
+--
+-- This can be seen as a generalisation of 'traverse', where the type
+-- @S@ does not need to be a type constructor with @A@ as the last
+-- parameter.
+--
+-- A 'Lens' is a 'Traversal' that acts on a single value.
+--
+-- A close relative is the 'Optics.AffineTraversal.AffineTraversal',
+-- which is a 'Traversal' that acts on at most one value.
 module Optics.Traversal
   (
   -- * Formation
-    A_Traversal
-  , Traversal
+    Traversal
   , Traversal'
+
   -- * Introduction
+  -- | A 'Traversal' can be constructed by applying 'traversalVL' to
+  -- the van Laarhoven encoding.
   , traversed
-  , toTraversal
+
   -- * Elimination
   , traverseOf
   , forOf
@@ -18,13 +35,32 @@ module Optics.Traversal
   , scanl1Of
   , failover
   , failover'
-  -- * Combinators
+
+  -- * Computation
+  -- |
+  --
+  -- @
+  -- 'traverseOf' 'traversed' = 'traverse'
+  -- 'traverseOf' ('traversalVL' f) = f
+  -- @
+
+    -- * Combinators
   , backwards
   , partsOf
+
+  -- * Subtyping
+  , A_Traversal
+  , toTraversal
+
   -- * van Laarhoven encoding
+  -- | The van Laarhoven representation of a 'Traversal' directly
+  -- expresses how it lifts an effectful operation @A -> F B@ on
+  -- elements to act on structures @S -> F T@.  Thus 'traverseOf'
+  -- converts a 'Traversal' to a 'TraversalVL'.
   , TraversalVL
   , TraversalVL'
   , traversalVL
+
   -- * Re-exports
   , module Optics.Optic
   )
@@ -129,7 +165,7 @@ transposeOf o = getZipList #. traverseOf o ZipList
 -- | This generalizes 'Data.Traversable.mapAccumL' to an arbitrary 'Traversal'.
 --
 -- @
--- 'mapAccumL' ≡ 'mapAccumLOf' 'traverse'
+-- 'Data.Traversable.mapAccumL' ≡ 'mapAccumLOf' 'traverse'
 -- @
 --
 -- 'mapAccumLOf' accumulates 'State' from left to right.
@@ -146,7 +182,7 @@ mapAccumLOf o = \f acc0 s ->
 -- | This generalizes 'Data.Traversable.mapAccumR' to an arbitrary 'Traversal'.
 --
 -- @
--- 'mapAccumR' ≡ 'mapAccumROf' 'traversed'
+-- 'Data.Traversable.mapAccumR' ≡ 'mapAccumROf' 'traversed'
 -- @
 --
 -- 'mapAccumROf' accumulates 'State' from right to left.
@@ -225,7 +261,10 @@ failover' o = \f s ->
 ----------------------------------------
 -- Traversals
 
--- | Traversal via the 'Traversable' class.
+-- | Construct a 'Traversal' via the 'Traversable' class.
+--
+-- Observe that @'traverseOf' 'traversed' = 'traverse'@.
+--
 traversed :: Traversable t => Traversal (t a) (t b) a b
 traversed = Optic traversed__
 {-# INLINE traversed #-}

--- a/optics-extra/src/Data/Text/Lazy/Optics.hs
+++ b/optics-extra/src/Data/Text/Lazy/Optics.hs
@@ -1,5 +1,16 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns #-}
+-- |
+-- Module: Data.Text.Lazy.Optics
+-- Description: Optics for working with lazy 'Text.Text'.
+--
+-- This module provides 'Iso's for converting lazy 'Text.Text' to or from a
+-- 'String' or 'Builder', and an 'IxTraversal' for traversing the individual
+-- characters of a 'Text.Text'.
+--
+-- If you need to work with both strict and lazy text, "Data.Text.Optics"
+-- provides combinators that support both varieties using a typeclass.
+--
 module Data.Text.Lazy.Optics
   ( packed
   , unpacked
@@ -10,7 +21,7 @@ module Data.Text.Lazy.Optics
   , pattern Text
   ) where
 
-import Data.ByteString.Lazy as ByteString
+import Data.ByteString.Lazy (ByteString)
 import Data.Text.Lazy as Text
 import Data.Text.Lazy.Builder
 import Data.Text.Lazy.Encoding
@@ -26,28 +37,28 @@ import Optics.Internal.Profunctor
 -- >>> :set -XOverloadedStrings
 -- >>> import Optics.Core
 
--- | This isomorphism can be used to 'pack' (or 'unpack') lazy 'Text'.
+-- | This isomorphism can be used to 'pack' (or 'unpack') lazy 'Text.Text'.
 --
 -- >>> "hello"^.packed -- :: Text
 -- "hello"
 --
 -- @
--- 'pack' x ≡ x '^.' 'packed'
--- 'unpack' x ≡ x '^.' 're' 'packed'
+-- 'pack' x ≡ x 'Optics.Operators.^.' 'packed'
+-- 'unpack' x ≡ x 'Optics.Operators.^.' 're' 'packed'
 -- 'packed' ≡ 're' 'unpacked'
 -- @
 packed :: Iso' String Text
 packed = iso Text.pack Text.unpack
 {-# INLINE packed #-}
 
--- | This isomorphism can be used to 'unpack' (or 'pack') lazy 'Text'.
+-- | This isomorphism can be used to 'unpack' (or 'pack') lazy 'Text.Text'.
 --
 -- >>> "hello"^.unpacked -- :: String
 -- "hello"
 --
 -- @
--- 'pack' x ≡ x '^.' 're' 'unpacked'
--- 'unpack' x ≡ x '^.' 'packed'
+-- 'pack' x ≡ x 'Optics.Operators.^.' 're' 'unpacked'
+-- 'unpack' x ≡ x 'Optics.Operators.^.' 'packed'
 -- @
 --
 -- This 'Iso' is provided for notational convenience rather than out of great
@@ -61,7 +72,7 @@ unpacked = Optic unpacked__
 {-# INLINE unpacked #-}
 
 -- | This is an alias for 'unpacked' that makes it clearer how to use it with
--- @('#')@.
+-- @('Optics.Operators.#')@.
 --
 -- @
 -- '_Text' = 're' 'packed'
@@ -73,17 +84,17 @@ _Text :: Iso' Text String
 _Text = re packed
 {-# INLINE _Text #-}
 
--- | Convert between lazy 'Text' and 'Builder' .
+-- | Convert between lazy 'Text.Text' and 'Builder' .
 --
 -- @
--- 'fromLazyText' x ≡ x '^.' 'builder'
--- 'toLazyText' x ≡ x '^.' 're' 'builder'
+-- 'fromLazyText' x ≡ x 'Optics.Operators.^.' 'builder'
+-- 'toLazyText' x ≡ x 'Optics.Operators.^.' 're' 'builder'
 -- @
 builder :: Iso' Text Builder
 builder = iso fromLazyText toLazyText
 {-# INLINE builder #-}
 
--- | Traverse the individual characters in a 'Text'.
+-- | Traverse the individual characters in a 'Text.Text'.
 --
 -- >>> anyOf text (=='c') "chello"
 -- True
@@ -104,7 +115,7 @@ text :: IxTraversal' Int Text Char
 text = Optic text__
 {-# INLINE text #-}
 
--- | Encode\/Decode a lazy 'Text' to\/from lazy 'ByteString', via UTF-8.
+-- | Encode\/Decode a lazy 'Text.Text' to\/from lazy 'ByteString', via UTF-8.
 --
 -- Note: This function does not decode lazily, as it must consume the entire
 -- input before deciding whether or not it fails.

--- a/optics-extra/src/Data/Text/Optics.hs
+++ b/optics-extra/src/Data/Text/Optics.hs
@@ -1,5 +1,17 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE PatternSynonyms #-}
+-- |
+-- Module: Data.Text.Optics
+-- Description: Optics for working with strict or lazy 'Text'.
+--
+-- This module provides 'Iso's for converting strict or lazy 'Text' to or from a
+-- 'String' or 'Builder', and an 'IxTraversal' for traversing the individual
+-- characters of a 'Text'.
+--
+-- The same combinators support both strict and lazy text using the 'IsText'
+-- typeclass.  You can import "Data.Text.Strict.Optics" or
+-- "Data.Text.Lazy.Optics" instead if you prefer monomorphic versions.
+--
 module Data.Text.Optics
   ( IsText(..)
   , unpacked
@@ -24,8 +36,8 @@ class IsText t where
   -- 'Text'.
   --
   -- @
-  -- 'pack' x ≡ x '^.' 'packed'
-  -- 'unpack' x ≡ x '^.' 're' 'packed'
+  -- 'pack' x ≡ x 'Optics.Operators.^.' 'packed'
+  -- 'unpack' x ≡ x 'Optics.Operators.^.' 're' 'packed'
   -- 'packed' ≡ 're' 'unpacked'
   -- @
   packed :: Iso' String t
@@ -33,7 +45,7 @@ class IsText t where
   -- | Convert between strict or lazy 'Text' and a 'Builder'.
   --
   -- @
-  -- 'fromText' x ≡ x '^.' 'builder'
+  -- 'fromText' x ≡ x 'Optics.Operators.^.' 'builder'
   -- @
   builder :: Iso' t Builder
 
@@ -58,8 +70,8 @@ instance IsText String where
 -- 'Text'.
 --
 -- @
--- 'unpack' x ≡ x '^.' 'unpacked'
--- 'pack' x ≡ x '^.' 're' 'unpacked'
+-- 'unpack' x ≡ x 'Optics.Operators.^.' 'unpacked'
+-- 'pack' x ≡ x 'Optics.Operators.^.' 're' 'unpacked'
 -- @
 --
 -- This 'Iso' is provided for notational convenience rather than out of great
@@ -74,7 +86,7 @@ unpacked = re packed
 {-# INLINE unpacked #-}
 
 -- | This is an alias for 'unpacked' that makes it clearer how to use it with
--- @('#')@.
+-- @('Optics.Operators.#')@.
 --
 -- @
 -- '_Text' = 're' 'packed'

--- a/optics-extra/src/Data/Text/Strict/Optics.hs
+++ b/optics-extra/src/Data/Text/Strict/Optics.hs
@@ -1,5 +1,16 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE PatternSynonyms #-}
+-- |
+-- Module: Data.Text.Strict.Optics
+-- Description: Optics for working with strict 'Strict.Text'.
+--
+-- This module provides 'Iso's for converting strict 'Strict.Text' to or from a
+-- 'String' or 'Builder', and an 'IxTraversal' for traversing the individual
+-- characters of a 'Strict.Text'.
+--
+-- If you need to work with both strict and lazy text, "Data.Text.Optics"
+-- provides combinators that support both varieties using a typeclass.
+--
 module Data.Text.Strict.Optics
   ( packed
   , unpacked
@@ -27,15 +38,15 @@ import Optics.Internal.Profunctor
 -- >>> :set -XOverloadedStrings
 -- >>> import Optics.Core
 
--- | This isomorphism can be used to 'pack' (or 'unpack') strict 'Text'.
+-- | This isomorphism can be used to 'pack' (or 'unpack') strict 'Strict.Text'.
 --
 --
 -- >>> "hello"^.packed -- :: Text
 -- "hello"
 --
 -- @
--- 'pack' x ≡ x '^.' 'packed'
--- 'unpack' x ≡ x '^.' 're' 'packed'
+-- 'pack' x ≡ x 'Optics.Operators.^.' 'packed'
+-- 'unpack' x ≡ x 'Optics.Operators.^.' 're' 'packed'
 -- 'packed' ≡ 're' 'unpacked'
 -- 'packed' ≡ 'iso' 'pack' 'unpack'
 -- @
@@ -43,7 +54,7 @@ packed :: Iso' String Text
 packed = iso pack unpack
 {-# INLINE packed #-}
 
--- | This isomorphism can be used to 'unpack' (or 'pack') lazy 'Text'.
+-- | This isomorphism can be used to 'unpack' (or 'pack') strict 'Strict.Text'.
 --
 -- >>> "hello"^.unpacked -- :: String
 -- "hello"
@@ -56,8 +67,8 @@ packed = iso pack unpack
 -- @
 --
 -- @
--- 'pack' x ≡ x '^.' 're' 'unpacked'
--- 'unpack' x ≡ x '^.' 'packed'
+-- 'pack' x ≡ x 'Optics.Operators.^.' 're' 'unpacked'
+-- 'unpack' x ≡ x 'Optics.Operators.^.' 'packed'
 -- 'unpacked' ≡ 'iso' 'unpack' 'pack'
 -- @
 unpacked :: Iso' Text String
@@ -65,7 +76,7 @@ unpacked = Optic unpacked__
 {-# INLINE unpacked #-}
 
 -- | This is an alias for 'unpacked' that makes it more obvious how to use it
--- with '#'
+-- with 'Optics.Operators.#'
 --
 -- >> _Text # "hello" -- :: Text
 -- "hello"
@@ -73,17 +84,17 @@ _Text :: Iso' Text String
 _Text = unpacked
 {-# INLINE _Text #-}
 
--- | Convert between strict 'Text' and 'Builder' .
+-- | Convert between strict 'Strict.Text' and 'Builder' .
 --
 -- @
--- 'fromText' x ≡ x '^.' 'builder'
--- 'toStrict' ('toLazyText' x) ≡ x '^.' 're' 'builder'
+-- 'fromText' x ≡ x 'Optics.Operators.^.' 'builder'
+-- 'toStrict' ('toLazyText' x) ≡ x 'Optics.Operators.^.' 're' 'builder'
 -- @
 builder :: Iso' Text Builder
 builder = iso fromText (toStrict . toLazyText)
 {-# INLINE builder #-}
 
--- | Traverse the individual characters in strict 'Text'.
+-- | Traverse the individual characters in strict 'Strict.Text'.
 --
 -- >>> anyOf text (=='o') "hello"
 -- True
@@ -101,7 +112,7 @@ text :: IxTraversal' Int Text Char
 text = Optic text__
 {-# INLINE text #-}
 
--- | Encode\/Decode a strict 'Text' to\/from strict 'ByteString', via UTF-8.
+-- | Encode\/Decode a strict 'Strict.Text' to\/from strict 'ByteString', via UTF-8.
 --
 -- >>> utf8 # "☃"
 -- "\226\152\131"

--- a/optics-extra/src/Optics/At.hs
+++ b/optics-extra/src/Optics/At.hs
@@ -1,15 +1,43 @@
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+-- |
+-- Module: Optics.At
+-- Description: Optics for 'Data.Map.Map' and 'Data.Set.Set'-like containers.
+--
+-- This module provides optics for 'Data.Map.Map' and 'Data.Set.Set'-like
+-- containers, including an 'AffineTraversal' to traverse a key in a map or an
+-- element of a sequence:
+--
+-- >>> preview (ix 1) ['a','b','c']
+-- Just 'b'
+--
+-- a 'Lens' to get, set or delete a key in a map:
+--
+-- >>> set (at 0) (Just 'b') (Map.fromList [(0, 'a')])
+-- fromList [(0,'b')]
+--
+-- and a 'Lens' to insert or remove an element of a set:
+--
+-- >>> IntSet.fromList [1,2,3,4] & contains 3 .~ False
+-- fromList [1,2,4]
+--
+-- This module includes the core definitions from "Optics.At.Core" along with
+-- extra (orphan) instances.
+--
 module Optics.At
   (
-  -- * At
-    At(..)
-  , sans
-  -- * Ixed
-  , Index
+    -- * Type families
+    Index
   , IxValue
+
+    -- * Ixed
   , Ixed(ix)
   , ixAt
+
+    -- * At
+  , At(..)
+  , sans
+
   -- * Contains
   , Contains(..)
   ) where

--- a/optics-extra/src/Optics/Indexed.hs
+++ b/optics-extra/src/Optics/Indexed.hs
@@ -1,12 +1,23 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+-- |
+-- Module: Optics.Indexed
+-- Description: Definitions of indexed optics.
+--
+-- This module defines general functionality for indexed optics.  See the
+-- "Indexed optics" section of the overview documentation in the @Optics@ module
+-- of the main @optics@ package for more details.
+--
+-- Unlike "Optics.Indexed.Core", this includes the definitions from modules for
+-- specific indexed optic flavours such as "Optics.IxTraversal", and includes
+-- additional instances for 'FunctorWithIndex' and similar classes.
+--
 module Optics.Indexed
-  ( -- * Indexed optics
-    module Optics.IxTraversal
-  , module Optics.IxFold
-  , module Optics.IxSetter
+  (
+    -- * Class for optic kinds that can be indexed
+    IxOptic(..)
 
-  -- * Index composition and modification
+    -- * Composition of indexed optics
   , (<%>)
   , (%>)
   , (<%)
@@ -15,7 +26,13 @@ module Optics.Indexed
   , icompose3
   , icompose4
   , icompose5
-  , IxOptic(..)
+
+    -- * Indexed optic flavours
+  , module Optics.IxAffineFold
+  , module Optics.IxAffineTraversal
+  , module Optics.IxFold
+  , module Optics.IxSetter
+  , module Optics.IxTraversal
 
   -- * Functors with index
   , FunctorWithIndex (..)
@@ -33,6 +50,8 @@ import qualified Data.Vector as V
 
 import Optics.Indexed.Core
 import Optics.Internal.Indexed
+import Optics.IxAffineFold
+import Optics.IxAffineTraversal
 import Optics.IxFold
 import Optics.IxSetter
 import Optics.IxTraversal

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -7,14 +7,17 @@ maintainer:      oleg@well-typed.com
 author:          Edward Kmett, Adam Gundry, Andres Löh, Andrzej Rybczak
 cabal-version:   1.24
 tested-with:     ghc ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.3
-synopsis:        Optics for generics-sop, and using generics-sop
+synopsis:        Optics as an abstract interface
 category:        Data, Optics, Lenses, Generics
 description:
-  TODO: briefly mention motivation and differences from @lens@
-  This package provides core definitions with small dependency footprint.
-  See @optics@ package (and its dependencies) for "batteries-included"
-  variant.
-  See the main module "Optics" for the documentation.
+  This package provides optics (as in the @lens@ package) but
+  encapsulates them in an abstract interface. See the main module
+  "Optics" for the documentation.
+
+  This is the "batteries-included"
+  variant with many dependencies; see the @optics-core@ package and
+  other @optics-*@ dependencies if you need a more limited dependency
+  footprint.
 
 extra-doc-files:
   optics.png

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -329,6 +329,9 @@ import Data.Either.Optics                    as P
 
 -- $differences
 --
+-- The sections above set out the major conceptual differences from the @lens@
+-- package. Some more specific design differences:
+--
 -- * The composition operator is ('%') rather than ('.').
 --
 -- * Fewer operators are provided, and none of operators are exported from the
@@ -351,6 +354,8 @@ import Data.Either.Optics                    as P
 --
 -- * @firstOf@ from @lens@ is replaced by 'headOf'.
 --
+-- * @concatOf@ from @lens@ is omitted in favour of the more general 'foldOf'.
+--
 -- * 'set'' is a strict version of 'set', not 'set' for type-preserving optics.
 --
 -- * Numbered lenses for accessing fields of tuples positionally are provided
@@ -370,8 +375,11 @@ import Data.Either.Optics                    as P
 -- * We can't use 'traverse' as an optic directly.  Instead there is a
 --   'Traversal' called 'traversed'.  Similarly 'traverseOf' must be used to
 --   apply a 'Traversal', rather than simply using it as a function.
-
--- * There are no 'from', only 're'.
+--
+-- * The 're' combinator produces a different optic kind depending on the kind
+--   of the input 'Iso', for example 'Prism' reverses to 'Getter' while a
+--   reversed 'Iso' is still an 'Iso'.  Thus there is no separate @from@
+--   combinator for reversing 'Iso's.
 
 
 -- $otherresources

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -409,8 +409,8 @@ import Data.Either.Optics                    as P
 -- * the subtyping relation 'Is' with an accompanying 'castOptic' function to
 --   convert an optic kind;
 --
--- * the 'Join' semilattice structure used to find the optic kind resulting from
---   a composition.
+-- * the 'Join' operation used to find the optic kind resulting from a
+--   composition.
 --
 -- Each optic kind is identified by a "tag type" (such as 'A_Lens'), which is an
 -- empty data type.  The type of the actual optics (such as 'Lens') is obtained
@@ -422,14 +422,27 @@ import Data.Either.Optics                    as P
 --
 -- <<optics.png Optics hierarchy>>
 --
--- The hierachy is a join-semilattice, where the optic kind resulting from a
--- composition is the least upper bound of the optic kinds being composed.  The
--- 'Join' type family computes the least upper bound given two optic kind tags.
--- For example the 'Join' of a 'Lens' and a 'Prism' is an 'AffineTraversal'.
+-- The optic kind resulting from a composition is the least upper bound (join)
+-- of the optic kinds being composed, if it exists.  The 'Join' type family
+-- computes the least upper bound given two optic kind tags.  For example the
+-- 'Join' of a 'Lens' and a 'Prism' is an 'AffineTraversal'.
 --
 -- >>> :kind! Join A_Lens A_Prism
 -- Join A_Lens A_Prism :: *
 -- = An_AffineTraversal
+--
+-- The join does not exist for some pairs of optic kinds, which means that they
+-- cannot be composed.  For example there is no optic kind above both 'Setter'
+-- and 'Fold':
+--
+-- >>> :kind! Join A_Setter A_Fold
+-- Join A_Setter A_Fold :: *
+-- = (TypeError ...)
+--
+-- >>> :t mapped % folded
+-- ...
+-- ...A_Setter cannot be composed with A_Fold
+-- ...
 --
 -- In addition to the optic kinds described above, there are also indexed
 -- variants, namely 'IxAffineTraversal', 'IxTraversal', 'IxAffineFold', 'IxFold'

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -47,165 +47,16 @@ module Optics
   -- * Basic usage
   -- $basicusage
 
-  -- * Core definitions
-
-  -- | "Optics.Optic" module provides core definitions:
-  --
-  -- * Opaque 'Optic' type,
-  --
-  -- * which is parameterised over a type representing an optic flavour;
-  --
-  -- * 'Is' and 'Join' relations, illustrated in the graph below;
-  --
-  -- * and optic composition operators '%' and '%%'.
-  --
-  -- <<optics.png Optics hierarchy>>
-  --
-  -- The arrows represent 'Is' relation (partial order). The hierachy is a 'Join' semilattice, for example the
-  -- 'Join' of a 'Lens' and a 'Prism' is an 'AffineTraversal'.
-  --
-  -- >>> :kind! Join A_Lens A_Prism
-  -- Join A_Lens A_Prism :: *
-  -- = An_AffineTraversal
-  --
-  -- There are also indexed variants of 'Traversal', 'Fold' and 'Setter'.
-  -- Indexed optics are explained in more detail in /Differences from lens/ section.
-  --
+  -- * Core definitions and subtyping
+  -- $coredefinitions
     module Optics.Optic
 
-  -- * Optic variants
-
-  -- | #opticvariants#
-  --
-  -- There are 16 different kinds of optics, each documented in a separate
-  -- module.  Each optic module documentation has /formation/, /introduction/,
-  -- /elimination/, and /well-formedness/ sections.
-  --
-  -- * The __formation__ sections contain type definitions. For example
-  --
-  --     @
-  --     -- Tag for a lens.
-  --     data A_Lens
-  --
-  --     -- Type synonym for a type-modifying lens.
-  --     type 'Lens' s t a b = 'Optic' 'A_Lens' NoIx s t a b
-  --     @
-  --
-  -- * In the __introduction__ sections are described the ways to construct
-  --   the particular optic. Continuing with a 'Lens' example:
-  --
-  --     @
-  --     -- Build a lens from a getter and a setter.
-  --     'lens' :: (s -> a) -> (s -> b -> t) :: 'Lens' s t a b
-  --     @
-  --
-  -- * In the __elimination__ sections are shown how you can destruct the
-  --   optic into a pieces it was constructed from.
-  --
-  --     @
-  --     -- 'Lens' is a 'Setter' and a 'Getter', therefore you can
-  --
-  --     'view' :: 'Lens' s t a b -> s -> a
-  --     'set'  :: 'Lens' s t a b -> b -> s -> t
-  --     'over' :: 'Lens' s t a b -> (a -> b) -> s -> t
-  --     @
-  --
-  -- * __Computation__ rules tie introduction and
-  --   elimination combinators together. These rules are automatically
-  --   fulfilled.
-  --
-  --     @
-  --     'view' ('lens' f g)   s = f s
-  --     'set'  ('lens' f g) a s = g s a
-  --     @
-  --
-  -- * All optics provided by the library are __well-formed__.
-  --     Constructing of ill-formed optics is possible, but should be avoided.
-  --     Ill-formed optic /might/ behave differently from what computation rules specify.
-  --
-  --     A 'Lens' should obey three laws, known as /GetPut/, /PutGet/ and /PutPut/.
-  --     See "Optics.Lens" module for their definitions.
-  --
-  -- /Note:/ you should also consult the optics hierarchy diagram.
-  -- Neither introduction or elimination sections list all ways to construct or use
-  -- particular optic kind.
-  -- For example you can construct 'Lens' from 'Iso' using 'castOptic'.
-  -- Also, as a 'Lens' is also a 'Traversal', a 'Fold' etc, so you can use 'traverseOf', 'preview'
-  -- and many other combinators.
-  --
+  -- * Optic kinds
+  -- $optickinds
   , module O
 
   -- * Indexed optics
-
-  -- |
-  --
-  -- @optics@ library also provides indexed optics, which provide
-  -- an additional /index/ value in mappings:
-  --
-  -- @
-  -- 'over'  :: 'Setter'     s t a b -> (a -> b)      -> s -> t
-  -- 'iover' :: 'IxSetter' i s t a b -> (i -> a -> b) -> s -> t
-  -- @
-  --
-  -- Note that there aren't any laws about indices.
-  -- Especially in compositions same index may occur multiple times.
-  --
-  -- The machinery builds on indexed variants of 'Functor', 'Foldable', and 'Traversable' classes:
-  -- 'FunctorWithIndex', 'FoldableWithIndex' and 'TraversableWithIndex' respectively.
-  -- There are instances for types in the boot libraries.
-  --
-  -- @
-  -- class ('FoldableWithIndex' i t, 'Traversable' t)
-  --   => 'TraversableWithIndex' i t | t -> i where
-  --     'itraverse' :: 'Applicative' f => (i -> a -> f b) -> t a -> f (t b)
-  -- @
-  --
-  -- Indexed optics /can/ be used as regular ones, i.e. indexed optics
-  -- gracefully downgrade to regular ones.
-  --
-  -- >>> toListOf ifolded "foo"
-  -- "foo"
-  --
-  -- But there is also a combinator to explicitly erase indices:
-  --
-  -- >>> :t (ifolded % simple)
-  -- (ifolded % simple)
-  --   :: FoldableWithIndex i f => Optic A_Fold '[i] (f b) (f b) b b
-  --
-  -- >>> :t noIx (ifolded % simple)
-  -- noIx (ifolded % simple)
-  --   :: FoldableWithIndex i f => Optic A_Fold NoIx (f b) (f b) b b
-  --
-  -- 'noIx' can erase all indices
-  --
-  -- >>> :t noIx (ifolded % ifolded)
-  -- noIx (ifolded % ifolded)
-  --   :: (FoldableWithIndex i1 f1, FoldableWithIndex i2 f2) =>
-  --      Optic A_Fold NoIx (f1 (f2 b)) (f1 (f2 b)) b b
-  --
-  -- As the example above illustrates (/TODO:/ will do),
-  -- regular and indexed optics have the same kind, in this case @'Optic' 'A_Fold'@.
-  -- Regular optics simply don't have any indices.
-  -- The provided type aliases `IxFold`, `IxSetter` and `IxTraversal`
-  -- are variants with a single index.
-  --
-  -- In the diagram below, the optics hierachy is amended with these (singly) indexed variants (in blue).
-  -- Orange arrows mean
-  -- "can be used as one, assuming it's composed with any optic below the
-  -- orange arrow first". For example. '_1' is not an indexed fold, but
-  -- @'itraversed' % '_1'@ is, because it's an indexed traversal, so it's
-  -- also an indexed fold.
-  --
-  -- >>> let fst' = _1 :: Lens (a, c) (b, c) a b
-  -- >>> :t fst' % itraversed
-  -- fst' % itraversed
-  --   :: TraversableWithIndex i t =>
-  --      Optic A_Traversal (WithIx i) (t a, c) (t b, c) a b
-  --
-  -- <<indexedoptics.png Indexed Optics>>
-  --
-  -- /TODO:/ write about 'icompose' and multiple indices.
-  --
+  -- $indexed
   , module Optics.Indexed
 
   -- * Optics utilities
@@ -215,13 +66,13 @@ module Optics
   -- | An 'AffineTraversal' to traverse a key in a map or an element of a
   -- sequence:
   --
-  -- >>> headOf (ix 1) ['a','b','c']
-  -- ... Just 'b'
+  -- >>> preview (ix 1) ['a','b','c']
+  -- Just 'b'
   --
   -- and a 'Lens' to get, set or delete a key in a map:
   --
   -- >>> set (at 0) (Just 'b') (Map.fromList [(0, 'a')])
-  -- ... Map.fromList [(0,'b')]
+  -- fromList [(0,'b')]
   --
   , module Optics.At
 
@@ -231,10 +82,10 @@ module Optics
   -- sequential structure:
   --
   -- >>> preview _Cons "abc"
-  -- ... Just ('a',"bc")
+  -- Just ('a',"bc")
   --
   -- >>> preview _Snoc "abc"
-  -- ... Just ("ab",'c')
+  -- Just ("ab",'c')
   --
   , module Optics.Cons
 
@@ -248,18 +99,18 @@ module Optics
   , module Optics.Each
 
   -- ** Empty
+
+  -- | A 'Prism' for a container type that may be empty.
+  --
+  -- >>> isn't _Empty [1,2,3]
+  -- True
+  --
   , module Optics.Empty
 
   -- ** Re
 
-  -- | Some optics can be reversed with 're':
-  -- @'Iso' s t a b@ into @'Iso' b a t s@,
-  -- @'Getter' s t a b@ into @'Review' b a t s@ etc.
-  -- Red arrows illustrate how 're' transforms optics:
-  --
-  -- <<reoptics.png Reversed Optics>>
-  --
-  -- 're' is mainly useful to invert 'Iso's:
+  -- | Some optics can be reversed with 're'.  This is mainly useful to invert
+  -- 'Iso's:
   --
   -- >>> let _Identity = iso runIdentity Identity
   -- >>> view (_1 % re _Identity) ('x', "yz")
@@ -270,14 +121,49 @@ module Optics
   -- >>> review (re _1) ('x', "yz")
   -- 'x'
   --
-  -- /Note:/ there are no @from@ combinator.
-
+  -- In the following diagram, red arrows illustrate how 're' transforms optics.
+  -- The 'LensyReview' and 'PrismaticGetter' optic kinds are essentially
+  -- equivalent to 'Review' and 'Getter' respectively, but are present so that
+  -- @'re' . 're'@ does not change the optic kind.
+  --
+  -- <<reoptics.png Reversed Optics>>
+  --
   , module Optics.Re
 
   -- ** View
+
+  -- | A generalized view function 'gview', which returns a single result (like
+  -- 'view') if the optic is a 'Getter', a 'Maybe' result (like 'preview') if
+  -- the optic is an 'AffineFold', or a monoidal summary of results (like
+  -- 'foldOf') if the optic is a 'Fold'.  In addition, it works for any
+  -- 'Control.Monad.Reader.MonadReader', not just @(->)@.
+  --
+  -- >>> gview _1 ('x','y')
+  -- 'x'
+  --
+  -- >>> gview _Left (Left 'x')
+  -- Just 'x'
+  --
+  -- >>> gview folded ["a", "b"]
+  -- "ab"
+  --
+  -- >>> runReaderT (gview _1) ('x','y') :: IO Char
+  -- 'x'
+  --
+  -- This module is experimental.  Using the more type-restricted variants is
+  -- encouraged where possible.
+  --
   , module Optics.View
 
   -- ** Zoom
+
+  -- | A class to 'zoom' in, changing the 'Control.Monad.State.State' supplied
+  -- by many different monad transformers, potentially quite deep in a monad
+  -- transformer stack.
+  --
+  -- >>> flip execState ('a','b') $ zoom _1 $ equality .= 'c'
+  -- ('c','b')
+  --
   , module Optics.Zoom
 
   -- * Generation of optics with Template Haskell
@@ -295,23 +181,23 @@ module Optics
 import Optics.Optic
 
 import Optics.Traversal                      as O
-import Optics.AffineTraversal                as O
 import Optics.Setter                         as O
 import Optics.Review                         as O
 import Optics.PrismaticGetter                as O
 import Optics.Prism                          as O
 import Optics.LensyReview                    as O
 import Optics.Lens                           as O
-import Optics.IxSetter                       as O
 import Optics.IxTraversal                    as O
-import Optics.IxAffineTraversal              as O
+import Optics.IxSetter                       as O
 import Optics.IxFold                         as O
+import Optics.IxAffineTraversal              as O
 import Optics.IxAffineFold                   as O
 import Optics.Iso                            as O
 import Optics.Getter                         as O
 import Optics.Fold                           as O
-import Optics.AffineFold                     as O
 import Optics.Equality                       as O
+import Optics.AffineTraversal                as O
+import Optics.AffineFold                     as O
 
 -- Optics utilities
 import Optics.At
@@ -340,9 +226,9 @@ import Data.Either.Optics                    as P
 -- think in terms of the abstract interface, rather than the details of the
 -- implementation, and implementation choices should not dictate the interface.
 --
--- Each optic variant has a module describing its abstract interface (e.g. see
--- "Optics.Lens"). See "Optics#opticvariants" below for a discussion of the
--- standard format in which these interfaces are described.
+-- Each optic kind has a module describing its abstract interface (e.g. see
+-- "Optics.Lens"). See "Optic kinds" below in "Optics#optickinds" for a
+-- discussion of the standard format in which these interfaces are described.
 --
 -- There is a subtyping relationship between optics, which is implemented using
 -- typeclasses.  In particular, the 'Is' typeclass captures the property that
@@ -350,7 +236,8 @@ import Data.Either.Optics                    as P
 -- 'A_Traversal'@ instance means that lenses can be used as traversals.
 -- Introduction forms (constructors) return a concrete optic kind, while
 -- elimination forms are generally polymorphic in the optic kind they accept.
--- (TODO: link to further discussion of subtyping.)
+-- See "Core definitions and subtyping" below in "Optics#coredefinitions" for
+-- more details.
 --
 -- For example,
 --
@@ -377,13 +264,12 @@ import Data.Either.Optics                    as P
 
 -- $advantages
 --
--- In general, this leads to better results from type inference (optics kind is
--- preserved)
+-- In general, this leads to better results from type inference (the optic kind
+-- is preserved in the inferred type):
 --
 --     >>> :t traversed % to not
 --     traversed % to not
 --       :: Traversable t => Optic A_Fold NoIx (t Bool) (t Bool) Bool Bool
---
 --
 -- Error messages are domain-specific:
 --
@@ -403,11 +289,24 @@ import Data.Either.Optics                    as P
 -- datastructure:
 --
 -- >>> :t [folded, backwards_ folded]
--- ... [folded, backwards_ folded] :: Foldable f => [Fold (f a) a]
+-- [folded, backwards_ folded] :: Foldable f => [Fold (f a) a]
 --
--- TODO: Less vulnerable to the monomorphism restriction
+-- It is possible to define aliases for optics without the monomorphism
+-- restriction spoiling the fun:
 --
--- TODO: Free choice of lens implementation
+-- >>> let { myoptic = _1; p = ('x','y') } in (view myoptic p, set myoptic 'c' p)
+-- ('x',('c','y'))
+--
+-- Since the interface is chosen rather than predetermined by the
+-- implementation, we are free to choose a more restricted interface where doing
+-- so leads to conceptual simplicity.  Thus we prefer separate 'view' and
+-- 'foldOf' operators rather than having 'view' unexpectedly introduce a
+-- 'Monoid' constraint when used with a 'Fold'.
+--
+-- Finally, having an abstract interface gives more freedom of choice in the
+-- internal implementation.  If there is a compelling reason to switch to an
+-- alternative representation, one can in principle do so without changing the
+-- interface.
 
 
 -- $disadvantages
@@ -420,60 +319,288 @@ import Data.Either.Optics                    as P
 -- on definitions from @base@, it is possible for libraries to define them
 -- without any extra dependencies, although this does not hold for more advanced
 -- optic kinds such as prisms or indexed optics).
--- TODO: document the package structure somewhere?
 --
--- TODO: polymorphism has to be \"baked in\" rather than emerging naturally from definitions
---
--- TODO: Can’t insert points into the subtyping order post hoc
+-- Rather than emerging naturally from the definitions, opportunities for
+-- polymorphism have to be identified in advance and explicitly introduced using
+-- type classes.  Similarly, the set of optic kinds and the subtyping
+-- relationships between them must be fixed in advance, and cannot be added to
+-- in downstream libraries.
 
 
 -- $differences
 --
--- TODO: tidy up this section
+-- * The composition operator is ('%') rather than ('.').
 --
--- * Composition operator is '%'
--- * 'set'' is a strict version of 'set', not 'set' for type-preserving optics
--- * 'view' is for getters
--- * 'preview' is for affine folds
--- * 'foldOf' is the equivalent of view for folds
--- * @firstOf@ is now 'headOf'
--- * Position lenses up to '_9' instead of _19 are provided
--- * 'Each' provides indexed traversals
--- * There are four variants of 'backwards' for (indexed) folds and traversals
--- * None of operators is exported from main module
--- * All ordinary optics are index-preserving by default
--- * Indexed optics interface is different (let's expand in own section, when the implementation is stabilised)
+-- * Fewer operators are provided, and none of operators are exported from the
+--   main "Optics" module. Import "Optics.Operators" or "Optics.Operators.State"
+--   if you want them.
+--
+-- * The 'view' function and corresponding ('Optics.Operators.^.') operator work
+--   only for 'Getter's and have a more restricted type. The equivalent for
+--   'Fold's is 'foldOf', and you can use 'preview' for
+--   'AffineFold's. Alternatively you can use 'gview' which is more compatible
+--   with @view@ from @lens@, but it uses a type class to choose between 'view',
+--   'preview' and 'foldOf'.
+--
+-- * Indexed optics are rather different, as described in the "Indexed optics"
+--   section below in "Optics#indexed".  All ordinary optics are
+--   "index-preserving", so there is no separate notion of an index-preserving
+--   optic.
+--
+-- * 'Each' provides indexed traversals.
+--
+-- * @firstOf@ from @lens@ is replaced by 'headOf'.
+--
+-- * 'set'' is a strict version of 'set', not 'set' for type-preserving optics.
+--
+-- * Numbered lenses for accessing fields of tuples positionally are provided
+--   only up to '_9', rather than @_19@.
+--
+-- * There are four variants of @backwards@ for (indexed) 'Traversal's and
+--   'Fold's: 'backwards', 'backwards_', 'ibackwards' and 'ibackwards_'.
+--
 -- * There is no @IndexedLens@, @IndexedGetter@, @Traversal1@ nor @Fold1@.
--- * There is 'AffineTraversal', 'AffineFold', 'IxAffineTraversal' and 'IxAffineFold'
--- * We can't use 'traverse' as an optic directly, but there is a 'Traversal' called 'traversed'.
--- * 'gview' is compatible with @lens@, but it uses a type class which chooses between
---   'view', 'preview' and 'foldOf' (See discussion in <https://github.com/well-typed/optics/issues/57 GitHub #57>: Do we need 'gview' at all, and what 'Optics.Operators.^.' should be)
-
--- * There are no 'from', only 're' (Should there be a 'from' restricted to 'Iso' or an alias to 're'? <https://github.com/well-typed/optics/pull/43#discussion_r247121380>)
 --
+-- * There are affine variants of (indexed) traversals and folds
+--   ('AffineTraversal', 'AffineFold', 'IxAffineTraversal' and 'IxAffineFold').
+--   An affine optic targets at most one value.  Composing a 'Lens' with a
+--   'Prism' produces an 'AffineTraversal', so for example @'matching' ('_1' '%'
+--   '_Left')@ is well-typed.
+--
+-- * We can't use 'traverse' as an optic directly.  Instead there is a
+--   'Traversal' called 'traversed'.  Similarly 'traverseOf' must be used to
+--   apply a 'Traversal', rather than simply using it as a function.
+
+-- * There are no 'from', only 're'.
+
 
 -- $otherresources
 --
 -- * <https://skillsmatter.com/skillscasts/10692-through-a-glass-abstractly-lenses-and-the-power-of-abstraction Through a Glass, Abstractly: Lenses and the Power of Abstraction> a talk on the principles behind this library with <https://github.com/well-typed/optics/raw/master/Talk.pdf accompanying slides> by Adam Gundry
 -- * <https://www.cs.ox.ac.uk/people/jeremy.gibbons/publications/poptics.pdf Profunctor Optics: Modular Data Accessors> a paper by Matthew Pickering, Jeremy Gibbons and Nicolas Wu
--- * <http://oleg.fi/gists/posts/2017-04-26-indexed-poptics.html Indexed Profunctor optics> a blog post by Oleg Grenrus
---
--- TODO: any other resources to mention here?
+-- * <http://oleg.fi/gists/posts/2017-04-26-indexed-poptics.html Indexed Profunctor optics> and <http://oleg.fi/gists/posts/2017-04-18-glassery.html Glassery>, blog posts by Oleg Grenrus
+
 
 -- $basicusage
+--
+-- To get started, you can just
 --
 -- @
 -- import "Optics"
 -- @
 --
--- and then...
---
--- Operators (if you prefer them) are in
+-- and if you prefer to use operators
 --
 -- @
 -- import "Optics.Operators"
+-- import "Optics.Operators.State"
+-- @
+
+
+-- $coredefinitions #coredefinitions#
+--
+-- The "Optics.Optic" module provides core definitions:
+--
+-- * an opaque 'Optic' type, which is parameterised over a type representing an
+--   optic kind (instantiated with tag types such as 'A_Lens');
+--
+-- * the optic composition operator ('%');
+--
+-- * the subtyping relation 'Is' with an accompanying 'castOptic' function to
+--   convert an optic kind;
+--
+-- * the 'Join' semilattice structure used to find the optic kind resulting from
+--   a composition.
+--
+-- Each optic kind is identified by a "tag type" (such as 'A_Lens'), which is an
+-- empty data type.  The type of the actual optics (such as 'Lens') is obtained
+-- by applying 'Optic' to the tag type.
+--
+-- The graph below represents the 'Is' partial order.  For example, a lens can
+-- be used as a traversal, so there are arrows from 'Lens' to 'Traversal' (via
+-- 'AffineTraversal') and there is an instance of @'Is' 'A_Lens' 'A_Traversal'@.
+--
+-- <<optics.png Optics hierarchy>>
+--
+-- The hierachy is a join-semilattice, where the optic kind resulting from a
+-- composition is the least upper bound of the optic kinds being composed.  The
+-- 'Join' type family computes the least upper bound given two optic kind tags.
+-- For example the 'Join' of a 'Lens' and a 'Prism' is an 'AffineTraversal'.
+--
+-- >>> :kind! Join A_Lens A_Prism
+-- Join A_Lens A_Prism :: *
+-- = An_AffineTraversal
+--
+-- In addition to the optic kinds described above, there are also indexed
+-- variants, namely 'IxAffineTraversal', 'IxTraversal', 'IxAffineFold', 'IxFold'
+-- and 'IxSetter'.  These are explained in more detail in the "Indexed optics"
+-- section below in "Optics#indexed".
+
+
+-- $optickinds #optickinds#
+--
+-- There are 16 different kinds of optics, each documented in a separate
+-- module.  Each optic module documentation has /formation/, /introduction/,
+-- /elimination/, and /well-formedness/ sections.
+--
+-- * The __formation__ sections contain type definitions. For example
+--
+--     @
+--     -- Tag for a lens.
+--     data A_Lens
+--
+--     -- Type synonym for a type-modifying lens.
+--     type 'Lens' s t a b = 'Optic' 'A_Lens' NoIx s t a b
+--     @
+--
+-- * In the __introduction__ sections are described the ways to construct
+--   the particular optic. Continuing with a 'Lens' example:
+--
+--     @
+--     -- Build a lens from a getter and a setter.
+--     'lens' :: (s -> a) -> (s -> b -> t) :: 'Lens' s t a b
+--     @
+--
+-- * In the __elimination__ sections are shown how you can destruct the
+--   optic into a pieces it was constructed from.
+--
+--     @
+--     -- 'Lens' is a 'Setter' and a 'Getter', therefore you can
+--
+--     'view' :: 'Lens' s t a b -> s -> a
+--     'set'  :: 'Lens' s t a b -> b -> s -> t
+--     'over' :: 'Lens' s t a b -> (a -> b) -> s -> t
+--     @
+--
+-- * __Computation__ rules tie introduction and
+--   elimination combinators together. These rules are automatically
+--   fulfilled.
+--
+--     @
+--     'view' ('lens' f g)   s = f s
+--     'set'  ('lens' f g) a s = g s a
+--     @
+--
+-- * All optics provided by the library are __well-formed__.
+--     Constructing of ill-formed optics is possible, but should be avoided.
+--     Ill-formed optic /might/ behave differently from what computation rules specify.
+--
+--     A 'Lens' should obey three laws, known as /GetPut/, /PutGet/ and /PutPut/.
+--     See "Optics.Lens" module for their definitions.
+--
+-- /Note:/ you should also consult the optics hierarchy diagram.
+-- Neither introduction or elimination sections list all ways to construct or use
+-- particular optic kind.
+-- For example you can construct 'Lens' from 'Iso' using 'castOptic'.
+-- Also, as a 'Lens' is also a 'Traversal', a 'Fold' etc, so you can use 'traverseOf', 'preview'
+-- and many other combinators.
+--
+
+-- $indexed #indexed#
+--
+-- The @optics@ library also provides indexed optics, which provide
+-- an additional /index/ value in mappings:
+--
+-- @
+-- 'over'  :: 'Setter'     s t a b -> (a -> b)      -> s -> t
+-- 'iover' :: 'IxSetter' i s t a b -> (i -> a -> b) -> s -> t
 -- @
 --
+-- Note that there aren't any laws about indices.
+-- Especially in compositions the same index may occur multiple times.
+--
+-- The machinery builds on indexed variants of 'Functor', 'Foldable', and 'Traversable' classes:
+-- 'FunctorWithIndex', 'FoldableWithIndex' and 'TraversableWithIndex' respectively.
+-- There are instances for types in the boot libraries.
+--
+-- @
+-- class ('FoldableWithIndex' i t, 'Traversable' t)
+--   => 'TraversableWithIndex' i t | t -> i where
+--     'itraverse' :: 'Applicative' f => (i -> a -> f b) -> t a -> f (t b)
+-- @
+--
+-- Indexed optics /can/ be used as regular ones, i.e. indexed optics
+-- gracefully downgrade to regular ones.
+--
+-- >>> toListOf ifolded "foo"
+-- "foo"
+--
+-- >>> itoListOf ifolded "foo"
+-- [(0,'f'),(1,'o'),(2,'o')]
+--
+-- But there is also a combinator 'noIx' to explicitly erase indices:
+--
+-- >>> :t (ifolded % simple)
+-- (ifolded % simple)
+--   :: FoldableWithIndex i f => Optic A_Fold '[i] (f b) (f b) b b
+--
+-- >>> :t noIx (ifolded % simple)
+-- noIx (ifolded % simple)
+--   :: FoldableWithIndex i f => Optic A_Fold NoIx (f b) (f b) b b
+--
+-- >>> :t noIx (ifolded % ifolded)
+-- noIx (ifolded % ifolded)
+--   :: (FoldableWithIndex i1 f1, FoldableWithIndex i2 f2) =>
+--      Optic A_Fold NoIx (f1 (f2 b)) (f1 (f2 b)) b b
+--
+-- As the example above illustrates, regular and indexed optics have the same
+-- tag in the first parameter of 'Optic', in this case 'A_Fold'.  Regular optics
+-- simply don't have any indices.  The provided type aliases 'IxFold',
+-- 'IxSetter' and 'IxTraversal' are variants with a single index. In general,
+-- the second parameter of the 'Optic' newtype is a type-level list of indices,
+-- which will typically be 'NoIx' (the empty index list) or @('WithIx' i)@ (a
+-- singleton list).
+--
+-- When two optics are composed with ('%'), the index lists are concatenated.
+-- Thus composing an unindexed optic with an indexed optic preserves the
+-- indices, or composing two indexed optics retains both indices:
+--
+-- >>> :t (ifolded % ifolded)
+-- (ifolded % ifolded)
+--  :: (FoldableWithIndex i1 f1, FoldableWithIndex i2 f2) =>
+--     Optic A_Fold '[i1, i2] (f1 (f2 b)) (f1 (f2 b)) b b
+--
+-- In order to use such an optic, it is necessary to flatten the indices into a
+-- single index using 'icompose' or a similar function:
+--
+-- >>> :t icompose (,) (ifolded % ifolded)
+-- icompose (,) (ifolded % ifolded)
+--  :: (FoldableWithIndex i1 f1, FoldableWithIndex i2 f2) =>
+--     Optic A_Fold (WithIx (i1, i2)) (f1 (f2 b)) (f1 (f2 b)) b b
+--
+-- For example:
+--
+-- >>> itoListOf (icompose (,) (ifolded % ifolded)) [['a','b'], ['c', 'd']]
+-- [((0,0),'a'),((0,1),'b'),((1,0),'c'),((1,1),'d')]
+--
+-- Alternatively, you can use one of the ('<%') or ('%>') operators to compose
+-- indexed optics and pick the index to retain, or the ('<%>') operator to
+-- retain a pair of indices:
+--
+-- >>> itoListOf (ifolded <% ifolded) [['a','b'], ['c', 'd']]
+-- [(0,'a'),(0,'b'),(1,'c'),(1,'d')]
+--
+-- >>> itoListOf (ifolded %> ifolded) [['a','b'], ['c', 'd']]
+-- [(0,'a'),(1,'b'),(0,'c'),(1,'d')]
+--
+-- >>> itoListOf (ifolded <%> ifolded) [['a','b'], ['c', 'd']]
+-- [((0,0),'a'),((0,1),'b'),((1,0),'c'),((1,1),'d')]
+--
+-- In the diagram below, the optics hierachy is amended with these (singly) indexed variants (in blue).
+-- Orange arrows mean
+-- "can be used as one, assuming it's composed with any optic below the
+-- orange arrow first". For example. '_1' is not an indexed fold, but
+-- @'itraversed' % '_1'@ is, because it's an indexed traversal, so it's
+-- also an indexed fold.
+--
+-- >>> let fst' = _1 :: Lens (a, c) (b, c) a b
+-- >>> :t fst' % itraversed
+-- fst' % itraversed
+--   :: TraversableWithIndex i t =>
+--      Optic A_Traversal (WithIx i) (t a, c) (t b, c) a b
+--
+-- <<indexedoptics.png Indexed Optics>>
+
 
 -- $setup
 -- >>> import Data.Functor.Identity

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -69,10 +69,15 @@ module Optics
   -- >>> preview (ix 1) ['a','b','c']
   -- Just 'b'
   --
-  -- and a 'Lens' to get, set or delete a key in a map:
+  -- a 'Lens' to get, set or delete a key in a map:
   --
   -- >>> set (at 0) (Just 'b') (Map.fromList [(0, 'a')])
   -- fromList [(0,'b')]
+  --
+  -- and a 'Lens' to insert or remove an element of a set:
+  --
+  -- >>> IntSet.fromList [1,2,3,4] & contains 3 .~ False
+  -- fromList [1,2,4]
   --
   , module Optics.At
 


### PR DESCRIPTION
This structures the documentation for each kind of optic around formation/introduction/elimination rules, adds some (brief) comments for each one and fixes lots of Haddock links.

I'm not sure whether it is worth breaking out computation rules as a separate section, and the docs are not entirely consistent yet. Perhaps the haddocks for the "core" introduction/elimination forms should simply state the rules they satisfy. Alternatively we could distinguish between "core" and "derived" introduction/elimination forms.

How to arrange the docs between the different `optics-*` modules needs some thought, in particular because `reexported-modules` don't seem to show up in Haddock. For example, we should perhaps move the diagrams to `optics-core` (as well?). 

This still needs some higher-level introduction and motivation, and an explanation of how indexed optics work.