### PR TITLE
Fix spelling in example

### DIFF
--- a/optics-th/src/Optics/TH.hs
+++ b/optics-th/src/Optics/TH.hs
@@ -102,7 +102,7 @@ import Optics.TH.Internal.Sum
 --   | Dog { animalAge    :: Int
 --         , animalAbsurd :: forall a b. a -> b
 --         }
--- makeFieldLabels ''Animmal
+-- makeFieldLabels ''Animal
 -- @
 --
 -- will create


### PR DESCRIPTION
Is it mentioned anywhere that `FlexibleInstances`, `MultiParamTypeClasses`, `UndecidableInstances` are needed? Should I enable them by default, when making `optics`?