### PR TITLE
Disable building benchmarks for GHCJS CI as they're not run anyway

### DIFF
--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -150,6 +150,10 @@ benchmark folds
   hs-source-dirs:   benchmarks
   ghc-options:      -Wall -threaded
 
+  -- GHCJS takes forever to compile dependencies
+  if impl(ghcjs)
+    buildable: False
+
   -- TODO: remove when deps compile with GHC 8.8
   if impl(ghc >= 8.8)
     buildable: False
@@ -171,6 +175,10 @@ benchmark traversals
   default-language: Haskell2010
   hs-source-dirs:   benchmarks
   ghc-options:      -Wall -threaded
+
+  -- GHCJS takes forever to compile dependencies
+  if impl(ghcjs)
+    buildable: False
 
   -- TODO: remove when deps compile with GHC 8.8
   if impl(ghc >= 8.8)


### PR DESCRIPTION
CI takes forever to build the dependencies.

https://travis-ci.org/well-typed/optics/builds/582262790?utm_source=github_status&utm_medium=notification