### PR TITLE
Relax optics-th bound on template-haskell

### DIFF
--- a/optics-th/optics-th.cabal
+++ b/optics-th/optics-th.cabal
@@ -30,7 +30,7 @@ library
                , containers             >= 0.5.7.1   && <0.7
                , mtl                    >= 2.2.2     && <2.3
                , optics-core            >= 0.1       && <1
-               , template-haskell       >= 2.11      && <2.15
+               , template-haskell       >= 2.11      && <2.16
                , th-abstraction         >= 0.2.1     && <0.4
                , transformers           >= 0.5       && <0.6
 


### PR DESCRIPTION
I spotted after releasing 0.1 (thanks to the matrix builder) that `optics-th` has an unnecessarily tight bound on `template-haskell`, which rules out GHC 8.8. This wasn't spotted before because our CI for 8.8 is still using `allow-newer`. I've made a Hackage revision of `optics-th` to relax this bound.