### PR TITLE
Make filtered inline, add unsafeFiltered and indices

### DIFF
--- a/optics-core/src/Optics/Fold.hs
+++ b/optics-core/src/Optics/Fold.hs
@@ -42,6 +42,7 @@ module Optics.Fold
   , folding
   , foldring
   , unfolded
+  , filtered
 
   -- * Additional elimination forms
   , has
@@ -69,7 +70,6 @@ module Optics.Fold
   , lookupOf
 
   -- * Combinators
-  , filtered
   , backwards_
 
   -- * Semigroup structure
@@ -229,12 +229,8 @@ unfolded step = mkFold $ \f -> fix $ \loop b ->
 {-# INLINE unfolded #-}
 
 -- | Filter results of a 'Fold' that don't satisfy a predicate.
-filtered
-  :: Is k A_Fold
-  => (a -> Bool)
-  -> Optic' k is s a
-  -> Fold s a
-filtered p o = mkFold $ \f -> traverseOf_ o (\a -> if p a then f a else pure ())
+filtered :: (a -> Bool) -> Fold a a
+filtered p = mkFold $ \f a -> if p a then f a else pure ()
 {-# INLINE filtered #-}
 
 -- | This allows you to traverse the elements of a 'Fold' in the opposite order.

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -54,6 +54,7 @@ module Optics.IxTraversal
   , ifailover'
 
   -- * Combinators
+  , indices
   , ibackwards
   , ipartsOf
 
@@ -226,6 +227,17 @@ ignored = ixTraversalVL $ \_ -> pure
 
 ----------------------------------------
 -- Traversal combinators
+
+-- | Filter results of an 'IxTraversal' that don't satisfy a predicate on the
+-- indices.
+indices
+  :: (Is k A_Traversal, is `HasSingleIndex` i)
+  => (i -> Bool)
+  -> Optic k is s t a a
+  -> IxTraversal i s t a a
+indices p o = ixTraversalVL $ \f ->
+  itraverseOf o $ \i a -> if p i then f i a else pure a
+{-# INLINE indices #-}
 
 -- | This allows you to 'traverse' the elements of an indexed traversal in the
 -- opposite order.

--- a/optics-core/src/Optics/Traversal.hs
+++ b/optics-core/src/Optics/Traversal.hs
@@ -47,6 +47,7 @@ module Optics.Traversal
 
   -- * Additional introduction forms
   , traversed
+  , unsafeFiltered
 
   -- * Additional elimination forms
   , forOf
@@ -275,6 +276,28 @@ failover' o = \f s ->
 traversed :: Traversable t => Traversal (t a) (t b) a b
 traversed = Optic traversed__
 {-# INLINE traversed #-}
+
+-- | Filter results of a 'Traversal' that don't satisfy a predicate.
+--
+-- /Note:/ This is /not/ a legal 'Traversal', unless you are very careful not to
+-- invalidate the predicate on the target.
+--
+-- As a counter example, consider that given @evens = 'unsafeFiltered' 'even'@
+-- the second 'Traversal' law is violated:
+--
+-- @
+-- 'Optics.Setter.over' evens 'succ' '.' 'Optics.over' evens 'succ' '/=' 'Optics.Setter.over' evens ('succ' '.' 'succ')
+-- @
+--
+-- So, in order for this to qualify as a legal 'Traversal' you can only use it
+-- for actions that preserve the result of the predicate!
+--
+-- For a safe variant see 'Optics.IxTraversal.indices' (or 'filtered' for
+-- read-only optics).
+--
+unsafeFiltered :: (a -> Bool) -> Traversal' a a
+unsafeFiltered p = traversalVL $ \f a -> if p a then f a else pure a
+{-# INLINE unsafeFiltered #-}
 
 ----------------------------------------
 -- Traversal combinators

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -377,6 +377,9 @@ import Data.Either.Optics                    as P
 --   'Prism' produces an 'AffineTraversal', so for example @'matching' ('_1' '%'
 --   '_Left')@ is well-typed.
 --
+-- * Functions 'ifiltered' and 'indices' are defined as optic combinators due to
+--   restrictions of internal representation.
+--
 -- * We can't use 'traverse' as an optic directly.  Instead there is a
 --   'Traversal' called 'traversed'.  Similarly 'traverseOf' must be used to
 --   apply a 'Traversal', rather than simply using it as a function.


### PR DESCRIPTION
I added `unsafeFIltered` and `indices`. I also made `filtered` inline so that it's compatible with `lens`.

`unsafeFiltered` and `filtered` can be defined as affine traversal and fold, but I didn't do that because they have at most one target, so it doesn't make much sense to me
