### PR TITLE
Move matching and isn't to AffineTraversal

### DIFF
--- a/optics-core/src/Optics/AffineFold.hs
+++ b/optics-core/src/Optics/AffineFold.hs
@@ -25,7 +25,10 @@ module Optics.AffineFold
   -- 'preview' ('afolding' f) ≡ f
   -- @
 
-  -- * Semigroup structure
+  -- * Additional elimination forms
+  , isn't
+
+    -- * Semigroup structure
   , afailing
 
   -- * Subtyping
@@ -34,6 +37,8 @@ module Optics.AffineFold
   -- * Re-exports
   , module Optics.Optic
   ) where
+
+import Data.Maybe
 
 import Optics.Internal.Bi
 import Optics.Internal.Profunctor
@@ -97,6 +102,15 @@ afailing
 afailing a b = afolding $ \s -> maybe (preview b s) Just (preview a s)
 infixl 3 `afailing` -- Same as (<|>)
 {-# INLINE afailing #-}
+
+-- | Check to see if this 'AffineFold' doesn't match.
+--
+-- >>> isn't _Just Nothing
+-- True
+--
+isn't :: Is k An_AffineFold => Optic' k is s a -> s -> Bool
+isn't k s = not (isJust (preview k s))
+{-# INLINE isn't #-}
 
 -- $setup
 -- >>> import Optics.Core

--- a/optics-core/src/Optics/AffineTraversal.hs
+++ b/optics-core/src/Optics/AffineTraversal.hs
@@ -36,7 +36,6 @@ module Optics.AffineTraversal
 
   -- * Additional elimination forms
   , withAffineTraversal
-  , isn't
 
   -- * Subtyping
   , An_AffineTraversal
@@ -127,14 +126,6 @@ toAtraversalVL
   -> AffineTraversalVL s t a b
 toAtraversalVL o point = runStarA . getOptic (toAffineTraversal o) . StarA point
 {-# INLINE toAtraversalVL #-}
-
--- | Check to see if this 'AffineTraversal' doesn't match.
-isn't :: Is k An_AffineTraversal => Optic k is s t a b -> s -> Bool
-isn't k s =
-  case matching k s of
-    Left  _ -> True
-    Right _ -> False
-{-# INLINE isn't #-}
 
 -- | Retrieve the value targeted by an 'AffineTraversal' or return the original
 -- value while allowing the type to change if it does not match.

--- a/optics-core/src/Optics/Empty/Core.hs
+++ b/optics-core/src/Optics/Empty/Core.hs
@@ -16,6 +16,7 @@ import Data.Set as Set
 import qualified Data.Sequence as Seq
 
 import Data.Maybe.Optics
+import Optics.AffineTraversal
 import Optics.Internal.Utils
 import Optics.Iso
 import Optics.Fold

--- a/optics-core/src/Optics/Prism.hs
+++ b/optics-core/src/Optics/Prism.hs
@@ -15,30 +15,29 @@ module Optics.Prism
   , prism
 
   -- * Elimination
-  -- | A 'Prism' is an 'Optics.Review.Review' and an
-  -- 'Optics.AffineFold.AffineFold', therefore you can specialise types to
-  -- obtain:
+  -- | A 'Prism' is a 'Optics.Review.Review' and
+  -- 'Optics.AffineTraversal.AffineTraversal', therefore you can specialise
+  -- types to obtain:
   --
   -- @
-  -- 'Optics.Review.review'  :: 'Prism' s t a b -> b -> t
-  -- 'Optics.AffineFold.preview' :: 'Prism'' s a -> s -> 'Maybe' a
+  -- 'Optics.Review.review'   :: 'Prism' s t a b -> b -> t
+  -- 'Optics.AffineTraversal.matching' :: 'Prism' s t a b -> s -> 'Either' t a
   -- @
-  , matching
 
   -- * Computation
   -- |
   --
   -- @
   -- 'Optics.Review.review'   ('prism' f g) ≡ f
-  -- 'matching' ('prism' f g) ≡ g
+  -- 'Optics.AffineTraversal.matching' ('prism' f g) ≡ g
   -- @
 
   -- * Well-formedness
   -- |
   --
   -- @
-  -- 'Optics.AffineFold.preview' o ('Optics.Review.review' o b) ≡ 'Just' b
-  -- 'Optics.AffineFold.preview' o s ≡ 'Just' a  =>  'Optics.Review.review' o a ≡ s
+  -- 'Optics.AffineTraversal.matching' o ('Optics.Review.review' o b) ≡ 'Left' b
+  -- 'Optics.AffineTraversal.matching' o s ≡ 'Left' a  =>  'Optics.Review.review' o a ≡ s
   -- @
 
   -- * Additional introduction forms
@@ -48,7 +47,6 @@ module Optics.Prism
 
   -- * Additional elimination forms
   , withPrism
-  , isn't
 
   -- * Combinators
   , aside
@@ -145,24 +143,6 @@ below k =
     Left _  -> Left s
     Right t -> Right t
 {-# INLINE below #-}
-
--- | Check to see if this 'Prism' doesn't match.
-isn't :: Is k A_Prism => Optic k is s t a b -> s -> Bool
-isn't k s =
-  case matching k s of
-    Left  _ -> True
-    Right _ -> False
-{-# INLINE isn't #-}
-
--- | Retrieve the value targeted by a 'Prism' or return the original value while
--- allowing the type to change if it does not match.
---
--- @
--- 'Optics.AffineFold.preview' o ≡ 'either' ('const' 'Nothing') 'id' . 'matching' o
--- @
-matching :: Is k A_Prism => Optic k is s t a b -> s -> Either t a
-matching o = withPrism o $ \_ match -> match
-{-# INLINE matching #-}
 
 -- | This 'Prism' compares for exact equality with a given value.
 --


### PR DESCRIPTION
Fixes #148. This makes the elimination/computation rules for `AffineTraversal` cleaner.