### PR TITLE
Add (^?!)

### DIFF
--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -74,6 +74,7 @@ library
                    Optics.Indexed.Core
                    Optics.Label
                    Optics.Operators
+                   Optics.Operators.Unsafe
                    Optics.Re
                    Optics.ReadOnly
 

--- a/optics-core/src/Optics/Operators.hs
+++ b/optics-core/src/Optics/Operators.hs
@@ -50,7 +50,7 @@ infixl 8 ^?
 
 infixl 8 ^..
 
--- | Flipped infix version of 'review'.
+-- | Infix version of 'review'.
 (#) :: Is k A_Review => Optic' k is t b -> b -> t
 (#) = review
 {-# INLINE (#) #-}

--- a/optics-core/src/Optics/Operators/Unsafe.hs
+++ b/optics-core/src/Optics/Operators/Unsafe.hs
@@ -1,0 +1,37 @@
+-- |
+-- Module: Optics.Operators.Unsafe
+-- Description: Definitions of unsafe infix operators for optics.
+--
+module Optics.Operators.Unsafe
+  ( (^?!)
+  )
+  where
+
+import Data.Maybe (fromMaybe)
+import GHC.Stack (HasCallStack)
+
+import Optics.AffineFold
+import Optics.Optic
+import Optics.Operators
+
+-- | Perform an *UNSAFE* 'head' of an affine fold assuming that it is there.
+--
+-- >>> Left 4 ^?! _Left
+-- 4
+--
+-- >>> "world" ^?! ix 3
+-- 'l'
+--
+-- >>> [] ^?! _head
+-- *** Exception: (^?!): empty affine fold
+-- ...
+--
+-- @since 0.2.1
+(^?!) :: (HasCallStack, Is k An_AffineFold) => s -> Optic' k is s a -> a
+s ^?! o = fromMaybe (error "(^?!): empty affine fold") (s ^? o)
+{-# INLINE (^?!) #-}
+
+infixl 8 ^?!
+
+-- $setup
+-- >>> import Optics.Core

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -84,6 +84,7 @@ library
                     , Optics.Indexed
                     , Optics.Label
                     , Optics.Operators
+                    , Optics.Operators.Unsafe
                     , Optics.Passthrough
                     , Optics.Re
                     , Optics.ReadOnly


### PR DESCRIPTION
I found that this is useful in tests when you expect the value of an affine fold to be there.

It's more succinct to use `^?!` than `^?` with `fromJust`.
