### PR TITLE
Support for turning read-write optics into their read-only counterparts

### DIFF
--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -56,6 +56,7 @@ library
     Optics.Prism
     Optics.PrismaticGetter
     Optics.Re
+    Optics.ReadOnly
     Optics.Review
     Optics.Setter
     Optics.Traversal

--- a/optics-core/src/Optics/Core.hs
+++ b/optics-core/src/Optics/Core.hs
@@ -51,6 +51,7 @@ import Optics.Cons.Core                        as P
 import Optics.Each.Core                        as P
 import Optics.Empty.Core                       as P
 import Optics.Re                               as P
+import Optics.ReadOnly                         as P
 
 import Data.Either.Optics                      as D
 import Data.Maybe.Optics                       as D

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -71,7 +71,6 @@ import Control.Applicative.Backwards
 import Control.Monad.Trans.State
 import Data.Functor.Identity
 
-import Optics.Internal.Bi
 import Optics.Internal.Indexed
 import Optics.Internal.IxTraversal
 import Optics.Internal.Profunctor
@@ -80,6 +79,7 @@ import Optics.Internal.Utils
 import Optics.Optic
 import Optics.IxLens
 import Optics.IxFold
+import Optics.ReadOnly
 import Optics.Traversal
 
 -- | Type synonym for a type-modifying indexed traversal.
@@ -302,11 +302,9 @@ ipartsOf
   => Optic k is s t a a
   -> IxLens [i] s t [a] [a]
 ipartsOf o = conjoined (partsOf $ traversalVL $ traverseOf o) $ ixLensVL $ \f s ->
-  evalState (traverseOf o update s) <$> uncurry f (unzip $ itoListOf fo s)
+  evalState (traverseOf o update s)
+    <$> uncurry f (unzip $ itoListOf (getting $ castOptic @A_Traversal o) s)
   where
-    fo :: IxFold i s a
-    fo = Optic $ rphantom . getOptic (castOptic @A_Traversal o)
-
     update a = get >>= \case
       []       ->            pure a
       a' : as' -> put as' >> pure a'

--- a/optics-core/src/Optics/ReadOnly.hs
+++ b/optics-core/src/Optics/ReadOnly.hs
@@ -8,32 +8,47 @@ import Optics.Internal.Profunctor
 
 -- | Class for read-write optics that have their read-only counterparts.
 class ToReadOnly k where
-  type ReadOnlyOptic k
   -- | Turn read-write optic into its read-only counterpart.
-  getting :: Optic k is s t a b -> Optic' (ReadOnlyOptic k) is s a
+  --
+  -- This is useful when you have an @optic :: Optic k is s t a b@ of read-write
+  -- kind @k@ such that @s@, @t@, @a@, @b@ are rigid, there is no evidence that
+  -- @s ~ t@ and @a ~ b@ and you want to pass @optic@ to one of the functions
+  -- that accept read-only optic kinds.
+  --
+  -- Example:
+  --
+  -- @
+  -- λ> let fstIntToChar = _1 :: Lens (Int, r) (Char, r) Int Char
+  -- λ> :t view fstIntToChar
+  --
+  -- <interactive>:1:6: error:
+  --     • Couldn't match type ‘Char’ with ‘Int’
+  --       Expected type: Optic' A_Lens NoIx (Int, r) Int
+  --         Actual type: Lens (Int, r) (Char, r) Int Char
+  --     • In the first argument of ‘view’, namely ‘fstIntToChar’
+  --       In the expression: view fstIntToChar
+  -- λ> :t view (getting fstIntToChar)
+  -- view (getting fstIntToChar) :: (Int, r) -> Int
+  -- @
+  getting :: Optic k is s t a b -> Optic' (Join A_Getter k) is s a
 
 instance ToReadOnly An_Iso where
-  type ReadOnlyOptic An_Iso = A_Getter
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 
 instance ToReadOnly A_Lens where
-  type ReadOnlyOptic A_Lens = A_Getter
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 
 instance ToReadOnly A_Prism where
-  type ReadOnlyOptic A_Prism = An_AffineFold
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 
 instance ToReadOnly An_AffineTraversal where
-  type ReadOnlyOptic An_AffineTraversal = An_AffineFold
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 
 instance ToReadOnly A_Traversal where
-  type ReadOnlyOptic A_Traversal = A_Fold
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 

--- a/optics-core/src/Optics/ReadOnly.hs
+++ b/optics-core/src/Optics/ReadOnly.hs
@@ -7,8 +7,9 @@ import Optics.Internal.Optic
 import Optics.Internal.Profunctor
 
 -- | Class for read-write optics that have their read-only counterparts.
-class ToReadOnly k where
-  -- | Turn read-write optic into its read-only counterpart.
+class ToReadOnly k s t a b where
+  -- | Turn read-write optic into its read-only counterpart (or leave read-only
+  -- optics as-is).
   --
   -- This is useful when you have an @optic :: Optic k is s t a b@ of read-write
   -- kind @k@ such that @s@, @t@, @a@, @b@ are rigid, there is no evidence that
@@ -32,24 +33,40 @@ class ToReadOnly k where
   -- @
   getting :: Optic k is s t a b -> Optic' (Join A_Getter k) is s a
 
-instance ToReadOnly An_Iso where
+instance ToReadOnly An_Iso s t a b where
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 
-instance ToReadOnly A_Lens where
+instance ToReadOnly A_Lens s t a b where
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 
-instance ToReadOnly A_Prism where
+instance ToReadOnly A_Prism s t a b where
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 
-instance ToReadOnly An_AffineTraversal where
+instance ToReadOnly An_AffineTraversal s t a b where
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 
-instance ToReadOnly A_Traversal where
+instance ToReadOnly A_Traversal s t a b where
   getting o = Optic (getting__ o)
+  {-# INLINE getting #-}
+
+instance ToReadOnly A_PrismaticGetter s t a b where
+  getting o = Optic (getting__ o)
+  {-# INLINE getting #-}
+
+instance (s ~ t, a ~ b) => ToReadOnly A_Getter s t a b where
+  getting = id
+  {-# INLINE getting #-}
+
+instance (s ~ t, a ~ b) => ToReadOnly An_AffineFold s t a b where
+  getting = id
+  {-# INLINE getting #-}
+
+instance (s ~ t, a ~ b) => ToReadOnly A_Fold s t a b where
+  getting = id
   {-# INLINE getting #-}
 
 -- | Internal implementation of 'getting'.

--- a/optics-core/src/Optics/ReadOnly.hs
+++ b/optics-core/src/Optics/ReadOnly.hs
@@ -1,0 +1,46 @@
+module Optics.ReadOnly
+  ( ToReadOnly(..)
+  ) where
+
+import Optics.Internal.Bi
+import Optics.Internal.Optic
+import Optics.Internal.Profunctor
+
+-- | Class for read-write optics that have their read-only counterparts.
+class ToReadOnly k where
+  type ReadOnlyOptic k
+  -- | Turn read-write optic into its read-only counterpart.
+  getting :: Optic k is s t a b -> Optic' (ReadOnlyOptic k) is s a
+
+instance ToReadOnly An_Iso where
+  type ReadOnlyOptic An_Iso = A_Getter
+  getting o = Optic (getting__ o)
+  {-# INLINE getting #-}
+
+instance ToReadOnly A_Lens where
+  type ReadOnlyOptic A_Lens = A_Getter
+  getting o = Optic (getting__ o)
+  {-# INLINE getting #-}
+
+instance ToReadOnly A_Prism where
+  type ReadOnlyOptic A_Prism = An_AffineFold
+  getting o = Optic (getting__ o)
+  {-# INLINE getting #-}
+
+instance ToReadOnly An_AffineTraversal where
+  type ReadOnlyOptic An_AffineTraversal = An_AffineFold
+  getting o = Optic (getting__ o)
+  {-# INLINE getting #-}
+
+instance ToReadOnly A_Traversal where
+  type ReadOnlyOptic A_Traversal = A_Fold
+  getting o = Optic (getting__ o)
+  {-# INLINE getting #-}
+
+-- | Internal implementation of 'getting'.
+getting__
+  :: (Profunctor p, Bicontravariant p, Constraints k p)
+  => Optic k            is    s t a b
+  -> Optic__ p i (Curry is i) s s a a
+getting__ (Optic o) = rphantom . o . rphantom
+{-# INLINE getting__ #-}

--- a/optics-core/src/Optics/Traversal.hs
+++ b/optics-core/src/Optics/Traversal.hs
@@ -84,7 +84,6 @@ import Control.Applicative.Backwards
 import Control.Monad.Trans.State
 import Data.Functor.Identity
 
-import Optics.Internal.Bi
 import Optics.Internal.Indexed
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
@@ -93,6 +92,7 @@ import Optics.Internal.Utils
 import Optics.Lens
 import Optics.Fold
 import Optics.Optic
+import Optics.ReadOnly
 
 -- | Type synonym for a type-modifying traversal.
 type Traversal s t a b = Optic A_Traversal NoIx s t a b
@@ -314,12 +314,9 @@ partsOf
   :: forall k s t a. Is k A_Traversal
   => Optic k NoIx s t a a
   -> Lens s t [a] [a]
-partsOf o = lensVL $ \f s ->
-  evalState (traverseOf o update s) <$> f (toListOf fo s)
+partsOf o = lensVL $ \f s -> evalState (traverseOf o update s)
+  <$> f (toListOf (getting $ castOptic @A_Traversal o) s)
   where
-    fo :: Fold s a
-    fo = Optic $ rphantom . getOptic (castOptic @A_Traversal o)
-
     update a = get >>= \case
       a' : as' -> put as' >> pure a'
       []       ->            pure a

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -75,6 +75,7 @@ library
                     , Optics.Operators.State
                     , Optics.Passthrough
                     , Optics.Re
+                    , Optics.ReadOnly
                     , Optics.View
                     , Optics.Zoom
 

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -106,6 +106,9 @@ module Optics
   --
   , module Optics.Re
 
+  -- ** ReadOnly
+  , module Optics.ReadOnly
+
   -- ** View
 
   -- | A generalized view function 'gview', which returns a single result (like
@@ -187,6 +190,7 @@ import Optics.Each
 import Optics.Empty
 import Optics.Indexed
 import Optics.Re
+import Optics.ReadOnly
 import Optics.View
 import Optics.Zoom
 


### PR DESCRIPTION
It's the equivalent of `getting` function from lens.

I didn't find `getting` to be a good name, but I'm not sure if `readOnly` is good either - suggestions welcome.