### PR TITLE
WIP&RFC: NonEmpty traversals and folds

### DIFF
--- a/codegen/Subtypes.hs
+++ b/codegen/Subtypes.hs
@@ -32,6 +32,8 @@ data OpticKind
   |  An_AffineTraversal
   -- | Tag for a traversal.
   |  A_Traversal
+  -- | Tag for a non empty traversal
+  |  A_Traversal1
   -- | Tag for a setter.
   |  A_Setter
   -- | Tag for a reversed prism.
@@ -40,6 +42,8 @@ data OpticKind
   |  A_Getter
   -- | Tag for an affine fold.
   |  An_AffineFold
+  -- | Tag for a nonempty fold.
+  |  A_Fold1
   -- | Tag for a fold.
   |  A_Fold
   -- | Tag for a reversed lens.
@@ -60,15 +64,20 @@ opticsKind = mkProper $ Map.fromListWith (<>)
     , A_Prism            ~> A_Review
     , A_Prism            ~> An_AffineTraversal
     , A_Lens             ~> An_AffineTraversal
+    , A_Lens             ~> A_Traversal1
     , An_AffineTraversal ~> A_Traversal
+    , A_Traversal1       ~> A_Traversal
     , A_Traversal        ~> A_Setter
 
     -- folds
     , A_Lens             ~> A_Getter
     , An_AffineTraversal ~> An_AffineFold
+    , A_Traversal1       ~> A_Fold1
     , A_Traversal        ~> A_Fold
 
     , A_Getter           ~> An_AffineFold
+    , A_Getter           ~> A_Fold1
+    , A_Fold1            ~> A_Fold
     , An_AffineFold      ~> A_Fold
     ]
   where

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -46,6 +46,7 @@ library
                    Optics.AffineFold
                    Optics.AffineTraversal
                    Optics.Fold
+                   Optics.Fold1
                    Optics.Getter
                    Optics.Iso
                    Optics.IxAffineFold
@@ -62,6 +63,7 @@ library
                    Optics.Review
                    Optics.Setter
                    Optics.Traversal
+                   Optics.Traversal1
 
                    -- optic utilities
                    Optics.Arrow

--- a/optics-core/src/Optics/Fold1.hs
+++ b/optics-core/src/Optics/Fold1.hs
@@ -1,0 +1,675 @@
+-- |
+-- Module: Optics.Fold1
+-- Description: Extracts elements from a non-empty container.
+--
+-- TBW. Non 
+--
+module Optics.Fold1
+  (
+  -- * Formation
+    Fold1
+
+  -- * Introduction
+  , fold1VL
+
+  -- * Elimination
+  , fold1Of
+  , foldMap1Of
+  -- , foldr1Of
+  -- , foldl1Of'
+
+  , toNonEmptyOf
+
+{-
+  , sequenceOf_
+  , traverseOf_
+  , forOf_
+
+  -- * Computation
+  --
+  -- |
+  --
+  -- @
+  -- 'traverseOf_' ('foldVL' f) ≡ f
+  -- @
+
+  -- * Additional introduction forms
+  , folded
+  , folding
+  , foldring
+  , unfolded
+
+  -- * Additional elimination forms
+  -- | See also 'Data.Set.Optics.setOf', which constructs a 'Data.Set.Set' from a 'Fold1'.
+  , has
+  , hasn't
+  , headOf
+  , lastOf
+  , andOf
+  , orOf
+  , allOf
+  , anyOf
+  , noneOf
+  , productOf
+  , sumOf
+  , asumOf
+  , msumOf
+  , elemOf
+  , notElemOf
+  , lengthOf
+  , maximumOf
+  , minimumOf
+  , maximumByOf
+  , minimumByOf
+  , findOf
+  , findMOf
+  , lookupOf
+
+  -- * Combinators
+  , pre
+  , backwards_
+
+  -- * Semigroup structure
+  , summing
+  , failing
+-}
+
+  -- * Subtyping
+  , A_Fold1
+  -- | <<diagrams/Fold1.png Fold1 in the optics hierarchy>>
+  )
+  where
+
+import Control.Applicative
+import Control.Applicative.Backwards
+import Control.Monad
+import Data.Foldable
+import Data.Function
+import Data.Monoid
+import Data.List.NonEmpty (NonEmpty (..))
+
+import qualified Data.List.NonEmpty as NE
+
+import Data.Profunctor.Indexed
+
+import Optics.AffineFold
+import Optics.Internal.Bi
+import Optics.Internal.Optic
+import Optics.Internal.Utils
+
+-- | Type synonym for a fold.
+type Fold1 s a = Optic' A_Fold1 NoIx s a
+
+-- | Obtain a 'Fold1' by lifting 'traverse_' like function.
+--
+-- @
+-- 'foldVL' '.' 'traverseOf_' ≡ 'id'
+-- 'traverseOf_' '.' 'foldVL' ≡ 'id'
+-- @
+fold1VL
+  :: (forall f. Apply f => (a -> f u) -> s -> f v)
+  -> Fold1 s a
+fold1VL f = Optic (rphantom . wander1 f . rphantom)
+{-# INLINE fold1VL #-}
+
+-- | Combine the results of a fold using a monoid.
+fold1Of :: (Is k A_Fold1, Semigroup a) => Optic' k is s a -> s -> a
+fold1Of o = foldMap1Of o id
+{-# INLINE fold1Of #-}
+
+-- | Fold1 via embedding into a monoid.
+foldMap1Of :: (Is k A_Fold1, Semigroup m) => Optic' k is s a -> (a -> m) -> s -> m
+foldMap1Of o = runForget #. getOptic (castOptic @A_Fold1 o) .# Forget
+{-# INLINE foldMap1Of #-}
+ 
+{-
+-- | Fold1 right-associatively.
+foldr1Of :: Is k A_Fold1 => Optic' k is s a -> (a -> a -> a) -> s -> a
+foldr1Of o = \arr s -> (\e -> appEndo e r) $ foldMap1Of o (Endo #. arr) s
+{-# INLINE foldr1Of #-}
+-}
+
+newtype NonEmptyDList a = NEDL { unNEDL :: [a] -> NonEmpty a }
+
+instance Semigroup (NonEmptyDList a) where
+  (<>) = append
+  {-# INLINE (<>) #-}
+
+-- | Create dlist with a single element
+singleton :: a -> NonEmptyDList a
+singleton = NEDL . (:|)
+
+-- | /O(1)/. Append dlists
+append :: NonEmptyDList a -> NonEmptyDList a -> NonEmptyDList a
+append xs ys = NEDL (unNEDL xs . NE.toList . unNEDL ys)
+
+-- | Convert a dlist to a non-empty list
+toNonEmpty :: NonEmptyDList a -> NonEmpty a
+toNonEmpty = ($[]) . unNEDL
+{-# INLINE toNonEmpty #-}
+
+{-
+-- | Fold1 left-associatively, and strictly.
+foldl1Of' :: Is k A_Fold1 => Optic' k is s a -> (r -> a -> r) -> r -> s -> r
+foldl1Of' o = \rar r0 s -> foldr1Of o (\a rr r -> rr $! rar r a) id s r0
+{-# INLINE foldl1Of' #-}
+-}
+
+-- | Fold1 to a list.
+toNonEmptyOf :: Is k A_Fold1 => Optic' k is s a -> s -> NonEmpty a
+toNonEmptyOf o = toNonEmpty . foldMap1Of o singleton
+{-# INLINE toNonEmptyOf #-}
+
+{-
+----------------------------------------
+
+-- | Traverse over all of the targets of a 'Fold1', computing an
+-- 'Applicative'-based answer, but unlike 'Optics.Traversal.traverseOf' do not
+-- construct a new structure. 'traverseOf_' generalizes
+-- 'Data.Fold1able.traverse_' to work over any 'Fold1'.
+--
+-- >>> traverseOf_ each putStrLn ("hello","world")
+-- hello
+-- world
+--
+-- @
+-- 'Data.Fold1able.traverse_' ≡ 'traverseOf_' 'folded'
+-- @
+traverseOf_
+  :: (Is k A_Fold1, Applicative f)
+  => Optic' k is s a
+  -> (a -> f r) -> s -> f ()
+traverseOf_ o = \f -> runTraversed . foldMapOf o (Traversed #. f)
+{-# INLINE traverseOf_ #-}
+
+-- | A version of 'traverseOf_' with the arguments flipped.
+forOf_
+  :: (Is k A_Fold1, Applicative f)
+  => Optic' k is s a
+  -> s -> (a -> f r) -> f ()
+forOf_ = flip . traverseOf_
+{-# INLINE forOf_ #-}
+
+-- | Evaluate each action in a structure observed by a 'Fold1' from left to
+-- right, ignoring the results.
+--
+-- @
+-- 'sequenceA_' ≡ 'sequenceOf_' 'folded'
+-- @
+--
+-- >>> sequenceOf_ each (putStrLn "hello",putStrLn "world")
+-- hello
+-- world
+sequenceOf_
+  :: (Is k A_Fold1, Applicative f)
+  => Optic' k is s (f a)
+  -> s -> f ()
+sequenceOf_ o = runTraversed . foldMapOf o Traversed
+{-# INLINE sequenceOf_ #-}
+
+----------------------------------------
+
+-- | Fold1 via the 'Fold1able' class.
+folded :: Fold1able f => Fold1 (f a) a
+folded = Optic folded__
+{-# INLINE folded #-}
+
+-- | Obtain a 'Fold1' by lifting an operation that returns a 'Fold1able' result.
+--
+-- This can be useful to lift operations from @Data.List@ and elsewhere into a
+-- 'Fold1'.
+--
+-- >>> toListOf (folding tail) [1,2,3,4]
+-- [2,3,4]
+folding :: Fold1able f => (s -> f a) -> Fold1 s a
+folding f = Optic (contrafirst f . foldVL__ traverse_)
+{-# INLINE folding #-}
+
+-- | Obtain a 'Fold1' by lifting 'foldr' like function.
+--
+-- >>> toListOf (foldring foldr) [1,2,3,4]
+-- [1,2,3,4]
+foldring
+  :: (forall f. Applicative f => (a -> f u -> f u) -> f v -> s -> f w)
+  -> Fold1 s a
+foldring fr = Optic (foldring__ fr)
+{-# INLINE foldring #-}
+
+-- | Build a 'Fold1' that unfolds its values from a seed.
+--
+-- @
+-- 'Prelude.unfoldr' ≡ 'toListOf' '.' 'unfolded'
+-- @
+--
+-- >>> toListOf (unfolded $ \b -> if b == 0 then Nothing else Just (b, b - 1)) 10
+-- [10,9,8,7,6,5,4,3,2,1]
+unfolded :: (s -> Maybe (a, s)) -> Fold1 s a
+unfolded step = foldVL $ \f -> fix $ \loop b ->
+  case step b of
+    Just (a, b') -> f a *> loop b'
+    Nothing      -> pure ()
+{-# INLINE unfolded #-}
+
+-- | Convert a fold to an 'AffineFold1' that visits the first element of the
+-- original fold.
+pre :: Is k A_Fold1 => Optic' k is s a -> AffineFold1 s a
+pre = afolding . headOf
+{-# INLINE pre #-}
+
+-- | This allows you to traverse the elements of a 'Fold1' in the opposite order.
+backwards_
+  :: Is k A_Fold1
+  => Optic' k is s a
+  -> Fold1 s a
+backwards_ o = foldVL $ \f -> forwards #. traverseOf_ o (Backwards #. f)
+{-# INLINE backwards_ #-}
+
+-- | Return entries of the first 'Fold1', then the second one.
+--
+-- >>> toListOf (_1 % ix 0 `summing` _2 % ix 1) ([1,2], [4,7,1])
+-- [1,7]
+--
+summing
+  :: (Is k A_Fold1, Is l A_Fold1)
+  => Optic' k is s a
+  -> Optic' l js s a
+  -> Fold1 s a
+summing a b = foldVL $ \f s -> traverseOf_ a f s *> traverseOf_ b f s
+infixr 6 `summing` -- Same as (<>)
+{-# INLINE summing #-}
+
+-- | Try the first 'Fold1'. If it returns no entries, try the second one.
+failing
+  :: (Is k A_Fold1, Is l A_Fold1)
+  => Optic' k is s a
+  -> Optic' l js s a
+  -> Fold1 s a
+failing a b = foldVL $ \f s ->
+  let OrT visited fu = traverseOf_ a (wrapOrT . f) s
+  in if visited
+     then fu
+     else traverseOf_ b f s
+infixl 3 `failing` -- Same as (<|>)
+{-# INLINE failing #-}
+
+----------------------------------------
+-- Special folds
+
+-- | Check to see if this optic matches 1 or more entries.
+--
+-- >>> has _Left (Left 12)
+-- True
+--
+-- >>> has _Right (Left 12)
+-- False
+--
+-- This will always return 'True' for a 'Optics.Lens.Lens' or
+-- 'Optics.Getter.Getter'.
+--
+-- >>> has _1 ("hello","world")
+-- True
+has :: Is k A_Fold1 => Optic' k is s a -> s -> Bool
+has o = getAny #. foldMapOf o (\_ -> Any True)
+{-# INLINE has #-}
+
+-- | Check to see if this 'Fold1' or 'Optics.Traversal.Traversal' has
+-- no matches.
+--
+-- >>> hasn't _Left (Right 12)
+-- True
+--
+-- >>> hasn't _Left (Left 12)
+-- False
+hasn't :: Is k A_Fold1 => Optic' k is s a -> s -> Bool
+hasn't o = getAll #. foldMapOf o (\_ -> All False)
+{-# INLINE hasn't #-}
+
+-- | Retrieve the first entry of a 'Fold1'.
+--
+-- >>> headOf folded [1..10]
+-- Just 1
+--
+-- >>> headOf each (1,2)
+-- Just 1
+headOf :: Is k A_Fold1 => Optic' k is s a -> s -> Maybe a
+headOf o = getLeftmost . foldMapOf o LLeaf
+{-# INLINE headOf #-}
+
+-- | Retrieve the last entry of a 'Fold1'.
+--
+-- >>> lastOf folded [1..10]
+-- Just 10
+--
+-- >>> lastOf each (1,2)
+-- Just 2
+lastOf :: Is k A_Fold1 => Optic' k is s a -> s -> Maybe a
+lastOf o = getRightmost . foldMapOf o RLeaf
+{-# INLINE lastOf #-}
+
+-- | Returns 'True' if every target of a 'Fold1' is 'True'.
+--
+-- >>> andOf each (True, False)
+-- False
+-- >>> andOf each (True, True)
+-- True
+--
+-- @
+-- 'Data.Fold1able.and' ≡ 'andOf' 'folded'
+-- @
+andOf :: Is k A_Fold1 => Optic' k is s Bool -> s -> Bool
+andOf o = getAll #. foldMapOf o All
+{-# INLINE andOf #-}
+
+-- | Returns 'True' if any target of a 'Fold1' is 'True'.
+--
+-- >>> orOf each (True, False)
+-- True
+-- >>> orOf each (False, False)
+-- False
+--
+-- @
+-- 'Data.Fold1able.or' ≡ 'orOf' 'folded'
+-- @
+orOf :: Is k A_Fold1 => Optic' k is s Bool -> s -> Bool
+orOf o = getAny #. foldMapOf o Any
+{-# INLINE orOf #-}
+
+-- | Returns 'True' if any target of a 'Fold1' satisfies a predicate.
+--
+-- >>> anyOf each (=='x') ('x','y')
+-- True
+anyOf :: Is k A_Fold1 => Optic' k is s a -> (a -> Bool) -> s -> Bool
+anyOf o = \f -> getAny #. foldMapOf o (Any #. f)
+{-# INLINE anyOf #-}
+
+-- | Returns 'True' if every target of a 'Fold1' satisfies a predicate.
+--
+-- >>> allOf each (>=3) (4,5)
+-- True
+-- >>> allOf folded (>=2) [1..10]
+-- False
+--
+-- @
+-- 'Data.Fold1able.all' ≡ 'allOf' 'folded'
+-- @
+allOf :: Is k A_Fold1 => Optic' k is s a -> (a -> Bool) -> s -> Bool
+allOf o = \f -> getAll #. foldMapOf o (All #. f)
+{-# INLINE allOf #-}
+
+-- | Returns 'True' only if no targets of a 'Fold1' satisfy a predicate.
+--
+-- >>> noneOf each (not . isn't _Nothing) (Just 3, Just 4, Just 5)
+-- True
+-- >>> noneOf (folded % folded) (<10) [[13,99,20],[3,71,42]]
+-- False
+noneOf :: Is k A_Fold1 => Optic' k is s a -> (a -> Bool) -> s -> Bool
+noneOf o = \f -> not . anyOf o f
+{-# INLINE noneOf #-}
+
+-- | Calculate the 'Product' of every number targeted by a 'Fold1'.
+--
+-- >>> productOf each (4,5)
+-- 20
+-- >>> productOf folded [1,2,3,4,5]
+-- 120
+--
+-- @
+-- 'Data.Fold1able.product' ≡ 'productOf' 'folded'
+-- @
+--
+-- This operation may be more strict than you would expect. If you want a lazier
+-- version use @\\o -> 'getProduct' '.' 'foldMapOf' o 'Product'@.
+productOf :: (Is k A_Fold1, Num a) => Optic' k is s a -> s -> a
+productOf o = foldlOf' o (*) 1
+{-# INLINE productOf #-}
+
+-- | Calculate the 'Sum' of every number targeted by a 'Fold1'.
+--
+-- >>> sumOf each (5,6)
+-- 11
+-- >>> sumOf folded [1,2,3,4]
+-- 10
+-- >>> sumOf (folded % each) [(1,2),(3,4)]
+-- 10
+--
+-- @
+-- 'Data.Fold1able.sum' ≡ 'sumOf' 'folded'
+-- @
+--
+-- This operation may be more strict than you would expect. If you want a lazier
+-- version use @\\o -> 'getSum' '.' 'foldMapOf' o 'Sum'@
+sumOf :: (Is k A_Fold1, Num a) => Optic' k is s a -> s -> a
+sumOf o = foldlOf' o (+) 0
+{-# INLINE sumOf #-}
+
+-- | The sum of a collection of actions.
+--
+-- >>> asumOf each ("hello","world")
+-- "helloworld"
+--
+-- >>> asumOf each (Nothing, Just "hello", Nothing)
+-- Just "hello"
+--
+-- @
+-- 'asum' ≡ 'asumOf' 'folded'
+-- @
+asumOf :: (Is k A_Fold1, Alternative f) => Optic' k is s (f a) -> s -> f a
+asumOf o = foldrOf o (<|>) empty
+{-# INLINE asumOf #-}
+
+-- | The sum of a collection of actions.
+--
+-- >>> msumOf each ("hello","world")
+-- "helloworld"
+--
+-- >>> msumOf each (Nothing, Just "hello", Nothing)
+-- Just "hello"
+--
+-- @
+-- 'msum' ≡ 'msumOf' 'folded'
+-- @
+msumOf :: (Is k A_Fold1, MonadPlus m) => Optic' k is s (m a) -> s -> m a
+msumOf o = foldrOf o mplus mzero
+{-# INLINE msumOf #-}
+
+-- | Does the element occur anywhere within a given 'Fold1' of the structure?
+--
+-- >>> elemOf each "hello" ("hello","world")
+-- True
+--
+-- @
+-- 'elem' ≡ 'elemOf' 'folded'
+-- @
+elemOf :: (Is k A_Fold1, Eq a) => Optic' k is s a -> a -> s -> Bool
+elemOf o = anyOf o . (==)
+{-# INLINE elemOf #-}
+
+-- | Does the element not occur anywhere within a given 'Fold1' of the structure?
+--
+-- >>> notElemOf each 'd' ('a','b','c')
+-- True
+--
+-- >>> notElemOf each 'a' ('a','b','c')
+-- False
+--
+-- @
+-- 'notElem' ≡ 'notElemOf' 'folded'
+-- @
+notElemOf :: (Is k A_Fold1, Eq a) => Optic' k is s a -> a -> s -> Bool
+notElemOf o = allOf o . (/=)
+{-# INLINE notElemOf #-}
+
+-- | Calculate the number of targets there are for a 'Fold1' in a given
+-- container.
+--
+-- /Note:/ This can be rather inefficient for large containers and just like
+-- 'length', this will not terminate for infinite folds.
+--
+-- @
+-- 'length' ≡ 'lengthOf' 'folded'
+-- @
+--
+-- >>> lengthOf _1 ("hello",())
+-- 1
+--
+-- >>> lengthOf folded [1..10]
+-- 10
+--
+-- >>> lengthOf (folded % folded) [[1,2],[3,4],[5,6]]
+-- 6
+lengthOf :: Is k A_Fold1 => Optic' k is s a -> s -> Int
+lengthOf o = foldlOf' o (\ n _ -> 1 + n) 0
+{-# INLINE lengthOf #-}
+
+-- | Obtain the maximum element (if any) targeted by a 'Fold1' safely.
+--
+-- Note: 'maximumOf' on a valid 'Optics.Iso.Iso', 'Optics.Lens.Lens'
+-- or 'Optics.Getter.Getter' will always return 'Just' a value.
+--
+-- >>> maximumOf folded [1..10]
+-- Just 10
+--
+-- >>> maximumOf folded []
+-- Nothing
+--
+-- >>> maximumOf (folded % filtered even) [1,4,3,6,7,9,2]
+-- Just 6
+--
+-- @
+-- 'maximum' ≡ 'Data.Maybe.fromMaybe' ('error' \"empty\") '.' 'maximumOf' 'folded'
+-- @
+--
+-- In the interest of efficiency, This operation has semantics more strict than
+-- strictly necessary.  @\\o -> 'Data.Semigroup.getMax' . 'foldMapOf' o 'Data.Semigroup.Max'@ has lazier
+-- semantics but could leak memory.
+maximumOf :: (Is k A_Fold1, Ord a) => Optic' k is s a -> s -> Maybe a
+maximumOf o = foldlOf' o mf Nothing where
+  mf Nothing y  = Just $! y
+  mf (Just x) y = Just $! max x y
+{-# INLINE maximumOf #-}
+
+-- | Obtain the minimum element (if any) targeted by a 'Fold1' safely.
+--
+-- Note: 'minimumOf' on a valid 'Optics.Iso.Iso', 'Optics.Lens.Lens'
+-- or 'Optics.Getter.Getter' will always return 'Just' a value.
+--
+-- >>> minimumOf folded [1..10]
+-- Just 1
+--
+-- >>> minimumOf folded []
+-- Nothing
+--
+-- >>> minimumOf (folded % filtered even) [1,4,3,6,7,9,2]
+-- Just 2
+--
+-- @
+-- 'minimum' ≡ 'Data.Maybe.fromMaybe' ('error' \"empty\") '.' 'minimumOf' 'folded'
+-- @
+--
+-- In the interest of efficiency, This operation has semantics more strict than
+-- strictly necessary.  @\\o -> 'Data.Semigroup.getMin' . 'foldMapOf' o 'Data.Semigroup.Min'@ has lazier
+-- semantics but could leak memory.
+minimumOf :: (Is k A_Fold1, Ord a) => Optic' k is s a -> s -> Maybe a
+minimumOf o = foldlOf' o mf Nothing where
+  mf Nothing y = Just $! y
+  mf (Just x) y = Just $! min x y
+{-# INLINE minimumOf #-}
+
+-- | Obtain the maximum element (if any) targeted by a 'Fold1' according to a
+-- user supplied 'Ordering'.
+--
+-- >>> maximumByOf folded (compare `on` length) ["mustard","relish","ham"]
+-- Just "mustard"
+--
+-- In the interest of efficiency, This operation has semantics more strict than
+-- strictly necessary.
+--
+-- @
+-- 'Data.Fold1able.maximumBy' cmp ≡ 'Data.Maybe.fromMaybe' ('error' \"empty\") '.' 'maximumByOf' 'folded' cmp
+-- @
+maximumByOf :: Is k A_Fold1 => Optic' k is s a -> (a -> a -> Ordering) -> s -> Maybe a
+maximumByOf o = \cmp ->
+  let mf Nothing y  = Just $! y
+      mf (Just x) y = Just $! if cmp x y == GT then x else y
+  in foldlOf' o mf Nothing
+{-# INLINE maximumByOf #-}
+
+-- | Obtain the minimum element (if any) targeted by a 'Fold1' according to a
+-- user supplied 'Ordering'.
+--
+-- In the interest of efficiency, This operation has semantics more strict than
+-- strictly necessary.
+--
+-- >>> minimumByOf folded (compare `on` length) ["mustard","relish","ham"]
+-- Just "ham"
+--
+-- @
+-- 'minimumBy' cmp ≡ 'Data.Maybe.fromMaybe' ('error' \"empty\") '.' 'minimumByOf' 'folded' cmp
+-- @
+minimumByOf :: Is k A_Fold1 => Optic' k is s a -> (a -> a -> Ordering) -> s -> Maybe a
+minimumByOf o = \cmp ->
+  let mf Nothing y  = Just $! y
+      mf (Just x) y = Just $! if cmp x y == GT then y else x
+  in foldlOf' o mf Nothing
+{-# INLINE minimumByOf #-}
+
+-- | The 'findOf' function takes a 'Fold1', a predicate and a structure and
+-- returns the leftmost element of the structure matching the predicate, or
+-- 'Nothing' if there is no such element.
+--
+-- >>> findOf each even (1,3,4,6)
+-- Just 4
+--
+-- >>> findOf folded even [1,3,5,7]
+-- Nothing
+--
+-- @
+-- 'Data.Fold1able.find' ≡ 'findOf' 'folded'
+-- @
+findOf :: Is k A_Fold1 => Optic' k is s a -> (a -> Bool) -> s -> Maybe a
+findOf o = \f -> foldrOf o (\a y -> if f a then Just a else y) Nothing
+{-# INLINE findOf #-}
+
+-- | The 'findMOf' function takes a 'Fold1', a monadic predicate and a structure
+-- and returns in the monad the leftmost element of the structure matching the
+-- predicate, or 'Nothing' if there is no such element.
+--
+-- >>> findMOf each (\x -> print ("Checking " ++ show x) >> return (even x)) (1,3,4,6)
+-- "Checking 1"
+-- "Checking 3"
+-- "Checking 4"
+-- Just 4
+--
+-- >>> findMOf each (\x -> print ("Checking " ++ show x) >> return (even x)) (1,3,5,7)
+-- "Checking 1"
+-- "Checking 3"
+-- "Checking 5"
+-- "Checking 7"
+-- Nothing
+--
+-- @
+-- 'findMOf' 'folded' :: (Monad m, Fold1able f) => (a -> m Bool) -> f a -> m (Maybe a)
+-- @
+findMOf :: (Is k A_Fold1, Monad m) => Optic' k is s a -> (a -> m Bool) -> s -> m (Maybe a)
+findMOf o = \f -> foldrOf o
+  (\a y -> f a >>= \r -> if r then pure (Just a) else y)
+  (pure Nothing)
+{-# INLINE findMOf #-}
+
+-- | The 'lookupOf' function takes a 'Fold1', a key, and a structure containing
+-- key/value pairs.  It returns the first value corresponding to the given
+-- key. This function generalizes 'lookup' to work on an arbitrary 'Fold1'
+-- instead of lists.
+--
+-- >>> lookupOf folded 4 [(2, 'a'), (4, 'b'), (4, 'c')]
+-- Just 'b'
+--
+-- >>> lookupOf folded 2 [(2, 'a'), (4, 'b'), (4, 'c')]
+-- Just 'a'
+lookupOf :: (Is k A_Fold1, Eq a) => Optic' k is s (a, v) -> a -> s -> Maybe v
+lookupOf o a = foldrOf o (\(a', v) next -> if a == a' then Just v else next) Nothing
+{-# INLINE lookupOf #-}
+-}
+
+-- $setup
+-- >>> import Optics.Core

--- a/optics-core/src/Optics/Internal/Optic/Subtyping.hs
+++ b/optics-core/src/Optics/Internal/Optic/Subtyping.hs
@@ -48,6 +48,8 @@ instance Is An_Iso             A_Prism            where implies _ = id
 instance Is An_Iso             A_Review           where implies _ = id
 instance Is An_Iso             A_Lens             where implies _ = id
 instance Is An_Iso             A_Getter           where implies _ = id
+instance Is An_Iso             A_Traversal1       where implies _ = id
+instance Is An_Iso             A_Fold1            where implies _ = id
 instance Is An_Iso             An_AffineTraversal where implies _ = id
 instance Is An_Iso             An_AffineFold      where implies _ = id
 instance Is An_Iso             A_Traversal        where implies _ = id
@@ -57,6 +59,7 @@ instance Is An_Iso             A_Setter           where implies _ = id
 instance Is A_ReversedLens     A_Review           where implies _ = id
 -- A_ReversedPrism
 instance Is A_ReversedPrism    A_Getter           where implies _ = id
+instance Is A_ReversedPrism    A_Fold1            where implies _ = id
 instance Is A_ReversedPrism    An_AffineFold      where implies _ = id
 instance Is A_ReversedPrism    A_Fold             where implies _ = id
 -- A_Prism
@@ -68,14 +71,24 @@ instance Is A_Prism            A_Fold             where implies _ = id
 instance Is A_Prism            A_Setter           where implies _ = id
 -- A_Lens
 instance Is A_Lens             A_Getter           where implies _ = id
+instance Is A_Lens             A_Traversal1       where implies _ = id
+instance Is A_Lens             A_Fold1            where implies _ = id
 instance Is A_Lens             An_AffineTraversal where implies _ = id
 instance Is A_Lens             An_AffineFold      where implies _ = id
 instance Is A_Lens             A_Traversal        where implies _ = id
 instance Is A_Lens             A_Fold             where implies _ = id
 instance Is A_Lens             A_Setter           where implies _ = id
 -- A_Getter
+instance Is A_Getter           A_Fold1            where implies _ = id
 instance Is A_Getter           An_AffineFold      where implies _ = id
 instance Is A_Getter           A_Fold             where implies _ = id
+-- A_Traversal1
+instance Is A_Traversal1       A_Fold1            where implies _ = id
+instance Is A_Traversal1       A_Traversal        where implies _ = id
+instance Is A_Traversal1       A_Fold             where implies _ = id
+instance Is A_Traversal1       A_Setter           where implies _ = id
+-- A_Fold1
+instance Is A_Fold1            A_Fold             where implies _ = id
 -- An_AffineTraversal
 instance Is An_AffineTraversal An_AffineFold      where implies _ = id
 instance Is An_AffineTraversal A_Traversal        where implies _ = id
@@ -99,6 +112,7 @@ instance Is A_Traversal        A_Setter           where implies _ = id
 --
 type family Join (k :: OpticKind) (l :: OpticKind) where
   -- BEGIN GENERATED CONTENT
+ 
   -- An_Iso-----
   Join An_Iso             A_ReversedLens     = A_ReversedLens
   Join An_Iso             A_ReversedPrism    = A_ReversedPrism
@@ -106,6 +120,8 @@ type family Join (k :: OpticKind) (l :: OpticKind) where
   Join An_Iso             A_Review           = A_Review
   Join An_Iso             A_Lens             = A_Lens
   Join An_Iso             A_Getter           = A_Getter
+  Join An_Iso             A_Traversal1       = A_Traversal1
+  Join An_Iso             A_Fold1            = A_Fold1
   Join An_Iso             An_AffineTraversal = An_AffineTraversal
   Join An_Iso             An_AffineFold      = An_AffineFold
   Join An_Iso             A_Traversal        = A_Traversal
@@ -119,6 +135,8 @@ type family Join (k :: OpticKind) (l :: OpticKind) where
   Join A_ReversedLens     A_Review           = A_Review
   -- no Join with         A_Lens
   -- no Join with         A_Getter
+  -- no Join with         A_Traversal1
+  -- no Join with         A_Fold1
   -- no Join with         An_AffineTraversal
   -- no Join with         An_AffineFold
   -- no Join with         A_Traversal
@@ -132,6 +150,8 @@ type family Join (k :: OpticKind) (l :: OpticKind) where
   -- no Join with         A_Review
   Join A_ReversedPrism    A_Lens             = A_Getter
   Join A_ReversedPrism    A_Getter           = A_Getter
+  Join A_ReversedPrism    A_Traversal1       = A_Fold1
+  Join A_ReversedPrism    A_Fold1            = A_Fold1
   Join A_ReversedPrism    An_AffineTraversal = An_AffineFold
   Join A_ReversedPrism    An_AffineFold      = An_AffineFold
   Join A_ReversedPrism    A_Traversal        = A_Fold
@@ -145,6 +165,8 @@ type family Join (k :: OpticKind) (l :: OpticKind) where
   Join A_Prism            A_Review           = A_Review
   Join A_Prism            A_Lens             = An_AffineTraversal
   Join A_Prism            A_Getter           = An_AffineFold
+  Join A_Prism            A_Traversal1       = A_Traversal
+  Join A_Prism            A_Fold1            = A_Fold
   Join A_Prism            An_AffineTraversal = An_AffineTraversal
   Join A_Prism            An_AffineFold      = An_AffineFold
   Join A_Prism            A_Traversal        = A_Traversal
@@ -158,6 +180,8 @@ type family Join (k :: OpticKind) (l :: OpticKind) where
   Join A_Review           A_Prism            = A_Review
   -- no Join with         A_Lens
   -- no Join with         A_Getter
+  -- no Join with         A_Traversal1
+  -- no Join with         A_Fold1
   -- no Join with         An_AffineTraversal
   -- no Join with         An_AffineFold
   -- no Join with         A_Traversal
@@ -171,6 +195,8 @@ type family Join (k :: OpticKind) (l :: OpticKind) where
   Join A_Lens             A_Prism            = An_AffineTraversal
   -- no Join with         A_Review
   Join A_Lens             A_Getter           = A_Getter
+  Join A_Lens             A_Traversal1       = A_Traversal1
+  Join A_Lens             A_Fold1            = A_Fold1
   Join A_Lens             An_AffineTraversal = An_AffineTraversal
   Join A_Lens             An_AffineFold      = An_AffineFold
   Join A_Lens             A_Traversal        = A_Traversal
@@ -184,10 +210,42 @@ type family Join (k :: OpticKind) (l :: OpticKind) where
   Join A_Getter           A_Prism            = An_AffineFold
   -- no Join with         A_Review
   Join A_Getter           A_Lens             = A_Getter
+  Join A_Getter           A_Traversal1       = A_Fold1
+  Join A_Getter           A_Fold1            = A_Fold1
   Join A_Getter           An_AffineTraversal = An_AffineFold
   Join A_Getter           An_AffineFold      = An_AffineFold
   Join A_Getter           A_Traversal        = A_Fold
   Join A_Getter           A_Fold             = A_Fold
+  -- no Join with         A_Setter
+
+  -- A_Traversal1-----
+  Join A_Traversal1       An_Iso             = A_Traversal1
+  -- no Join with         A_ReversedLens
+  Join A_Traversal1       A_ReversedPrism    = A_Fold1
+  Join A_Traversal1       A_Prism            = A_Traversal
+  -- no Join with         A_Review
+  Join A_Traversal1       A_Lens             = A_Traversal1
+  Join A_Traversal1       A_Getter           = A_Fold1
+  Join A_Traversal1       A_Fold1            = A_Fold1
+  Join A_Traversal1       An_AffineTraversal = A_Traversal
+  Join A_Traversal1       An_AffineFold      = A_Fold
+  Join A_Traversal1       A_Traversal        = A_Traversal
+  Join A_Traversal1       A_Fold             = A_Fold
+  Join A_Traversal1       A_Setter           = A_Setter
+
+  -- A_Fold1-----
+  Join A_Fold1            An_Iso             = A_Fold1
+  -- no Join with         A_ReversedLens
+  Join A_Fold1            A_ReversedPrism    = A_Fold1
+  Join A_Fold1            A_Prism            = A_Fold
+  -- no Join with         A_Review
+  Join A_Fold1            A_Lens             = A_Fold1
+  Join A_Fold1            A_Getter           = A_Fold1
+  Join A_Fold1            A_Traversal1       = A_Fold1
+  Join A_Fold1            An_AffineTraversal = A_Fold
+  Join A_Fold1            An_AffineFold      = A_Fold
+  Join A_Fold1            A_Traversal        = A_Fold
+  Join A_Fold1            A_Fold             = A_Fold
   -- no Join with         A_Setter
 
   -- An_AffineTraversal-----
@@ -198,6 +256,8 @@ type family Join (k :: OpticKind) (l :: OpticKind) where
   -- no Join with         A_Review
   Join An_AffineTraversal A_Lens             = An_AffineTraversal
   Join An_AffineTraversal A_Getter           = An_AffineFold
+  Join An_AffineTraversal A_Traversal1       = A_Traversal
+  Join An_AffineTraversal A_Fold1            = A_Fold
   Join An_AffineTraversal An_AffineFold      = An_AffineFold
   Join An_AffineTraversal A_Traversal        = A_Traversal
   Join An_AffineTraversal A_Fold             = A_Fold
@@ -211,6 +271,8 @@ type family Join (k :: OpticKind) (l :: OpticKind) where
   -- no Join with         A_Review
   Join An_AffineFold      A_Lens             = An_AffineFold
   Join An_AffineFold      A_Getter           = An_AffineFold
+  Join An_AffineFold      A_Traversal1       = A_Fold
+  Join An_AffineFold      A_Fold1            = A_Fold
   Join An_AffineFold      An_AffineTraversal = An_AffineFold
   Join An_AffineFold      A_Traversal        = A_Fold
   Join An_AffineFold      A_Fold             = A_Fold
@@ -224,6 +286,8 @@ type family Join (k :: OpticKind) (l :: OpticKind) where
   -- no Join with         A_Review
   Join A_Traversal        A_Lens             = A_Traversal
   Join A_Traversal        A_Getter           = A_Fold
+  Join A_Traversal        A_Traversal1       = A_Traversal
+  Join A_Traversal        A_Fold1            = A_Fold
   Join A_Traversal        An_AffineTraversal = A_Traversal
   Join A_Traversal        An_AffineFold      = A_Fold
   Join A_Traversal        A_Fold             = A_Fold
@@ -237,6 +301,8 @@ type family Join (k :: OpticKind) (l :: OpticKind) where
   -- no Join with         A_Review
   Join A_Fold             A_Lens             = A_Fold
   Join A_Fold             A_Getter           = A_Fold
+  Join A_Fold             A_Traversal1       = A_Fold
+  Join A_Fold             A_Fold1            = A_Fold
   Join A_Fold             An_AffineTraversal = A_Fold
   Join A_Fold             An_AffineFold      = A_Fold
   Join A_Fold             A_Traversal        = A_Fold
@@ -250,6 +316,8 @@ type family Join (k :: OpticKind) (l :: OpticKind) where
   -- no Join with         A_Review
   Join A_Setter           A_Lens             = A_Setter
   -- no Join with         A_Getter
+  Join A_Setter           A_Traversal1       = A_Setter
+  -- no Join with         A_Fold1
   Join A_Setter           An_AffineTraversal = A_Setter
   -- no Join with         An_AffineFold
   Join A_Setter           A_Traversal        = A_Setter

--- a/optics-core/src/Optics/Internal/Optic/Types.hs
+++ b/optics-core/src/Optics/Internal/Optic/Types.hs
@@ -23,6 +23,8 @@ data A_Lens :: OpticKind
 data A_Prism :: OpticKind
 -- | Tag for an affine traversal.
 data An_AffineTraversal :: OpticKind
+-- | Tag for a non-empty traversal.
+data A_Traversal1 :: OpticKind
 -- | Tag for a traversal.
 data A_Traversal :: OpticKind
 -- | Tag for a setter.
@@ -33,6 +35,8 @@ data A_ReversedPrism :: OpticKind
 data A_Getter :: OpticKind
 -- | Tag for an affine fold.
 data An_AffineFold :: OpticKind
+-- | Tag for a non-empty fold.
+data A_Fold1 :: OpticKind
 -- | Tag for a fold.
 data A_Fold :: OpticKind
 -- | Tag for a reversed lens.
@@ -52,9 +56,11 @@ type family Constraints (k :: OpticKind) (p :: Type -> Type -> Type -> Type) :: 
   Constraints A_Prism            p = Choice p
   Constraints A_ReversedPrism    p = Cochoice p
   Constraints An_AffineTraversal p = Visiting p
+  Constraints A_Traversal1       p = Traversing1 p
   Constraints A_Traversal        p = Traversing p
   Constraints A_Setter           p = Mapping p
   Constraints A_Getter           p = (Bicontravariant p, Cochoice p, Strong p)
   Constraints An_AffineFold      p = (Bicontravariant p, Cochoice p, Visiting p)
+  Constraints A_Fold1            p = (Bicontravariant p, Cochoice p, Traversing1 p)
   Constraints A_Fold             p = (Bicontravariant p, Cochoice p, Traversing p)
   Constraints A_Review           p = (Bifunctor p, Choice p, Costrong p)

--- a/optics-core/src/Optics/Traversal1.hs
+++ b/optics-core/src/Optics/Traversal1.hs
@@ -1,0 +1,356 @@
+-- |
+-- Module: Optics.Traversal1
+-- Description: Lifts an effectful operation on elements to act on structures.
+--
+-- TBW: Traversal1 is to Traversal is like Semigroup to Monoid. 
+--
+module Optics.Traversal1
+  (
+  -- * Formation
+    Traversal1
+  , Traversal1'
+
+  -- * Introduction
+  , traversal1VL
+
+  -- * Elimination
+  , traverse1Of
+
+  -- * Computation
+  -- |
+  --
+  -- @
+  -- 'traverseOf' ('traversalVL' f) ≡ f
+  -- @
+
+  -- * Well-formedness
+  -- |
+  --
+  -- @
+  -- 'traverseOf' o 'pure' ≡ 'pure'
+  -- 'fmap' ('traverseOf' o f) . 'traverseOf' o g ≡ 'Data.Functor.Compose.getCompose' . 'traverseOf' o ('Data.Functor.Compose.Compose' . 'fmap' f . g)
+  -- @
+
+  -- * Additional introduction forms
+  , traversed1
+
+  -- * Additional elimination forms
+  , for1Of
+  , sequence1Of
+
+{-
+  , transposeOf
+  , mapAccumROf
+  , mapAccumLOf
+  , scanr1Of
+  , scanl1Of
+  , failover
+  , failover'
+
+    -- * Combinators
+  , backwards
+  , partsOf
+-}
+
+  -- * Subtyping
+  , A_Traversal1
+  -- | <<diagrams/Traversal1.png Traversal1 in the optics hierarchy>>
+
+  -- * van Laarhoven encoding
+  -- | The van Laarhoven representation of a 'Traversal1' directly expresses how
+  -- it lifts an effectful operation @A -> F B@ on elements to act on structures
+  -- @S -> F T@.  Thus 'traverseOf' converts a 'Traversal1' to a 'Traversal1VL'.
+  , Traversal1VL
+  , Traversal1VL'
+  )
+  where
+
+import Control.Applicative
+import Control.Applicative.Backwards
+import Control.Monad.Trans.State
+import Data.Functor.Identity
+
+import Data.Profunctor.Indexed
+
+import Optics.Fold
+import Optics.Internal.Optic
+import Optics.Internal.Utils
+import Optics.Lens
+import Optics.ReadOnly
+
+import Data.List.NonEmpty (NonEmpty (..))
+
+-- | Type synonym for a type-modifying traversal.
+type Traversal1 s t a b = Optic A_Traversal1 NoIx s t a b
+
+-- | Type synonym for a type-preserving traversal.
+type Traversal1' s a = Optic' A_Traversal1 NoIx s a
+
+-- | Type synonym for a type-modifying van Laarhoven traversal.
+type Traversal1VL s t a b = forall f. Apply f => (a -> f b) -> s -> f t
+
+-- | Type synonym for a type-preserving van Laarhoven traversal.
+type Traversal1VL' s a = Traversal1VL s s a a
+
+-- | Build a traversal from the van Laarhoven representation.
+--
+-- @
+-- 'traversalVL' '.' 'traverseOf' ≡ 'id'
+-- 'traverseOf' '.' 'traversalVL' ≡ 'id'
+-- @
+traversal1VL :: Traversal1VL s t a b -> Traversal1 s t a b
+traversal1VL t = Optic (wander1 t)
+{-# INLINE traversal1VL #-}
+
+-- | Map each element of a structure targeted by a 'Traversal1', evaluate these
+-- actions from left to right, and collect the results.
+traverse1Of
+  :: (Is k A_Traversal1, Apply f)
+  => Optic k is s t a b
+  -> (a -> f b) -> s -> f t
+traverse1Of o = \f -> runStar1 $ getOptic (castOptic @A_Traversal1 o) (Star1 f)
+{-# INLINE traverse1Of #-}
+
+-- | A version of 'traverseOf' with the arguments flipped.
+for1Of
+  :: (Is k A_Traversal1, Apply f)
+  => Optic k is s t a b
+  -> s -> (a -> f b) -> f t
+for1Of = flip . traverse1Of
+{-# INLINE for1Of #-}
+
+-- | Evaluate each action in the structure from left to right, and collect the
+-- results.
+--
+-- >>> sequenceOf each ([1,2],[3,4])
+-- [(1,3),(1,4),(2,3),(2,4)]
+--
+-- @
+-- 'sequence' ≡ 'sequenceOf' 'traversed' ≡ 'traverse' 'id'
+-- 'sequenceOf' o ≡ 'traverseOf' o 'id'
+-- @
+sequence1Of
+  :: (Is k A_Traversal1, Apply f)
+  => Optic k is s t (f b) b
+  -> s -> f t
+sequence1Of o = traverse1Of o id
+{-# INLINE sequence1Of #-}
+
+{- TODO
+ 
+-- | This generalizes 'Data.List.transpose' to an arbitrary 'Traversal1'.
+--
+-- Note: 'Data.List.transpose' handles ragged inputs more intelligently, but for
+-- non-ragged inputs:
+--
+-- >>> transposeOf traversed [[1,2,3],[4,5,6]]
+-- [[1,4],[2,5],[3,6]]
+--
+-- @
+-- 'Data.List.transpose' ≡ 'transposeOf' 'traverse'
+-- @
+transposeOf
+  :: Is k A_Traversal1
+  => Optic k is s t [a] a
+  -> s -> [t]
+transposeOf o = getZipList #. traverseOf o ZipList
+{-# INLINE transposeOf #-}
+
+-- | This generalizes 'Data.Traversable.mapAccumL' to an arbitrary 'Traversal1'.
+--
+-- @
+-- 'Data.Traversable.mapAccumL' ≡ 'mapAccumLOf' 'traverse'
+-- @
+--
+-- 'mapAccumLOf' accumulates 'State' from left to right.
+mapAccumLOf
+  :: Is k A_Traversal1
+  => Optic k is s t a b
+  -> (acc -> a -> (b, acc)) -> acc -> s -> (t, acc)
+mapAccumLOf o = \f acc0 s ->
+  let g a = state $ \acc -> f acc a
+  in runState (traverseOf o g s) acc0
+
+{-# INLINE mapAccumLOf #-}
+
+-- | This generalizes 'Data.Traversable.mapAccumR' to an arbitrary 'Traversal1'.
+--
+-- @
+-- 'Data.Traversable.mapAccumR' ≡ 'mapAccumROf' 'traversed'
+-- @
+--
+-- 'mapAccumROf' accumulates 'State' from right to left.
+mapAccumROf
+  :: Is k A_Traversal1
+  => Optic k is s t a b
+  -> (acc -> a -> (b, acc)) -> acc -> s -> (t, acc)
+mapAccumROf = mapAccumLOf . backwards
+{-# INLINE mapAccumROf #-}
+
+-- | This permits the use of 'scanl1' over an arbitrary 'Traversal1'.
+--
+-- @
+-- 'scanl1' ≡ 'scanl1Of' 'traversed'
+-- @
+scanl1Of
+  :: Is k A_Traversal1
+  => Optic k is s t a a
+  -> (a -> a -> a) -> s -> t
+scanl1Of o = \f ->
+  let step Nothing a  = (a, Just a)
+      step (Just s) a = let r = f s a in (r, Just r)
+  in fst . mapAccumLOf o step Nothing
+{-# INLINE scanl1Of #-}
+
+-- | This permits the use of 'scanr1' over an arbitrary 'Traversal1'.
+--
+-- @
+-- 'scanr1' ≡ 'scanr1Of' 'traversed'
+-- @
+scanr1Of
+  :: Is k A_Traversal1
+  => Optic k is s t a a
+  -> (a -> a -> a) -> s -> t
+scanr1Of o = \f ->
+  let step Nothing a  = (a, Just a)
+      step (Just s) a = let r = f a s in (r, Just r)
+  in fst . mapAccumROf o step Nothing
+{-# INLINE scanr1Of #-}
+
+-- | Try to map a function over this 'Traversal1', returning Nothing if the
+-- traversal has no targets.
+--
+-- >>> failover (element 3) (*2) [1,2]
+-- Nothing
+--
+-- >>> failover _Left (*2) (Right 4)
+-- Nothing
+--
+-- >>> failover _Right (*2) (Right 4)
+-- Just (Right 8)
+--
+failover
+  :: Is k A_Traversal1
+  => Optic k is s t a b
+  -> (a -> b) -> s -> Maybe t
+failover o = \f s ->
+  let OrT visited t = traverseOf o (wrapOrT . Identity #. f) s
+  in if visited
+     then Just (runIdentity t)
+     else Nothing
+{-# INLINE failover #-}
+
+-- | Version of 'failover' strict in the application of @f@.
+failover'
+  :: Is k A_Traversal1
+  => Optic k is s t a b
+  -> (a -> b) -> s -> Maybe t
+failover' o = \f s ->
+  let OrT visited t = traverseOf o (wrapOrT . wrapIdentity' . f) s
+  in if visited
+     then Just (unwrapIdentity' t)
+     else Nothing
+{-# INLINE failover' #-}
+
+-}
+
+----------------------------------------
+-- Traversal1s
+
+-- | Construct a 'Traversal1' via the 'Traversable' class.
+--
+-- @
+-- 'traverseOf' 'traversed' = 'traverse'
+-- @
+--
+traversed1 :: Traversable1 t => Traversal1 (t a) (t b) a b
+traversed1 = Optic (wander1 traverse1)
+{-# INLINE traversed1 #-}
+
+-- TODO: move to own module
+-- TODO: also from semigroupoids
+class Foldable f => Foldable1 f where
+  foldMap1 :: Semigroup m => (a -> m) -> f a -> m
+  foldMap1 f = foldMap1 f . toNonEmpty
+
+  toNonEmpty :: f a -> NonEmpty a 
+  toNonEmpty = foldMap1 (:|[]) -- TODO: use dlistnonempty?
+
+  {-# MINIMAL foldMap1 | toNonEmpty #-}
+
+class (Foldable1 t, Traversable t) => Traversable1 t where
+  traverse1 :: Apply f => (a -> f b) -> t a -> f (t b)
+
+  -- TODO: more instances
+
+instance Foldable1 Identity where
+  foldMap1 f (Identity x) = f x
+  toNonEmpty (Identity x) = x :| []
+
+
+instance Traversable1 Identity where
+  traverse1 f = fmap Identity . f . runIdentity
+
+instance Foldable1 NonEmpty where
+  foldMap1 f (x :| [])     = f x
+  foldMap1 f (x :| y : ys) = f x <> foldMap1 f (y :| ys)
+
+  toNonEmpty = id
+
+instance Traversable1 NonEmpty where
+  traverse1 f (a :| []) = (:|[]) <$> f a
+  traverse1 f (a :| (b: bs)) = (\a' (b':| bs') -> a' :| b': bs') <$> f a <.> traverse1 f (b :| bs)
+
+{- TODO:
+
+----------------------------------------
+-- Traversal1 combinators
+
+-- | This allows you to 'traverse' the elements of a traversal in the opposite
+-- order.
+backwards
+  :: Is k A_Traversal1
+  => Optic k is s t a b
+  -> Traversal1 s t a b
+backwards o = traversalVL $ \f -> forwards #. traverseOf o (Backwards #. f)
+{-# INLINE backwards #-}
+
+-- | 'partsOf' turns a 'Traversal1' into a 'Lens'.
+--
+-- /Note:/ You should really try to maintain the invariant of the number of
+-- children in the list.
+--
+-- >>> ('a','b','c') & partsOf each .~ ['x','y','z']
+-- ('x','y','z')
+--
+-- Any extras will be lost. If you do not supply enough, then the remainder will
+-- come from the original structure.
+--
+-- >>> ('a','b','c') & partsOf each .~ ['w','x','y','z']
+-- ('w','x','y')
+--
+-- >>> ('a','b','c') & partsOf each .~ ['x','y']
+-- ('x','y','c')
+--
+-- >>> ('b', 'a', 'd', 'c') & partsOf each %~ sort
+-- ('a','b','c','d')
+--
+-- So technically, this is only a 'Lens' if you do not change the number of
+-- results it returns.
+partsOf
+  :: forall k is s t a. Is k A_Traversal1
+  => Optic k is s t a a
+  -> Lens s t [a] [a]
+partsOf o = lensVL $ \f s -> evalState (traverseOf o update s)
+  <$> f (toListOf (getting $ castOptic @A_Traversal1 o) s)
+  where
+    update a = get >>= \case
+      a' : as' -> put as' >> pure a'
+      []       ->            pure a
+{-# INLINE partsOf #-}
+
+-}
+
+-- $setup
+-- >>> import Data.List
+-- >>> import Optics.Core


### PR DESCRIPTION
At the moment, these are not so useful, as the only common
non-empty structures are `NonEmpty` and `Tree`.

After https://github.com/haskell/containers/pull/616 (nonempty maps and
sets) is done, there might be bigger interest in non-empty
traversals/folds.

This commit is a PoC that we can these relatively easily provide them.

- We need Apply, Foldable1, Traversable1 from semigroupoids
- but we can vendor them
    * Foldable1/Traversable1 are used for folded1 / traversed1,
      which we can write instances for common things: (NonEmpty, NESet, NEMap)
    * Apply is virtually hidden, if higher abstraction eliminators are used

Also I think that the interesting&useful bit is non empty Fold.
There aren't that many interesting Apply's which aren't Applicative,
but extracting NonEmpty / NESet / ... from a structure sounds useful
(e.g. maximumBy!)

There's also a https://gitlab.haskell.org/ghc/ghc/issues/13573
about adding Foldable1 to base, which can actually happen,
as it doesn't shake the existing type-class hierarchy.