### PR TITLE
Release 0.2

### DIFF
--- a/generic-optics/generic-optics.cabal
+++ b/generic-optics/generic-optics.cabal
@@ -26,7 +26,7 @@ library
 
   build-depends:    base                   >= 4.9        && <5
                   , generic-lens           >= 1.1        && <1.3
-                  , optics-core            >= 0.1        && <0.2
+                  , optics-core            >= 0.2        && <0.3
                   , profunctors            >= 5.0        && <6.0
 
   exposed-modules: Optics.Generic.Product.Fields

--- a/indexed-profunctors/CHANGELOG.md
+++ b/indexed-profunctors/CHANGELOG.md
@@ -1,0 +1,2 @@
+# indexed-profunctors-0.1 (2019-10-11)
+* Initial release

--- a/indexed-profunctors/indexed-profunctors.cabal
+++ b/indexed-profunctors/indexed-profunctors.cabal
@@ -14,6 +14,9 @@ description:
   are primarily intended as internal utilities to support the @optics@ and
   @generic-lens@ package families.
 
+extra-doc-files:
+  CHANGELOG.md
+
 bug-reports:   https://github.com/well-typed/optics/issues
 source-repository head
   type:     git

--- a/optics-core/CHANGELOG.md
+++ b/optics-core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# optics-core-0.2 (????-??-??)
+# optics-core-0.2 (2019-10-18)
 * Add `non`, `non'` and `anon` to `Optics.Iso`
 * `ix` can produce optic kinds other than `AffineTraversal`
 * Generalise type of `generic1`

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -14,8 +14,8 @@ description:
   and other optics, using an abstract interface.
   .
   This variant provides core definitions with a minimal dependency footprint.
-  See the @optics@ package (and its dependencies) for documentation and the
-  "batteries-included" variant.
+  See the @<https://hackage.haskell.org/package/optics optics>@ package (and its
+  dependencies) for documentation and the "batteries-included" variant.
 
 extra-doc-files:
   diagrams/*.png

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -1,5 +1,5 @@
 name:          optics-core
-version:       0.1
+version:       0.2
 license:       BSD3
 license-file:  LICENSE
 build-type:    Simple

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -19,6 +19,7 @@ description:
 
 extra-doc-files:
   diagrams/*.png
+  CHANGELOG.md
 
 bug-reports:   https://github.com/well-typed/optics/issues
 source-repository head

--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -11,6 +11,8 @@ import Data.Kind (Type)
 import GHC.TypeLits
 
 -- | A list of index types, used for indexed optics.
+--
+-- @since 0.2
 type IxList = [Type]
 
 -- | An alias for an empty index-list

--- a/optics-core/src/Optics/Internal/Optic/Types.hs
+++ b/optics-core/src/Optics/Internal/Optic/Types.hs
@@ -13,6 +13,8 @@ import Data.Profunctor.Indexed
 import Optics.Internal.Bi
 
 -- | Kind for types used as optic tags, such as 'A_Lens'.
+--
+-- @since 0.2
 type OpticKind = Type
 
 -- | Tag for an iso.

--- a/optics-core/src/Optics/Iso.hs
+++ b/optics-core/src/Optics/Iso.hs
@@ -250,6 +250,8 @@ coerced1 = Optic (lcoerce' . rcoerce')
 --
 -- >>> non 0 # rem 10 5
 -- Nothing
+--
+-- @since 0.2
 non :: Eq a => a -> Iso' (Maybe a) a
 non = non' . only
 {-# INLINE non #-}
@@ -264,6 +266,8 @@ non = non' . only
 --
 -- >>> Map.fromList [("hello", Map.fromList [("world","!!!")])] & at "hello" % non' _Empty % at "world" .~ Nothing
 -- fromList []
+--
+-- @since 0.2
 non' :: Prism' a () -> Iso' (Maybe a) a
 non' p = iso (fromMaybe def) go where
   def                = review p ()
@@ -285,6 +289,8 @@ non' p = iso (fromMaybe def) go where
 --
 -- >>> Map.fromList [("hello", Map.fromList [("world","!!!")])] & at "hello" % anon Map.empty Map.null % at "world" .~ Nothing
 -- fromList []
+--
+-- @since 0.2
 anon :: a -> (a -> Bool) -> Iso' (Maybe a) a
 anon a = non' . nearly a
 {-# INLINE anon #-}

--- a/optics-extra/CHANGELOG.md
+++ b/optics-extra/CHANGELOG.md
@@ -1,0 +1,9 @@
+# optics-extra-0.1 (????-??-??)
+* Move `use` from `Optics.View` to `Optics.State` and restrict its type
+* Add `preuse` to `Optics.State`
+* Rename `use`, `uses`, `listening` and `listenings` to reflect the fact that
+  they have `ViewResult`-generalised types
+* Depend on new `indexed-profunctors` package
+
+# optics-extra-0.1 (2019-09-02)
+* Initial release

--- a/optics-extra/CHANGELOG.md
+++ b/optics-extra/CHANGELOG.md
@@ -1,4 +1,4 @@
-# optics-extra-0.1 (????-??-??)
+# optics-extra-0.1 (2019-10-18)
 * Move `use` from `Optics.View` to `Optics.State` and restrict its type
 * Add `preuse` to `Optics.State`
 * Rename `use`, `uses`, `listening` and `listenings` to reflect the fact that

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -14,6 +14,9 @@ description:
   @optics-core@ package, without incurring too many dependencies.  See the
   @optics@ package for more documentation.
 
+extra-doc-files:
+  CHANGELOG.md
+
 bug-reports:   https://github.com/well-typed/optics/issues
 source-repository head
   type:     git

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -1,5 +1,5 @@
 name:          optics-extra
-version:       0.1
+version:       0.2
 license:       BSD3
 license-file:  LICENSE
 build-type:    Simple
@@ -35,7 +35,7 @@ library
                , hashable               >= 1.1.1     && <1.4
                , indexed-profunctors    >= 0.1       && <0.2
                , mtl                    >= 2.2.2     && <2.3
-               , optics-core            >= 0.1       && <0.1.1
+               , optics-core            >= 0.2       && <0.2.1
                , text                   >= 1.2       && <1.3
                , transformers           >= 0.5       && <0.6
                , unordered-containers   >= 0.2.6     && <0.3

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -11,8 +11,10 @@ synopsis:      Extra utilities and instances for optics-core
 category:      Data, Optics, Lenses
 description:
   This package provides extra definitions and instances that extend the
-  @optics-core@ package, without incurring too many dependencies.  See the
-  @optics@ package for more documentation.
+  @<https://hackage.haskell.org/package/optics-core optics-core>@ package,
+  without incurring too many dependencies.  See the
+  @<https://hackage.haskell.org/package/optics optics>@ package for more
+  documentation.
 
 extra-doc-files:
   CHANGELOG.md

--- a/optics-extra/src/Optics/State.hs
+++ b/optics-extra/src/Optics/State.hs
@@ -102,6 +102,7 @@ use o = gets (view o)
 -- >>> evalState (preuse $ _1 % _Right) (Right 'a','b')
 -- Just 'a'
 --
+-- @since 0.2
 preuse
   :: (Is k An_AffineFold, MonadState s m)
   => Optic' k is s a

--- a/optics-extra/src/Optics/View.hs
+++ b/optics-extra/src/Optics/View.hs
@@ -108,6 +108,8 @@ instance Monoid r => ViewableOptic A_Fold r where
 --
 -- >>> evalState (guse _2) ("hello","world")
 -- "world"
+--
+-- @since 0.2
 guse
   :: (ViewableOptic k a, MonadState s m)
   => Optic' k is s a
@@ -120,6 +122,8 @@ guse o = gets (gview o)
 --
 -- >>> evalState (guses _1 length) ("hello","world")
 -- 5
+--
+-- @since 0.2
 guses
   :: (ViewableOptic k r, MonadState s m)
   => Optic' k is s a
@@ -132,6 +136,8 @@ guses o f = gets (gviews o f)
 -- the log that is focused on by a 'Getter'. If given a 'Fold' or a 'Traversal'
 -- then a monoidal summary of the parts of the log that are visited will be
 -- returned.
+--
+-- @since 0.2
 glistening
   :: (ViewableOptic k r, MonadWriter s m)
   => Optic' k is s r
@@ -146,6 +152,8 @@ glistening o m = do
 -- the log that is focused on by a 'Getter'. If given a 'Fold' or a 'Traversal'
 -- then a monoidal summary of the parts of the log that are visited will be
 -- returned.
+--
+-- @since 0.2
 glistenings
   :: (ViewableOptic k r, MonadWriter s m)
   => Optic' k is s a

--- a/optics-sop/optics-sop.cabal
+++ b/optics-sop/optics-sop.cabal
@@ -29,7 +29,7 @@ library
 
   build-depends: base          >=4.9     && <5
                , generics-sop  >=0.3.1.0 && <0.6
-               , optics-core   >=0.1     && <0.2
+               , optics-core   >=0.2     && <0.3
 
   exposed-modules: Optics.SOP
                    Optics.SOP.ToTuple

--- a/optics-th/CHANGELOG.md
+++ b/optics-th/CHANGELOG.md
@@ -1,0 +1,5 @@
+# optics-th-0.2 (????-??-??)
+* Add `noPrefixFieldLabels` and `noPrefixNamer` to `Optics.TH`
+
+# optics-th-0.1 (2019-09-02)
+* Initial release

--- a/optics-th/CHANGELOG.md
+++ b/optics-th/CHANGELOG.md
@@ -1,4 +1,4 @@
-# optics-th-0.2 (????-??-??)
+# optics-th-0.2 (2019-10-18)
 * Add `noPrefixFieldLabels` and `noPrefixNamer` to `Optics.TH`
 
 # optics-th-0.1 (2019-09-02)

--- a/optics-th/optics-th.cabal
+++ b/optics-th/optics-th.cabal
@@ -1,5 +1,5 @@
 name:          optics-th
-version:       0.1
+version:       0.2
 license:       BSD3
 license-file:  LICENSE
 build-type:    Simple
@@ -32,7 +32,7 @@ library
   build-depends: base                   >= 4.9       && <5
                , containers             >= 0.5.7.1   && <0.7
                , mtl                    >= 2.2.2     && <2.3
-               , optics-core            >= 0.1       && <0.2
+               , optics-core            >= 0.2       && <0.3
                , template-haskell       >= 2.11      && <2.16
                , th-abstraction         >= 0.2.1     && <0.4
                , transformers           >= 0.5       && <0.6

--- a/optics-th/optics-th.cabal
+++ b/optics-th/optics-th.cabal
@@ -15,6 +15,9 @@ description:
   .
   See the @template-haskell-optics@ package for optics to work with @template-haskell@ types.
 
+extra-doc-files:
+  CHANGELOG.md
+
 bug-reports:   https://github.com/well-typed/optics/issues
 source-repository head
   type:     git

--- a/optics-th/optics-th.cabal
+++ b/optics-th/optics-th.cabal
@@ -10,8 +10,8 @@ tested-with:   ghc ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.1, GHCJS ==
 synopsis:      Optics construction using TemplateHaskell
 category:      Data, Optics, Lenses
 description:
-  This package is part of the @optics@ package family.  It provides machinery to
-  construct optics using @TemplateHaskell@.
+  This package is part of the @<https://hackage.haskell.org/package/optics optics>@
+  package family.  It provides machinery to construct optics using @TemplateHaskell@.
   .
   See the @template-haskell-optics@ package for optics to work with @template-haskell@ types.
 

--- a/optics-th/optics-th.cabal
+++ b/optics-th/optics-th.cabal
@@ -5,7 +5,7 @@ license-file:  LICENSE
 build-type:    Simple
 maintainer:    optics@well-typed.com
 author:        Andrzej Rybczak
-cabal-version: >=1.10
+cabal-version: 1.24
 tested-with:   ghc ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.1, GHCJS ==8.4
 synopsis:      Optics construction using TemplateHaskell
 category:      Data, Optics, Lenses

--- a/optics-th/src/Optics/TH.hs
+++ b/optics-th/src/Optics/TH.hs
@@ -662,6 +662,11 @@ lensClass = lensVL $ \f r ->
 ----------------------------------------
 -- Common sets of rules
 
+-- | Field rules for fields without any prefix. Useful for generation of field
+-- labels when paired with @DuplicateRecordFields@ language extension so that no
+-- prefixes for field names are necessary.
+--
+-- @since 0.2
 noPrefixFieldLabels :: LensRules
 noPrefixFieldLabels = fieldLabelsRules { _fieldToDef = noPrefixNamer }
 
@@ -712,6 +717,8 @@ abbreviatedFields = defaultFieldRules { _fieldToDef = abbreviatedNamer }
 -- | A 'FieldNamer' that leaves the field name as-is. Useful for generation of
 -- field labels when paired with @DuplicateRecordFields@ language extension so
 -- that no prefixes for field names are necessary.
+--
+-- @since 0.2
 noPrefixNamer :: FieldNamer
 noPrefixNamer _ _ n = [TopName n]
 

--- a/optics-vl/CHANGELOG.md
+++ b/optics-vl/CHANGELOG.md
@@ -1,2 +1,5 @@
+# optics-vl-0.2 (2019-10-18)
+* Depend on new `indexed-profunctors` package
+
 # optics-vl-0.1 (2019-09-02)
 * Initial release

--- a/optics-vl/CHANGELOG.md
+++ b/optics-vl/CHANGELOG.md
@@ -1,0 +1,2 @@
+# optics-vl-0.1 (2019-09-02)
+* Initial release

--- a/optics-vl/optics-vl.cabal
+++ b/optics-vl/optics-vl.cabal
@@ -5,7 +5,7 @@ license-file:  LICENSE
 build-type:    Simple
 maintainer:    optics@well-typed.com
 author:        Andrzej Rybczak
-cabal-version: >=1.10
+cabal-version: 1.24
 tested-with:   ghc ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.1, GHCJS ==8.4
 synopsis:      Utilities for compatibility with van Laarhoven optics
 category:      Data, Optics, Lenses

--- a/optics-vl/optics-vl.cabal
+++ b/optics-vl/optics-vl.cabal
@@ -10,9 +10,11 @@ tested-with:   ghc ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.1, GHCJS ==
 synopsis:      Utilities for compatibility with van Laarhoven optics
 category:      Data, Optics, Lenses
 description:
-  This package is part of the @optics@ package family.  It provides utilities
-  for converting between the 'Optic' type defined by @optics@ and the van
-  Laarhoven representations of optics (in particular isomorphisms and prisms).
+  This package is part of the @<https://hackage.haskell.org/package/optics optics>@
+  package family.  It provides utilities for converting between the 'Optic' type
+  defined by @<https://hackage.haskell.org/package/optics optics>@ and the van
+  Laarhoven representations of optics that require definitions outside of @base@
+  (in particular isomorphisms and prisms).
 
 extra-doc-files:
   CHANGELOG.md

--- a/optics-vl/optics-vl.cabal
+++ b/optics-vl/optics-vl.cabal
@@ -1,5 +1,5 @@
 name:          optics-vl
-version:       0.1
+version:       0.2
 license:       BSD3
 license-file:  LICENSE
 build-type:    Simple
@@ -29,7 +29,7 @@ library
 
   build-depends: base                   >= 4.9        && <5
                , indexed-profunctors    >= 0.1        && <0.2
-               , optics-core            >= 0.1        && <0.2
+               , optics-core            >= 0.2        && <0.3
                , profunctors            >= 5.0        && <6.0
 
   ghc-options: -Wall

--- a/optics-vl/optics-vl.cabal
+++ b/optics-vl/optics-vl.cabal
@@ -14,6 +14,9 @@ description:
   for converting between the 'Optic' type defined by @optics@ and the van
   Laarhoven representations of optics (in particular isomorphisms and prisms).
 
+extra-doc-files:
+  CHANGELOG.md
+
 bug-reports:   https://github.com/well-typed/optics/issues
 source-repository head
   type:     git

--- a/optics/CHANGELOG.md
+++ b/optics/CHANGELOG.md
@@ -1,11 +1,16 @@
-# optics-core-0.2 (????-??-??)
+# optics-0.2 (????-??-??)
 * Add `non`, `non'` and `anon` to `Optics.Iso`
 * `ix` can produce optic kinds other than `AffineTraversal`
 * Generalise type of `generic1`
+* Move `use` from `Optics.View` to `Optics.State` and restrict its type
+* Add `preuse` to `Optics.State`
+* Rename `use`, `uses`, `listening` and `listenings` to reflect the fact that
+  they have `ViewResult`-generalised types
+* Add `noPrefixFieldLabels` and `noPrefixNamer` to `Optics.TH`
 * Move some internal definitions out to new `indexed-profunctors` package
 * Introduce `OpticKind` and `IxList` type synonyms for better type inference
 * Make `itraverse` for `Seq` faster for `containers >= 0.6.0`
 * Assorted documentation improvements
 
-# optics-core-0.1 (2019-09-02)
+# optics-0.1 (2019-09-02)
 * Initial release

--- a/optics/CHANGELOG.md
+++ b/optics/CHANGELOG.md
@@ -1,4 +1,4 @@
-# optics-0.2 (????-??-??)
+# optics-0.2 (2019-10-18)
 * Add `non`, `non'` and `anon` to `Optics.Iso`
 * `ix` can produce optic kinds other than `AffineTraversal`
 * Generalise type of `generic1`

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -1,5 +1,5 @@
 name:            optics
-version:         0.1
+version:         0.2
 license:         BSD3
 license-file:    LICENSE
 build-type:      Simple
@@ -37,9 +37,9 @@ library
                , array                  >= 0.5.1.1   && <0.6
                , containers             >= 0.5.7.1   && <0.7
                , mtl                    >= 2.2.2     && <2.3
-               , optics-core            >= 0.1       && <0.1.1
-               , optics-extra           >= 0.1       && <0.1.1
-               , optics-th              >= 0.1       && <0.1.1
+               , optics-core            >= 0.2       && <0.2.1
+               , optics-extra           >= 0.2       && <0.2.1
+               , optics-th              >= 0.2       && <0.2.1
                , transformers           >= 0.5       && <0.6
 
   -- main module to land with repl

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -20,6 +20,7 @@ description:
 
 extra-doc-files:
   diagrams/*.png
+  CHANGELOG.md
 
 bug-reports:   https://github.com/well-typed/optics/issues
 source-repository head

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -14,9 +14,14 @@ description:
   and other optics, using an abstract interface. See the main module "Optics"
   for the documentation.
   .
+
   This is the "batteries-included" variant with many dependencies; see the
-  @optics-core@ package and other @optics-*@ dependencies if you need a more
-  limited dependency footprint.
+  @<https://hackage.haskell.org/package/optics-core optics-core>@ package and
+  other @optics-*@ dependencies if you need a more limited dependency footprint.
+  .
+  Note: Hackage does not yet display documentation for reexported-modules,
+  but you can start from the "Optics" module documentation or see the module
+  list in @<https://hackage.haskell.org/package/optics-core optics-core>@.
 
 extra-doc-files:
   diagrams/*.png

--- a/template-haskell-optics/template-haskell-optics.cabal
+++ b/template-haskell-optics/template-haskell-optics.cabal
@@ -26,7 +26,7 @@ library
   ghc-options:      -Wall
 
   build-depends: base                   >= 4.9       && <5
-               , optics-core            >= 0.1       && <0.2
+               , optics-core            >= 0.2       && <0.3
                , containers             >= 0.5.7.1   && <0.7
                , template-haskell       >= 2.11      && <2.16
 


### PR DESCRIPTION
Fixes #257. I've added changelogs, `@since` annotations, bumped the versions of published packages to 0.2, uploaded candidates:
 * https://hackage.haskell.org/package/optics-core-0.2/candidate
 * https://hackage.haskell.org/package/optics-extra-0.2/candidate
 * https://hackage.haskell.org/package/optics-th-0.2/candidate
 * https://hackage.haskell.org/package/optics-0.2/candidate
 * https://hackage.haskell.org/package/optics-vl-0.2/candidate

This needs a release date, and I'd like to add more cross-package hyperlinks to the package descriptions, as I've done for `optics`. Anything else needed for the release?