### PR TITLE
Increase bounds on th-abstraction

### DIFF
--- a/optics-th/optics-th.cabal
+++ b/optics-th/optics-th.cabal
@@ -26,7 +26,7 @@ library
     , containers        >=0.5.7.1   && <0.7
     , mtl               >=2.2.2     && <2.3
     , template-haskell  >=2.11      && <2.15
-    , th-abstraction    >=0.2.1     && <0.3
+    , th-abstraction    >=0.2.1     && <0.4
     , transformers      >=0.5       && <0.6
 
   exposed-modules:  Language.Haskell.TH.Optics


### PR DESCRIPTION
The [breaking change in `0.3`](https://github.com/glguy/th-abstraction/blob/master/ChangeLog.md) appears to be irrelevant as `datatypeVars` is not used.

> Breaking change: the datatypeVars field of DatatypeInfo is now of type [TyVarBndr] instead of [Type], as it now refers to all of the bound type variables in the data type. The old datatypeVars field has been renamed to datatypeInstTypes to better reflect its purpose.