### PR TITLE
Finish off haddocks for optics-sop

### DIFF
--- a/optics-sop/src/Generics/SOP/Optics.hs
+++ b/optics-sop/src/Generics/SOP/Optics.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+-- | This module defines optics for working with the types in @generics-sop@.
+--
 module Generics.SOP.Optics
   ( rep
   , sop

--- a/optics-sop/src/Optics/SOP.hs
+++ b/optics-sop/src/Optics/SOP.hs
@@ -5,6 +5,25 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+-- | This module provides machinery to construct lenses and prisms using
+-- @generics-sop@.
+--
+-- If you have a datatype @T@ with a 'Generics.SOP.Generic' instance, you can
+-- use @'mkLenses' :: 'LensesFor' T@ to obtain a tuple of lenses, or similarly
+-- use @'mkPrisms' :: 'PrismsFor' T@ to obtain a tuple of prisms. For example:
+--
+-- >>> :set -XDeriveGeneric -XDeriveAnyClass
+-- >>> import qualified GHC.Generics as GHC
+-- >>> import qualified Generics.SOP as SOP
+-- >>> data T = MkT { _foo :: Int, _bar :: Bool } deriving (GHC.Generic, SOP.Generic)
+-- >>> Lenses (foo, bar) = mkLenses :: LensesFor T
+-- >>> view foo (MkT 42 True)
+-- 42
+--
+-- >>> Prisms (_Nothing, _Just) = mkPrisms :: PrismsFor (Maybe a)
+-- >>> isn't _Just Nothing
+-- True
+--
 module Optics.SOP
   ( WrappedLens(..)
   , WrappedNPPrism(..)

--- a/optics-sop/src/Optics/SOP/ToTuple.hs
+++ b/optics-sop/src/Optics/SOP/ToTuple.hs
@@ -2,6 +2,9 @@
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
+-- | Conversions between lists of types (of length up to 16) and the
+-- corresponding tuple types.
+--
 module Optics.SOP.ToTuple where
 
 import Generics.SOP hiding (from, to)
@@ -9,6 +12,7 @@ import Optics.Core
 
 import Generics.SOP.Optics
 
+-- | Convert a list of types into a tuple of those types.
 type family ToTuple (xs :: [*]) :: * where
   ToTuple '[]                                                                      = ()
   ToTuple '[x1]                                                                    = x1
@@ -28,7 +32,11 @@ type family ToTuple (xs :: [*]) :: * where
   ToTuple '[x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15]      = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15)
   ToTuple '[x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16)
 
+-- | A list of types is 'TupleLike' if it is isomorphic to the tuple given by
+-- 'ToTuple',
 class TupleLike xs where
+  -- | Value-level isomorphsim between a heterogeneous list and the
+  -- corresponding tuple type.
   tuple :: Iso' (NP I xs) (ToTuple xs)
   default tuple :: (IsProductType a xs, ToTuple xs ~ a) => Iso' (NP I xs) (ToTuple xs)
   tuple = re productRep


### PR DESCRIPTION
See #22.

Should the main `Optics` module re-export `Optics.SOP`?