### PR TITLE
Make construction from VL optics more visible

### DIFF
--- a/optics-core/src/Optics/AffineTraversal.hs
+++ b/optics-core/src/Optics/AffineTraversal.hs
@@ -16,6 +16,7 @@ module Optics.AffineTraversal
 
   -- * Introduction
   , atraversal
+  , atraversalVL
 
   -- * Elimination
   -- | An 'AffineTraversal' is a 'Optics.Setter.Setter', therefore you can
@@ -50,7 +51,6 @@ module Optics.AffineTraversal
   -- * van Laarhoven encoding
   , AffineTraversalVL
   , AffineTraversalVL'
-  , atraversalVL
   , toAtraversalVL
 
   -- * Re-exports
@@ -113,6 +113,28 @@ withAffineTraversal o = \k ->
 {-# INLINE withAffineTraversal #-}
 
 -- | Build an affine traversal from the van Laarhoven representation.
+--
+-- Example:
+--
+-- >>> :{
+-- azSnd = atraversalVL $ \point f ab@(a, b) ->
+--   if a >= 'a' && a <= 'z'
+--   then (a, ) <$> f b
+--   else point ab
+-- :}
+--
+-- >>> preview azSnd ('a', "Hi")
+-- Just "Hi"
+--
+-- >>> preview azSnd ('@', "Hi")
+-- Nothing
+--
+-- >>> over azSnd (++ "!!!") ('f', "Hi")
+-- ('f',"Hi!!!")
+--
+-- >>> set azSnd "Bye" ('Y', "Hi")
+-- ('Y',"Hi")
+--
 atraversalVL :: AffineTraversalVL s t a b -> AffineTraversal s t a b
 atraversalVL f = Optic (visit f)
 {-# INLINE atraversalVL #-}
@@ -157,3 +179,6 @@ matching o = withAffineTraversal o $ \match _ -> match
 unsafeFiltered :: (a -> Bool) -> AffineTraversal' a a
 unsafeFiltered p = atraversalVL (\point f a -> if p a then f a else point a)
 {-# INLINE unsafeFiltered #-}
+
+-- $setup
+-- >>> import Optics.Core

--- a/optics-core/src/Optics/IxAffineTraversal.hs
+++ b/optics-core/src/Optics/IxAffineTraversal.hs
@@ -15,6 +15,7 @@ module Optics.IxAffineTraversal
 
   -- * Introduction
   , iatraversal
+  , ixAtraversalVL
 
   -- * Subtyping
   , An_AffineTraversal
@@ -22,7 +23,6 @@ module Optics.IxAffineTraversal
   -- * van Laarhoven encoding
   , IxAffineTraversalVL
   , IxAffineTraversalVL'
-  , ixAtraversalVL
   , toIxAtraversalVL
 
   -- * Re-exports
@@ -54,9 +54,11 @@ type IxAffineTraversalVL i s t a b =
 -- | Type synonym for a type-preserving van Laarhoven indexed affine traversal.
 type IxAffineTraversalVL' i s a = IxAffineTraversalVL i s s a a
 
+-- | Build an indexed affine traversal from a matcher and an updater.
 iatraversal :: (s -> Either t (i, a)) -> (s -> b -> t) -> IxAffineTraversal i s t a b
 iatraversal match update = ixAtraversalVL $ \point f s ->
   either point (\a -> update s <$> uncurry f a) (match s)
+{-# INLINE iatraversal #-}
 
 -- | Build an indexed affine traversal from the van Laarhoven representation.
 ixAtraversalVL :: IxAffineTraversalVL i s t a b -> IxAffineTraversal i s t a b

--- a/optics-core/src/Optics/IxAffineTraversal.hs
+++ b/optics-core/src/Optics/IxAffineTraversal.hs
@@ -13,6 +13,9 @@ module Optics.IxAffineTraversal
     IxAffineTraversal
   , IxAffineTraversal'
 
+  -- * Introduction
+  , iatraversal
+
   -- * Subtyping
   , An_AffineTraversal
 
@@ -50,6 +53,10 @@ type IxAffineTraversalVL i s t a b =
 
 -- | Type synonym for a type-preserving van Laarhoven indexed affine traversal.
 type IxAffineTraversalVL' i s a = IxAffineTraversalVL i s s a a
+
+iatraversal :: (s -> Either t (i, a)) -> (s -> b -> t) -> IxAffineTraversal i s t a b
+iatraversal match update = ixAtraversalVL $ \point f s ->
+  either point (\a -> update s <$> uncurry f a) (match s)
 
 -- | Build an indexed affine traversal from the van Laarhoven representation.
 ixAtraversalVL :: IxAffineTraversalVL i s t a b -> IxAffineTraversal i s t a b

--- a/optics-core/src/Optics/IxLens.hs
+++ b/optics-core/src/Optics/IxLens.hs
@@ -14,6 +14,7 @@ module Optics.IxLens
 
   -- * Introduction
   , ilens
+  , ixLensVL
 
   -- * Subtyping
   , A_Lens
@@ -21,7 +22,6 @@ module Optics.IxLens
   -- * van Laarhoven encoding
   , IxLensVL
   , IxLensVL'
-  , ixLensVL
   , toIxLensVL
   , withIxLensVL
 
@@ -50,6 +50,7 @@ type IxLensVL' i s a = IxLensVL i s s a a
 -- | Build an indexed lens from a getter and a setter.
 ilens :: (s -> (i, a)) -> (s -> b -> t) -> IxLens i s t a b
 ilens get set = ixLensVL $ \f s -> set s <$> uncurry f (get s)
+{-# INLINE ilens #-}
 
 -- | Build an indexed lens from the van Laarhoven representation.
 ixLensVL :: IxLensVL i s t a b -> IxLens i s t a b

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -109,9 +109,7 @@ type IxTraversalVL' i s a = IxTraversalVL i s s a a
 -- 'ixTraversalVL' '.' 'itraverseOf' ≡ 'id'
 -- 'itraverseOf' '.' 'ixTraversalVL' ≡ 'id'
 -- @
-ixTraversalVL
-  :: (forall f. Applicative f => (i -> a -> f b) -> s -> f t)
-  -> IxTraversal i s t a b
+ixTraversalVL :: IxTraversalVL i s t a b -> IxTraversal i s t a b
 ixTraversalVL t = Optic (iwander t)
 {-# INLINE ixTraversalVL #-}
 

--- a/optics-core/src/Optics/Lens.hs
+++ b/optics-core/src/Optics/Lens.hs
@@ -36,6 +36,7 @@ module Optics.Lens
 
   -- * Introduction
   , lens
+  , lensVL
 
   -- * Elimination
   -- | A 'Lens' is a 'Optics.Setter.Setter' and a
@@ -99,7 +100,6 @@ module Optics.Lens
   -- have a performance penalty.
   , LensVL
   , LensVL'
-  , lensVL
   , toLensVL
   , withLensVL
 


### PR DESCRIPTION
If `*VL` functions are not in the `Introduction` section, but at the end in the `van Laarhoven` section, people will have hard time discovering them, so I moved them up.