### PR TITLE
Licensing/authorship

### DIFF
--- a/generic-optics/LICENSE
+++ b/generic-optics/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2018, Well-Typed LLP
+Copyright (c) 2017-2019, Well-Typed LLP
 
 All rights reserved.
 
@@ -13,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of Andres Loeh nor the names of other
+    * Neither the name of Well-Typed LLP nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/optics-core/LICENSE
+++ b/optics-core/LICENSE
@@ -60,3 +60,38 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
+
+
+This software incorporates code from the profunctors package (available from
+https://hackage.haskell.org/package/profunctors) under the following license:
+
+Copyright 2011-2015 Edward Kmett
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the author nor the names of his contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/optics-core/LICENSE
+++ b/optics-core/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2018, Well-Typed LLP
+Copyright (c) 2017-2019, Well-Typed LLP
 
 All rights reserved.
 
@@ -13,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of Andres Loeh nor the names of other
+    * Neither the name of Well-Typed LLP nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 
@@ -28,3 +28,35 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+This software incorporates code from the lens package (available from
+https://hackage.haskell.org/package/lens) under the following license:
+
+
+Copyright 2012-2016 Edward Kmett
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -5,13 +5,16 @@ license-file:  LICENSE
 build-type:    Simple
 cabal-version: 1.24
 maintainer:    optics@well-typed.com
-author:        Adam Gundry, Andres Löh, Andrzej Rybczak, Edward Kmett, Oleg Grenrus
+author:        Adam Gundry, Andres Löh, Andrzej Rybczak, Oleg Grenrus
 tested-with:   ghc ==8.0.2 || ==8.2.2 || ==8.4.4 ||  ==8.6.5 || ==8.8.1
 synopsis:      Optics as an abstract interface: core definitions
-category:      Data, Optics, Lenses, Generics
+category:      Data, Optics, Lenses
 description:
-  This package provides core definitions with a minimal dependency footprint.
-  See @optics@ package (and its dependencies) for documentation and
+  This package makes it possible to define and use Lenses, Traversals, Prisms
+  and other optics, using an abstract interface.
+  .
+  This variant provides core definitions with a minimal dependency footprint.
+  See @optics@ package (and its dependencies) for documentation and the
   "batteries-included" variant.
 
 library

--- a/optics-extra/LICENSE
+++ b/optics-extra/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2018, Well-Typed LLP
+Copyright (c) 2017-2019, Well-Typed LLP
 
 All rights reserved.
 
@@ -13,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of Andres Loeh nor the names of other
+    * Neither the name of Well-Typed LLP nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 
@@ -28,3 +28,35 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+This software incorporates code from the lens package (available from
+https://hackage.haskell.org/package/lens) under the following license:
+
+
+Copyright 2012-2016 Edward Kmett
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/optics-sop/LICENSE
+++ b/optics-sop/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2018, Well-Typed LLP
+Copyright (c) 2017-2019, Well-Typed LLP
 
 All rights reserved.
 
@@ -13,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of Andres Loeh nor the names of other
+    * Neither the name of Well-Typed LLP nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/optics-vl/LICENSE
+++ b/optics-vl/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2018, Well-Typed LLP
+Copyright (c) 2017-2019, Well-Typed LLP
 
 All rights reserved.
 
@@ -13,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of Andres Loeh nor the names of other
+    * Neither the name of Well-Typed LLP nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/optics/LICENSE
+++ b/optics/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2018, Well-Typed LLP
+Copyright (c) 2017-2019, Well-Typed LLP
 
 All rights reserved.
 
@@ -13,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of Andres Loeh nor the names of other
+    * Neither the name of Well-Typed LLP nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 
@@ -28,3 +28,35 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+This software incorporates code from the lens package (available from
+https://hackage.haskell.org/package/lens) under the following license:
+
+
+Copyright 2012-2016 Edward Kmett
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -4,20 +4,19 @@ license:         BSD3
 license-file:    LICENSE
 build-type:      Simple
 maintainer:      optics@well-typed.com
-author:          Edward Kmett, Adam Gundry, Andres Löh, Andrzej Rybczak
+author:          Adam Gundry, Andres Löh, Andrzej Rybczak, Oleg Grenrus
 cabal-version:   1.24
 tested-with:     ghc ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.1
 synopsis:        Optics as an abstract interface
-category:        Data, Optics, Lenses, Generics
+category:        Data, Optics, Lenses
 description:
-  This package provides optics (as in the @lens@ package) but
-  encapsulates them in an abstract interface. See the main module
-  "Optics" for the documentation.
-
-  This is the "batteries-included"
-  variant with many dependencies; see the @optics-core@ package and
-  other @optics-*@ dependencies if you need a more limited dependency
-  footprint.
+  This package makes it possible to define and use Lenses, Traversals, Prisms
+  and other optics, using an abstract interface. See the main module "Optics"
+  for the documentation.
+  .
+  This is the "batteries-included" variant with many dependencies; see the
+  @optics-core@ package and other @optics-*@ dependencies if you need a more
+  limited dependency footprint.
 
 extra-doc-files:
   optics.png


### PR DESCRIPTION
This corrects attribution in the `.cabal` files and updates the licenses, including with the licenses of packages from which we have derived code. Fixes #167.