### PR TITLE
Do not re-export Optics.Optic from optic kind modules

### DIFF
--- a/optics-core/src/Data/IntMap/Optics.hs
+++ b/optics-core/src/Data/IntMap/Optics.hs
@@ -47,6 +47,7 @@ import Data.IntMap as IntMap
 
 import Optics.IxAffineTraversal
 import Optics.IxFold
+import Optics.Optic
 
 -- | Construct a map from an 'IxFold'.
 --

--- a/optics-core/src/Data/IntSet/Optics.hs
+++ b/optics-core/src/Data/IntSet/Optics.hs
@@ -13,6 +13,7 @@ module Data.IntSet.Optics
 import Data.IntSet as IntSet
 
 import Optics.Fold
+import Optics.Optic
 import Optics.Setter
 
 -- | IntSet isn't Foldable, but this 'Fold' can be used to access the members of

--- a/optics-core/src/Data/Map/Optics.hs
+++ b/optics-core/src/Data/Map/Optics.hs
@@ -54,6 +54,7 @@ import Data.Map as Map
 
 import Optics.IxAffineTraversal
 import Optics.IxFold
+import Optics.Optic
 
 -- | Construct a map from an 'IxFold'.
 --

--- a/optics-core/src/Data/Sequence/Optics.hs
+++ b/optics-core/src/Data/Sequence/Optics.hs
@@ -16,6 +16,7 @@ import Optics.Internal.Indexed
 import Optics.Fold
 import Optics.Iso
 import Optics.IxTraversal
+import Optics.Optic
 import Optics.Traversal
 
 -- * Sequence isomorphisms

--- a/optics-core/src/Data/Set/Optics.hs
+++ b/optics-core/src/Data/Set/Optics.hs
@@ -12,6 +12,7 @@ module Data.Set.Optics
 import Data.Set as Set
 
 import Optics.Fold
+import Optics.Optic
 import Optics.Setter
 
 -- | This 'Setter' can be used to change the type of a 'Set' by mapping the

--- a/optics-core/src/Data/Tuple/Optics.hs
+++ b/optics-core/src/Data/Tuple/Optics.hs
@@ -47,8 +47,8 @@ import Data.Proxy
 import GHC.Generics ((:*:)(..), Generic(..), K1, M1, U1)
 
 import GHC.Generics.Optics
-import Optics.Iso
 import Optics.Lens
+import Optics.Optic
 
 -- | Provides access to 1st field of a tuple.
 class Field1 s t a b | s -> a, t -> b, s b -> t, t a -> s where

--- a/optics-core/src/Numeric/Optics.hs
+++ b/optics-core/src/Numeric/Optics.hs
@@ -30,6 +30,7 @@ import Numeric (readInt, showIntAtBase)
 import Data.Tuple.Optics
 import Optics.AffineFold
 import Optics.Iso
+import Optics.Optic
 import Optics.Prism
 import Optics.Review
 import Optics.Setter

--- a/optics-core/src/Optics/AffineFold.hs
+++ b/optics-core/src/Optics/AffineFold.hs
@@ -37,9 +37,6 @@ module Optics.AffineFold
   -- * Subtyping
   , An_AffineFold
   -- | <<diagrams/AffineFold.png AffineFold in the optics hierarchy>>
-
-  -- * Re-exports
-  , module Optics.Optic
   ) where
 
 import Data.Maybe
@@ -47,7 +44,6 @@ import Data.Maybe
 import Optics.Internal.Bi
 import Optics.Internal.Profunctor
 import Optics.Internal.Optic
-import Optics.Optic
 
 -- | Type synonym for an affine fold.
 type AffineFold s a = Optic' An_AffineFold NoIx s a

--- a/optics-core/src/Optics/AffineTraversal.hs
+++ b/optics-core/src/Optics/AffineTraversal.hs
@@ -57,16 +57,12 @@ module Optics.AffineTraversal
   , AffineTraversalVL'
   , atraversalVL
   , toAtraversalVL
-
-  -- * Re-exports
-  , module Optics.Optic
   )
   where
 
 import Optics.Internal.Concrete
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
-import Optics.Optic
 
 -- | Type synonym for a type-modifying affine traversal.
 type AffineTraversal s t a b = Optic An_AffineTraversal NoIx s t a b

--- a/optics-core/src/Optics/At/Core.hs
+++ b/optics-core/src/Optics/At/Core.hs
@@ -57,6 +57,7 @@ import Data.Maybe.Optics
 import Optics.AffineTraversal
 import Optics.Iso
 import Optics.Lens
+import Optics.Optic
 import Optics.Setter
 
 -- | Type family that takes a key-value container type and returns the type of

--- a/optics-core/src/Optics/Cons/Core.hs
+++ b/optics-core/src/Optics/Cons/Core.hs
@@ -38,6 +38,7 @@ import Data.Tuple.Optics
 import Optics.AffineFold
 import Optics.AffineTraversal
 import Optics.Coerce
+import Optics.Optic
 import Optics.Prism
 import Optics.Review
 

--- a/optics-core/src/Optics/Core.hs
+++ b/optics-core/src/Optics/Core.hs
@@ -8,8 +8,11 @@
 --
 module Optics.Core
   (
+  -- * Basic definitions
+    module Optics.Optic
+
   -- * Kinds of optic
-    module O
+  , module O
 
   -- * Indexed optics
   , module I
@@ -58,6 +61,7 @@ import Optics.Re                               as P
 import Optics.ReadOnly                         as P
 
 import Optics.Label
+import Optics.Optic
 
 import Data.Either.Optics                      as D
 import Data.Maybe.Optics                       as D

--- a/optics-core/src/Optics/Empty/Core.hs
+++ b/optics-core/src/Optics/Empty/Core.hs
@@ -37,6 +37,7 @@ import Optics.AffineTraversal
 import Optics.Internal.Utils
 import Optics.Iso
 import Optics.Fold
+import Optics.Optic
 import Optics.Prism
 import Optics.Review
 

--- a/optics-core/src/Optics/Fold.hs
+++ b/optics-core/src/Optics/Fold.hs
@@ -82,9 +82,6 @@ module Optics.Fold
   -- * Subtyping
   , A_Fold
   -- | <<diagrams/Fold.png Fold in the optics hierarchy>>
-
-  -- * Re-exports
-  , module Optics.Optic
   )
   where
 
@@ -101,7 +98,6 @@ import Optics.Internal.Optic
 import Optics.Internal.Profunctor
 import Optics.Internal.Utils
 import Optics.AffineFold
-import Optics.Optic
 
 -- | Type synonym for a fold.
 type Fold s a = Optic' A_Fold NoIx s a

--- a/optics-core/src/Optics/Getter.hs
+++ b/optics-core/src/Optics/Getter.hs
@@ -36,16 +36,12 @@ module Optics.Getter
   -- * Subtyping
   , A_Getter
   -- | <<diagrams/Getter.png Getter in the optics hierarchy>>
-
-  -- * Re-exports
-  , module Optics.Optic
   )
   where
 
 import Optics.Internal.Bi
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
-import Optics.Optic
 
 -- | Type synonym for a getter.
 type Getter s a = Optic' A_Getter NoIx s a

--- a/optics-core/src/Optics/Iso.hs
+++ b/optics-core/src/Optics/Iso.hs
@@ -74,9 +74,6 @@ module Optics.Iso
   -- * Subtyping
   , An_Iso
   -- | <<diagrams/Iso.png Iso in the optics hierarchy>>
-
-  -- * Re-exports
-  , module Optics.Optic
   )
   where
 
@@ -87,7 +84,6 @@ import Data.Coerce
 import Optics.Internal.Concrete
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
-import Optics.Optic
 
 -- | Type synonym for a type-modifying iso.
 type Iso s t a b = Optic An_Iso NoIx s t a b

--- a/optics-core/src/Optics/IxAffineFold.hs
+++ b/optics-core/src/Optics/IxAffineFold.hs
@@ -31,9 +31,6 @@ module Optics.IxAffineFold
 
   -- * Subtyping
   , An_AffineFold
-
-  -- * Re-exports
-  , module Optics.Optic
   ) where
 
 import Optics.AffineFold
@@ -41,7 +38,6 @@ import Optics.Internal.Bi
 import Optics.Internal.Indexed
 import Optics.Internal.Profunctor
 import Optics.Internal.Optic
-import Optics.Optic
 
 -- | Type synonym for an indexed affine fold.
 type IxAffineFold i s a = Optic' An_AffineFold (WithIx i) s a

--- a/optics-core/src/Optics/IxAffineTraversal.hs
+++ b/optics-core/src/Optics/IxAffineTraversal.hs
@@ -38,15 +38,11 @@ module Optics.IxAffineTraversal
   , IxAffineTraversalVL'
   , iatraversalVL
   , toIxAtraversalVL
-
-  -- * Re-exports
-  , module Optics.Optic
   ) where
 
 import Optics.Internal.Indexed
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
-import Optics.Optic
 
 -- | Type synonym for a type-modifying indexed affine traversal.
 type IxAffineTraversal i s t a b = Optic An_AffineTraversal (WithIx i) s t a b

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -53,7 +53,6 @@ module Optics.IxFold
 
   -- * Re-exports
   , FoldableWithIndex(..)
-  , module Optics.Optic
   ) where
 
 import Control.Applicative.Backwards
@@ -68,7 +67,6 @@ import Optics.Internal.Profunctor
 import Optics.Internal.Utils
 import Optics.IxAffineFold
 import Optics.Fold
-import Optics.Optic
 
 -- | Type synonym for an indexed fold.
 type IxFold i s a = Optic' A_Fold (WithIx i) s a

--- a/optics-core/src/Optics/IxLens.hs
+++ b/optics-core/src/Optics/IxLens.hs
@@ -40,9 +40,6 @@ module Optics.IxLens
   , ilensVL
   , toIxLensVL
   , withIxLensVL
-
-  -- * Re-exports
-  , module Optics.Optic
   ) where
 
 import Data.Void
@@ -50,7 +47,6 @@ import Data.Void
 import Optics.Internal.Indexed
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
-import Optics.Optic
 
 -- | Type synonym for a type-modifying indexed lens.
 type IxLens i s t a b = Optic A_Lens (WithIx i) s t a b

--- a/optics-core/src/Optics/IxSetter.hs
+++ b/optics-core/src/Optics/IxSetter.hs
@@ -55,14 +55,12 @@ module Optics.IxSetter
 
   -- * Re-exports
   , FunctorWithIndex(..)
-  , module Optics.Optic
   ) where
 
 import Optics.Internal.Indexed
 import Optics.Internal.IxSetter
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
-import Optics.Optic
 
 -- | Type synonym for a type-modifying indexed setter.
 type IxSetter i s t a b = Optic A_Setter (WithIx i) s t a b

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -72,7 +72,6 @@ module Optics.IxTraversal
 
   -- * Re-exports
   , TraversableWithIndex(..)
-  , module Optics.Optic
   ) where
 
 import Control.Applicative.Backwards
@@ -84,7 +83,6 @@ import Optics.Internal.IxTraversal
 import Optics.Internal.Profunctor
 import Optics.Internal.Optic
 import Optics.Internal.Utils
-import Optics.Optic
 import Optics.IxLens
 import Optics.IxFold
 import Optics.ReadOnly

--- a/optics-core/src/Optics/Lens.hs
+++ b/optics-core/src/Optics/Lens.hs
@@ -104,9 +104,6 @@ module Optics.Lens
   , lensVL
   , toLensVL
   , withLensVL
-
-  -- * Re-exports
-  , module Optics.Optic
   )
   where
 
@@ -114,7 +111,6 @@ import Optics.Internal.Concrete
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
 import Optics.Internal.Utils
-import Optics.Optic
 
 -- | Type synonym for a type-modifying lens.
 type Lens s t a b = Optic A_Lens NoIx s t a b

--- a/optics-core/src/Optics/Operators.hs
+++ b/optics-core/src/Optics/Operators.hs
@@ -21,6 +21,7 @@ module Optics.Operators
 import Optics.AffineFold
 import Optics.Fold
 import Optics.Getter
+import Optics.Optic
 import Optics.Review
 import Optics.Setter
 

--- a/optics-core/src/Optics/Prism.hs
+++ b/optics-core/src/Optics/Prism.hs
@@ -64,9 +64,6 @@ module Optics.Prism
   -- * Subtyping
   , A_Prism
   -- | <<diagrams/Prism.png Prism in the optics hierarchy>>
-
-  -- * Re-exports
-  , module Optics.Optic
   )
   where
 
@@ -76,7 +73,6 @@ import Data.Bifunctor
 import Optics.Internal.Concrete
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
-import Optics.Optic
 
 -- | Type synonym for a type-modifying prism.
 type Prism s t a b = Optic A_Prism NoIx s t a b

--- a/optics-core/src/Optics/ReversedLens.hs
+++ b/optics-core/src/Optics/ReversedLens.hs
@@ -52,13 +52,9 @@ module Optics.ReversedLens
   -- * Subtyping
   , A_ReversedLens
   -- | <<diagrams/ReversedLens.png ReversedLens in the optics hierarchy>>
-
-  -- * Re-exports
-  , module Optics.Optic
   ) where
 
 import Optics.Internal.Optic
-import Optics.Optic
 
 -- | Type synonym for a type-modifying reversed lens.
 type ReversedLens s t a b = Optic A_ReversedLens NoIx s t a b

--- a/optics-core/src/Optics/ReversedPrism.hs
+++ b/optics-core/src/Optics/ReversedPrism.hs
@@ -52,13 +52,9 @@ module Optics.ReversedPrism
   -- * Subtyping
   , A_ReversedPrism
   -- | <<diagrams/ReversedPrism.png ReversedPrism in the optics hierarchy>>
-
-  -- * Re-exports
-  , module Optics.Optic
   ) where
 
 import Optics.Internal.Optic
-import Optics.Optic
 
 -- | Type synonym for a type-modifying reversed prism.
 type ReversedPrism s t a b = Optic A_ReversedPrism NoIx s t a b

--- a/optics-core/src/Optics/Review.hs
+++ b/optics-core/src/Optics/Review.hs
@@ -26,9 +26,6 @@ module Optics.Review
   -- * Subtyping
   , A_Review
   -- | <<diagrams/Review.png Review in the optics hierarchy>>
-
-  -- * Re-exports
-  , module Optics.Optic
   )
   where
 
@@ -37,7 +34,6 @@ import Optics.Internal.Optic
 import Optics.Internal.Profunctor
 import Optics.Internal.Tagged
 import Optics.Internal.Utils
-import Optics.Optic
 
 -- | Type synonym for a review.
 type Review t b = Optic' A_Review NoIx t b

--- a/optics-core/src/Optics/Setter.hs
+++ b/optics-core/src/Optics/Setter.hs
@@ -58,15 +58,11 @@ module Optics.Setter
   -- * Subtyping
   , A_Setter
   -- | <<diagrams/Setter.png Setter in the optics hierarchy>>
-
-  -- * Re-exports
-  , module Optics.Optic
   ) where
 
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
 import Optics.Internal.Setter
-import Optics.Optic
 
 -- | Type synonym for a type-modifying setter.
 type Setter s t a b = Optic A_Setter NoIx s t a b

--- a/optics-core/src/Optics/Traversal.hs
+++ b/optics-core/src/Optics/Traversal.hs
@@ -72,9 +72,6 @@ module Optics.Traversal
   -- @S -> F T@.  Thus 'traverseOf' converts a 'Traversal' to a 'TraversalVL'.
   , TraversalVL
   , TraversalVL'
-
-  -- * Re-exports
-  , module Optics.Optic
   )
   where
 
@@ -83,14 +80,12 @@ import Control.Applicative.Backwards
 import Control.Monad.Trans.State
 import Data.Functor.Identity
 
-import Optics.Internal.Indexed
 import Optics.Internal.Optic
 import Optics.Internal.Profunctor
 import Optics.Internal.Traversal
 import Optics.Internal.Utils
 import Optics.Lens
 import Optics.Fold
-import Optics.Optic
 import Optics.ReadOnly
 
 -- | Type synonym for a type-modifying traversal.

--- a/optics-extra/src/Data/HashSet/Optics.hs
+++ b/optics-extra/src/Data/HashSet/Optics.hs
@@ -14,6 +14,7 @@ import Data.Hashable
 import Data.HashSet as HashSet
 
 import Optics.Fold
+import Optics.Optic
 import Optics.Setter
 
 -- | This 'Setter' can be used to change the type of a 'HashSet' by mapping the


### PR DESCRIPTION
This stops `Optics.Lens` and other optic kind modules from re-exporting `Optics.Optic`. Instead it (or `Optics.Core` or `Optics`) must be imported explicitly.

I'm in two minds about this change. The motivation is that it makes the GHCi commands like `:browse Optics.Lens` more useful; at the moment the output is swamped by all the things re-exported from `Optics.Optic`. On the other hand it will typically mean an extra import if you only want to import a few optic kinds.

Opinions?