### PR TITLE
Add %& post-composition operator.

### DIFF
--- a/optics-core/src/Optics/Indexed/Core.hs
+++ b/optics-core/src/Optics/Indexed/Core.hs
@@ -82,7 +82,10 @@ o <% o' = o % noIx o'
 
 -- | Remap the index.
 --
--- >>> itoListOf (reindex succ ifolded) "foo"
+-- >>> itoListOf (reindexed succ ifolded) "foo"
+-- [(1,'f'),(2,'o'),(3,'o')]
+--
+-- itoListOf (ifolded %& reindexed succ) "foo"
 -- [(1,'f'),(2,'o'),(3,'o')]
 --
 reindexed
@@ -94,6 +97,10 @@ reindexed = icomposeN
 {-# INLINE reindexed #-}
 
 -- | Flatten indices obtained from two indexed optics.
+--
+-- >>> itoListOf (ifolded % ifolded %& icompose (,)) ["foo","bar"]
+-- [((0,0),'f'),((0,1),'o'),((0,2),'o'),((1,0),'b'),((1,1),'a'),((1,2),'r')]
+--
 icompose
   :: IxOptic k s t a b
   => (i -> j -> ix)
@@ -103,6 +110,10 @@ icompose = icomposeN
 {-# INLINE icompose #-}
 
 -- | Flatten indices obtained from three indexed optics.
+--
+-- >>> itoListOf (ifolded % ifolded % ifolded %& icompose3 (,,)) [["foo","bar"],["xyz"]]
+-- [((0,0,0),'f'),((0,0,1),'o'),((0,0,2),'o'),((0,1,0),'b'),((0,1,1),'a'),((0,1,2),'r'),((1,0,0),'x'),((1,0,1),'y'),((1,0,2),'z')]
+--
 icompose3
   :: IxOptic k s t a b
   => (i1 -> i2 -> i3 -> ix)

--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -26,6 +26,7 @@ module Optics.Internal.Optic
   , castOptic
   , (%)
   , (%%)
+  , (%&)
   , IsProxy(..)
   -- * Labels
   , LabelOptic(..)
@@ -36,6 +37,7 @@ module Optics.Internal.Optic
   , module Optics.Internal.Optic.TypeLevel
   ) where
 
+import Data.Function ((&))
 import Data.Proxy (Proxy (..))
 import Data.Type.Equality
 import GHC.OverloadedLabels
@@ -151,6 +153,21 @@ Optic o %% Optic o' = Optic oo
            -> Optic_ k p i (Curry ks j           ) s t a b)
       (o . o')
 {-# INLINE (%%) #-}
+
+-- | Flipped function application, specialised to optics and binding tightly.
+--
+-- Useful for post-composing optics transformations:
+--
+-- >>> toListOf (ifolded %& ifiltered (\i s -> length s <= i)) ["", "a","abc"]
+-- ["","a"]
+--
+infixl 9 %&
+(%&) :: Optic k is s t a b
+     -> (Optic k is s t a b -> Optic l js s' t' a' b')
+     -> Optic l js s' t' a' b'
+(%&) = (&)
+{-# INLINE (%&) #-}
+
 
 -- |
 --

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -184,6 +184,10 @@ ifoldring fr = Optic (ifoldring__ fr)
 {-# INLINE ifoldring #-}
 
 -- | Filter results of an 'IxFold' that don't satisfy a predicate.
+--
+-- >>> toListOf (ifolded %& ifiltered (>)) [3,2,1,0]
+-- [1,0]
+--
 ifiltered
   :: (Is k A_Fold, is `HasSingleIndex` i)
   => (i -> a -> Bool)
@@ -192,6 +196,13 @@ ifiltered
 ifiltered p o = mkIxFold $ \f ->
   itraverseOf_ o (\i a -> if p i a then f i a else pure ())
 {-# INLINE ifiltered #-}
+-- Note: technically this should be defined per optic kind:
+--
+-- ifiltered :: _ -> IxFold i s a       -> IxFold i s a
+-- ifiltered :: _ -> IxGetter i s a     -> IxAffineFold i s a
+-- ifiltered :: _ -> IxAffineFold i s a -> IxAffineFold i s a
+--
+-- and similarly for (non-existent) unsafeIFiltered.
 
 -- | This allows you to traverse the elements of an 'IxFold' in the opposite
 -- order.

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -230,6 +230,10 @@ ignored = ixTraversalVL $ \_ -> pure
 
 -- | Filter results of an 'IxTraversal' that don't satisfy a predicate on the
 -- indices.
+--
+-- >>> toListOf (itraversed %& indices even) "foobar"
+-- "foa"
+--
 indices
   :: (Is k A_Traversal, is `HasSingleIndex` i)
   => (i -> Bool)

--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -21,6 +21,7 @@ module Optics.Optic
   -- * Composition
   , (%)
   , (%%)
+  , (%&)
 
   -- * Labels
   , LabelOptic(..)


### PR DESCRIPTION
Allows to put filtered, ifiltered and other such not-quite-optics
into the optic composition chain.

left-associativity is essential for this to work,
but it works nicely!