### PR TITLE
Introduce type synonyms for optic kind and indices

### DIFF
--- a/optics-core/src/Optics/Internal/Indexed.hs
+++ b/optics-core/src/Optics/Internal/Indexed.hs
@@ -38,7 +38,7 @@ import Optics.Internal.Profunctor
 import Optics.Internal.Utils
 
 -- | Show useful error message when a function expects optics without indices.
-class is ~ NoIx => AcceptsEmptyIndices (f :: Symbol) (is :: Indices)
+class is ~ NoIx => AcceptsEmptyIndices (f :: Symbol) (is :: IxList)
 
 instance
   ( TypeError
@@ -50,7 +50,7 @@ instance AcceptsEmptyIndices f '[]
 
 -- | Check whether a list of indices is not empty and generate sensible error
 -- message if it's not.
-class NonEmptyIndices (is :: Indices)
+class NonEmptyIndices (is :: IxList)
 
 instance
   ( TypeError
@@ -62,7 +62,7 @@ instance NonEmptyIndices (x ': xs)
 -- | Generate sensible error messages in case a user tries to pass either an
 -- unindexed optic or indexed optic with unflattened indices where indexed optic
 -- with a single index is expected.
-class is ~ '[i] => HasSingleIndex (is :: Indices) (i :: Type)
+class is ~ '[i] => HasSingleIndex (is :: IxList) (i :: Type)
 
 instance HasSingleIndex '[i] i
 

--- a/optics-core/src/Optics/Internal/Indexed.hs
+++ b/optics-core/src/Optics/Internal/Indexed.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeInType #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
@@ -19,6 +20,7 @@ import Data.Functor.Product
 import Data.Functor.Reverse
 import Data.Functor.Sum
 import Data.Ix
+import Data.Kind (Type)
 import Data.List.NonEmpty
 import Data.Monoid hiding (Product, Sum)
 import Data.Proxy
@@ -36,7 +38,7 @@ import Optics.Internal.Profunctor
 import Optics.Internal.Utils
 
 -- | Show useful error message when a function expects optics without indices.
-class is ~ NoIx => AcceptsEmptyIndices (f :: Symbol) (is :: [*])
+class is ~ NoIx => AcceptsEmptyIndices (f :: Symbol) (is :: Indices)
 
 instance
   ( TypeError
@@ -48,7 +50,7 @@ instance AcceptsEmptyIndices f '[]
 
 -- | Check whether a list of indices is not empty and generate sensible error
 -- message if it's not.
-class NonEmptyIndices (is :: [*])
+class NonEmptyIndices (is :: Indices)
 
 instance
   ( TypeError
@@ -60,7 +62,7 @@ instance NonEmptyIndices (x ': xs)
 -- | Generate sensible error messages in case a user tries to pass either an
 -- unindexed optic or indexed optic with unflattened indices where indexed optic
 -- with a single index is expected.
-class is ~ '[i] => HasSingleIndex (is :: [*]) (i :: *)
+class is ~ '[i] => HasSingleIndex (is :: Indices) (i :: Type)
 
 instance HasSingleIndex '[i] i
 
@@ -113,7 +115,7 @@ instance
 ----------------------------------------
 -- Helpers for HasSingleIndex
 
-type family ShowTypes (types :: [*]) :: ErrorMessage where
+type family ShowTypes (types :: [Type]) :: ErrorMessage where
   ShowTypes '[i]      = QuoteType i
   ShowTypes '[i, j]   = QuoteType i ':<>: 'Text " and " ':<>: QuoteType j
   ShowTypes (i ': is) = QuoteType i ':<>: 'Text ", " ':<>: ShowTypes is

--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -64,7 +64,7 @@ import Unsafe.Coerce (unsafeCoerce)
 -- The parameters @s@ and @t@ represent the "big" structure,
 -- whereas @a@ and @b@ represent the "small" structure.
 --
-newtype Optic (k :: OpticKind) (is :: Indices) s t a b = Optic
+newtype Optic (k :: OpticKind) (is :: IxList) s t a b = Optic
   { getOptic :: forall p i. Profunctor p
              => Optic_ k p i (Curry is i) s t a b
   }

--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeInType #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
@@ -38,6 +39,7 @@ module Optics.Internal.Optic
   ) where
 
 import Data.Function ((&))
+import Data.Kind (Type)
 import Data.Proxy (Proxy (..))
 import Data.Type.Equality
 import GHC.OverloadedLabels
@@ -70,7 +72,7 @@ type WithIx i = '[i]
 -- The parameters @s@ and @t@ represent the "big" structure,
 -- whereas @a@ and @b@ represent the "small" structure.
 --
-newtype Optic (k :: *) (is :: [*]) s t a b = Optic
+newtype Optic (k :: OpticKind) (is :: [Type]) s t a b = Optic
   { getOptic :: forall p i. Profunctor p
              => Optic_ k p i (Curry is i) s t a b
   }
@@ -94,7 +96,7 @@ type Optic__ p i j s t a b = p i a b -> p j s t
 
 -- | Proxy type for use as an argument to 'implies'.
 --
-data IsProxy (k :: *) (l :: *) (p :: * -> * -> * -> *) =
+data IsProxy (k :: Type) (l :: Type) (p :: Type -> Type -> Type -> Type) =
   IsProxy
 
 -- | Explicit cast from one optic flavour to another.
@@ -183,7 +185,7 @@ infixl 9 %&
 --
 -- It shows that usage of 'unsafeCoerce' in '(%%)' is, in fact, safe.
 --
-class Append xs ys ~ zs => AppendProof (xs :: [*]) (ys :: [*]) (zs :: [*])
+class Append xs ys ~ zs => AppendProof (xs :: [Type]) (ys :: [Type]) (zs :: [Type])
   | xs ys -> zs, zs xs -> ys {- , zs ys -> xs -} where
   appendProof :: Proxy i -> Curry xs (Curry ys i) :~: Curry zs i
 

--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -22,8 +22,6 @@ module Optics.Internal.Optic
   , Optic'
   , Optic_
   , Optic__
-  , NoIx
-  , WithIx
   , castOptic
   , (%)
   , (%%)
@@ -53,12 +51,6 @@ import Optics.Internal.Profunctor
 -- to make %% simpler
 import Unsafe.Coerce (unsafeCoerce)
 
--- | An alias for an empty index-list
-type NoIx = '[]
-
--- | Singleton index list
-type WithIx i = '[i]
-
 -- | Wrapper newtype for the whole family of optics.
 --
 -- The first parameter @k@ identifies the particular optic kind (e.g. 'A_Lens'
@@ -72,7 +64,7 @@ type WithIx i = '[i]
 -- The parameters @s@ and @t@ represent the "big" structure,
 -- whereas @a@ and @b@ represent the "small" structure.
 --
-newtype Optic (k :: OpticKind) (is :: [Type]) s t a b = Optic
+newtype Optic (k :: OpticKind) (is :: Indices) s t a b = Optic
   { getOptic :: forall p i. Profunctor p
              => Optic_ k p i (Curry is i) s t a b
   }

--- a/optics-core/src/Optics/Internal/Optic/Subtyping.hs
+++ b/optics-core/src/Optics/Internal/Optic/Subtyping.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeInType #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
@@ -96,7 +97,7 @@ instance Is A_Traversal        A_Setter           where implies _ = id
 -- l@. This means in particular that composition of an @Optic k@ and an @Optic
 -- k@ will yield an @Optic (Join k l)@.
 --
-type family Join (k :: *) (l :: *) where
+type family Join (k :: OpticKind) (l :: OpticKind) where
   -- BEGIN GENERATED CONTENT
   -- An_Iso-----
   Join An_Iso             A_ReversedLens     = A_ReversedLens

--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -11,13 +11,13 @@ import Data.Kind (Type)
 import GHC.TypeLits
 
 -- | A list of index types, used for indexed optics.
-type Indices = [Type]
+type IxList = [Type]
 
 -- | An alias for an empty index-list
-type NoIx = ('[] :: Indices)
+type NoIx = ('[] :: IxList)
 
 -- | Singleton index list
-type WithIx i = ('[i] :: Indices)
+type WithIx i = ('[i] :: IxList)
 
 -- | Show a type surrounded by quote marks.
 type family QuoteType (x :: Type) :: ErrorMessage where
@@ -30,12 +30,12 @@ type family QuoteType (x :: Type) :: ErrorMessage where
 -- @
 -- 'Curry' xs y = 'foldr' (->) y xs
 -- @
-type family Curry (xs :: Indices) (y :: Type) :: Type where
+type family Curry (xs :: IxList) (y :: Type) :: Type where
   Curry '[]       y = y
   Curry (x ': xs) y = x -> Curry xs y
 
 -- | Append two type-level lists together.
-type family Append (xs :: Indices) (ys :: Indices) :: Indices where
+type family Append (xs :: IxList) (ys :: IxList) :: IxList where
   Append '[]       ys  = ys -- needed for (<%>) and (%>)
   Append xs        '[] = xs -- needed for (<%)
   Append (x ': xs) ys  = x ': Append xs ys

--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -1,15 +1,26 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeInType #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
 -- | This module is intended for internal use only, and may change without
 -- warning in subsequent releases.
 module Optics.Internal.Optic.TypeLevel where
 
+import Data.Kind (Type)
 import GHC.TypeLits
 
+-- | A list of index types, used for indexed optics.
+type Indices = [Type]
+
+-- | An alias for an empty index-list
+type NoIx = ('[] :: Indices)
+
+-- | Singleton index list
+type WithIx i = ('[i] :: Indices)
+
 -- | Show a type surrounded by quote marks.
-type family QuoteType (x :: *) :: ErrorMessage where
+type family QuoteType (x :: Type) :: ErrorMessage where
   QuoteType x = 'Text "‘" ':<>: 'ShowType x ':<>: 'Text "’"
 
 -- | Curry a type-level list.
@@ -19,12 +30,12 @@ type family QuoteType (x :: *) :: ErrorMessage where
 -- @
 -- 'Curry' xs y = 'foldr' (->) y xs
 -- @
-type family Curry (xs :: [*]) (y :: *) :: * where
+type family Curry (xs :: Indices) (y :: Type) :: Type where
   Curry '[]       y = y
   Curry (x ': xs) y = x -> Curry xs y
 
 -- | Append two type-level lists together.
-type family Append (xs :: [*]) (ys :: [*]) :: [*] where
+type family Append (xs :: Indices) (ys :: Indices) :: Indices where
   Append '[]       ys  = ys -- needed for (<%>) and (%>)
   Append xs        '[] = xs -- needed for (<%)
   Append (x ': xs) ys  = x ': Append xs ys

--- a/optics-core/src/Optics/Internal/Optic/Types.hs
+++ b/optics-core/src/Optics/Internal/Optic/Types.hs
@@ -1,45 +1,50 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeInType #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
 -- | This module is intended for internal use only, and may change without
 -- warning in subsequent releases.
 module Optics.Internal.Optic.Types where
 
-import GHC.Exts (Constraint)
+import Data.Kind (Constraint, Type)
 
 import Optics.Internal.Bi
 import Optics.Internal.Profunctor
 
+-- | Kind for types used as optic tags, such as 'A_Lens'.
+type OpticKind = Type
+
 -- | Tag for an iso.
-data An_Iso
+data An_Iso :: OpticKind
 -- | Tag for a lens.
-data A_Lens
+data A_Lens :: OpticKind
 -- | Tag for a prism.
-data A_Prism
+data A_Prism :: OpticKind
 -- | Tag for an affine traversal.
-data An_AffineTraversal
+data An_AffineTraversal :: OpticKind
 -- | Tag for a traversal.
-data A_Traversal
+data A_Traversal :: OpticKind
 -- | Tag for a setter.
-data A_Setter
+data A_Setter :: OpticKind
 -- | Tag for a reversed prism.
-data A_ReversedPrism
+data A_ReversedPrism :: OpticKind
 -- | Tag for a getter.
-data A_Getter
+data A_Getter :: OpticKind
 -- | Tag for an affine fold.
-data An_AffineFold
+data An_AffineFold :: OpticKind
 -- | Tag for a fold.
-data A_Fold
+data A_Fold :: OpticKind
 -- | Tag for a reversed lens.
-data A_ReversedLens
+data A_ReversedLens :: OpticKind
 -- | Tag for a review.
-data A_Review
+data A_Review :: OpticKind
 
 -- | Mapping tag types @k@ to constraints on @p@.
 --
 -- Using this type family we define the constraints that the various flavours of
 -- optics have to fulfill.
 --
-type family Constraints (k :: *) (p :: * -> * -> * -> *) :: Constraint where
+type family Constraints (k :: OpticKind) (p :: Type -> Type -> Type -> Type) :: Constraint where
   Constraints An_Iso             p = Profunctor p
   Constraints A_Lens             p = Strong p
   Constraints A_ReversedLens     p = Costrong p

--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -42,7 +42,7 @@ module Optics.Optic
   -- | See the "Indexed optics" section of the overview documentation in the
   -- @Optics@ module of the main @optics@ package for more details on indexed
   -- optics.
-  , Indices
+  , IxList
   , NoIx
   , WithIx
   , Append

--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -39,6 +39,10 @@ module Optics.Optic
   , (%&)
 
   -- * Indexed optics
+  -- | See the "Indexed optics" section of the overview documentation in the
+  -- @Optics@ module of the main @optics@ package for more details on indexed
+  -- optics.
+  , Indices
   , NoIx
   , WithIx
   , Append

--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -24,7 +24,8 @@
 -- documentation.
 --
 module Optics.Optic
-  ( Optic
+  ( OpticKind
+  , Optic
   , Optic'
 
   -- * Subtyping

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -517,7 +517,7 @@ import Data.Either.Optics                    as P
 -- 'Join' of a 'Lens' and a 'Prism' is an 'AffineTraversal'.
 --
 -- >>> :kind! Join A_Lens A_Prism
--- Join A_Lens A_Prism :: *
+-- Join A_Lens A_Prism :: OpticKind
 -- = An_AffineTraversal
 --
 -- The join does not exist for some pairs of optic kinds, which means that they
@@ -525,7 +525,7 @@ import Data.Either.Optics                    as P
 -- and 'Fold':
 --
 -- >>> :kind! Join A_Setter A_Fold
--- Join A_Setter A_Fold :: *
+-- Join A_Setter A_Fold :: OpticKind
 -- = (TypeError ...)
 --
 -- >>> :t mapped % folded


### PR DESCRIPTION
Fixes #71. This improves the haddocks and repl use: 
```hs
*Optics.Core> :kind Optic
Optic :: OpticKind -> Indices -> * -> * -> * -> * -> *
```
We need to enable `TypeInType` for older GHCs. This has an effect on the parsing of `*`, so I've switched to `Type` in a few places.

Opinions on `Indices` vs `IxList`?