### PR TITLE
Use stricter uncurry for better performance

### DIFF
--- a/optics-core/src/Optics/Arrow.hs
+++ b/optics-core/src/Optics/Arrow.hs
@@ -16,6 +16,7 @@ import Optics.AffineTraversal
 import Optics.Prism
 import Optics.Setter
 import Optics.Internal.Optic
+import Optics.Internal.Utils
 
 newtype WrappedArrow p i a b = WrapArrow { unwrapArrow :: p a b }
 
@@ -105,7 +106,7 @@ assignA
   :: (Is k A_Setter, Arrow arr)
   => Optic k is s t a b
   -> arr s b -> arr s t
-assignA o p = arr (flip $ set o) &&& p >>> arr (uncurry id)
+assignA o p = arr (flip $ set o) &&& p >>> arr (uncurry' id)
 {-# INLINE assignA #-}
 
 ----------------------------------------

--- a/optics-core/src/Optics/Cons/Core.hs
+++ b/optics-core/src/Optics/Cons/Core.hs
@@ -38,6 +38,7 @@ import Data.Tuple.Optics
 import Optics.AffineFold
 import Optics.AffineTraversal
 import Optics.Coerce
+import Optics.Internal.Utils
 import Optics.Optic
 import Optics.Prism
 import Optics.Review
@@ -86,7 +87,7 @@ class Cons s t a b | s -> a, t -> b, s b -> t, t a -> s where
   _Cons :: Prism s t (a, s) (b, t)
 
 instance Cons [a] [b] a b where
-  _Cons = prism (uncurry (:)) $ \ aas -> case aas of
+  _Cons = prism (uncurry' (:)) $ \aas -> case aas of
     (a:as) -> Right (a, as)
     []     -> Left  []
   {-# INLINE _Cons #-}
@@ -100,7 +101,7 @@ instance Cons (ZipList a) (ZipList b) a b where
   {-# INLINE _Cons #-}
 
 instance Cons (Seq a) (Seq b) a b where
-  _Cons = prism (uncurry (Seq.<|)) $ \aas -> case viewl aas of
+  _Cons = prism (uncurry' (Seq.<|)) $ \aas -> case viewl aas of
     a Seq.:< as -> Right (a, as)
     EmptyL  -> Left mempty
   {-# INLINE _Cons #-}
@@ -238,7 +239,7 @@ instance Snoc (ZipList a) (ZipList b) a b where
   {-# INLINE _Snoc #-}
 
 instance Snoc (Seq a) (Seq b) a b where
-  _Snoc = prism (uncurry (Seq.|>)) $ \aas -> case viewr aas of
+  _Snoc = prism (uncurry' (Seq.|>)) $ \aas -> case viewr aas of
     as Seq.:> a -> Right (as, a)
     EmptyR  -> Left mempty
   {-# INLINE _Snoc #-}

--- a/optics-core/src/Optics/Internal/Indexed.hs
+++ b/optics-core/src/Optics/Internal/Indexed.hs
@@ -238,7 +238,7 @@ instance FunctorWithIndex k ((,) k) where
   {-# INLINE imap #-}
 
 instance FoldableWithIndex k ((,) k) where
-  ifoldMap = uncurry
+  ifoldMap = uncurry'
   {-# INLINE ifoldMap #-}
 
 instance TraversableWithIndex k ((,) k) where
@@ -257,7 +257,7 @@ instance FunctorWithIndex Int []
 instance FoldableWithIndex Int []
 instance TraversableWithIndex Int [] where
   -- Faster than @indexing traverse@, also best for folds and setters.
-  itraverse f = traverse (uncurry f) . Prelude.zip [0..]
+  itraverse f = traverse (uncurry' f) . Prelude.zip [0..]
   {-# INLINE itraverse #-}
 
 -- ZipList
@@ -274,7 +274,7 @@ instance FunctorWithIndex Int NonEmpty
 instance FoldableWithIndex Int NonEmpty
 instance TraversableWithIndex Int NonEmpty where
   itraverse f ~(a :| as) =
-    (:|) <$> f 0 a <*> traverse (uncurry f) (Prelude.zip [1..] as)
+    (:|) <$> f 0 a <*> traverse (uncurry' f) (Prelude.zip [1..] as)
   {-# INLINE itraverse #-}
 
 -- Maybe
@@ -352,16 +352,16 @@ instance TraversableWithIndex k (Map.Map k) where
 
 instance Ix i => FunctorWithIndex i (Array.Array i) where
   imap f arr = Array.listArray (Array.bounds arr)
-    . fmap (uncurry f) $ Array.assocs arr
+    . fmap (uncurry' f) $ Array.assocs arr
   {-# INLINE imap #-}
 
 instance Ix i => FoldableWithIndex i (Array.Array i) where
-  ifoldMap f = foldMap (uncurry f) . Array.assocs
+  ifoldMap f = foldMap (uncurry' f) . Array.assocs
   {-# INLINE ifoldMap #-}
 
 instance Ix i => TraversableWithIndex i (Array.Array i) where
   itraverse f arr = Array.listArray (Array.bounds arr)
-    <$> traverse (uncurry f) (Array.assocs arr)
+    <$> traverse (uncurry' f) (Array.assocs arr)
   {-# INLINE itraverse #-}
 
 -- Compose

--- a/optics-core/src/Optics/Internal/Utils.hs
+++ b/optics-core/src/Optics/Internal/Utils.hs
@@ -15,6 +15,7 @@ module Optics.Internal.Utils
 
   , (#.)
   , (.#)
+  , uncurry'
   ) where
 
 import qualified Data.Semigroup as SG
@@ -103,3 +104,8 @@ instance Applicative f => Applicative (OrT f) where
 wrapOrT :: f a -> OrT f a
 wrapOrT = OrT True
 {-# INLINE wrapOrT #-}
+
+-- | 'uncurry' with no lazy pattern matching for more efficient code.
+uncurry' :: (a -> b -> c) -> (a, b) -> c
+uncurry' f (a, b) = f a b
+{-# INLINE uncurry' #-}

--- a/optics-core/src/Optics/IxAffineFold.hs
+++ b/optics-core/src/Optics/IxAffineFold.hs
@@ -39,6 +39,7 @@ import Optics.AffineFold
 import Optics.Internal.Bi
 import Optics.Internal.Indexed
 import Optics.Internal.Optic
+import Optics.Internal.Utils
 
 -- | Type synonym for an indexed affine fold.
 type IxAffineFold i s a = Optic' An_AffineFold (WithIx i) s a
@@ -65,7 +66,7 @@ ipreviews o = \f -> runIxForgetM
 -- | Create an 'IxAffineFold' from a partial function.
 iafolding :: (s -> Maybe (i, a)) -> IxAffineFold i s a
 iafolding g = Optic
-  $ ivisit (\point f s -> maybe (point s) (uncurry f) $ g s)
+  $ ivisit (\point f s -> maybe (point s) (uncurry' f) $ g s)
   . rphantom
 {-# INLINE iafolding #-}
 

--- a/optics-core/src/Optics/IxAffineTraversal.hs
+++ b/optics-core/src/Optics/IxAffineTraversal.hs
@@ -44,6 +44,7 @@ import Data.Profunctor.Indexed
 
 import Optics.Internal.Indexed
 import Optics.Internal.Optic
+import Optics.Internal.Utils
 
 -- | Type synonym for a type-modifying indexed affine traversal.
 type IxAffineTraversal i s t a b = Optic An_AffineTraversal (WithIx i) s t a b
@@ -71,7 +72,7 @@ type IxAffineTraversalVL' i s a = IxAffineTraversalVL i s s a a
 -- representation, use 'iatraversalVL'.
 iatraversal :: (s -> Either t (i, a)) -> (s -> b -> t) -> IxAffineTraversal i s t a b
 iatraversal match update = iatraversalVL $ \point f s ->
-  either point (\a -> update s <$> uncurry f a) (match s)
+  either point (\a -> update s <$> uncurry' f a) (match s)
 {-# INLINE iatraversal #-}
 
 -- | Build an indexed affine traversal from the van Laarhoven representation.

--- a/optics-core/src/Optics/IxGetter.hs
+++ b/optics-core/src/Optics/IxGetter.hs
@@ -28,6 +28,7 @@ import Data.Profunctor.Indexed
 import Optics.Internal.Bi
 import Optics.Internal.Indexed
 import Optics.Internal.Optic
+import Optics.Internal.Utils
 
 -- | Type synonym for an indexed getter.
 type IxGetter i s a = Optic' A_Getter (WithIx i) s a
@@ -37,7 +38,7 @@ type IxGetter i s a = Optic' A_Getter (WithIx i) s a
 -- >>> iview (ito id) ('i', 'x')
 -- ('i','x')
 ito :: (s -> (i, a)) -> IxGetter i s a
-ito f = Optic (lmap f . ilinear uncurry . rphantom)
+ito f = Optic (lmap f . ilinear uncurry' . rphantom)
 {-# INLINE ito #-}
 
 -- | Use a value itself as its own index. This is essentially an indexed version

--- a/optics-core/src/Optics/IxLens.hs
+++ b/optics-core/src/Optics/IxLens.hs
@@ -48,6 +48,7 @@ import Data.Profunctor.Indexed
 
 import Optics.Internal.Indexed
 import Optics.Internal.Optic
+import Optics.Internal.Utils
 
 -- | Type synonym for a type-modifying indexed lens.
 type IxLens i s t a b = Optic A_Lens (WithIx i) s t a b
@@ -67,7 +68,7 @@ type IxLensVL' i s a = IxLensVL i s s a a
 -- If you want to build an 'IxLens' from the van Laarhoven representation, use
 -- 'ilensVL'.
 ilens :: (s -> (i, a)) -> (s -> b -> t) -> IxLens i s t a b
-ilens get set = ilensVL $ \f s -> set s <$> uncurry f (get s)
+ilens get set = ilensVL $ \f s -> set s <$> uncurry' f (get s)
 {-# INLINE ilens #-}
 
 -- | Build an indexed lens from the van Laarhoven representation.

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -315,7 +315,7 @@ ipartsOf
   -> IxLens [i] s t [a] [a]
 ipartsOf o = conjoined (partsOf o) $ ilensVL $ \f s ->
   evalState (traverseOf o update s)
-    <$> uncurry f (unzip $ itoListOf (getting $ castOptic @A_Traversal o) s)
+    <$> uncurry' f (unzip $ itoListOf (getting $ castOptic @A_Traversal o) s)
   where
     update a = get >>= \case
       []       ->            pure a

--- a/optics-extra/src/Optics/Cons.hs
+++ b/optics-extra/src/Optics/Cons.hs
@@ -40,48 +40,49 @@ import qualified Data.Vector.Storable as Storable
 import qualified Data.Vector.Unboxed as Unbox
 
 import Optics.Core
+import Optics.Internal.Utils
 
 -- Cons
 
 instance Cons StrictB.ByteString StrictB.ByteString Word8 Word8 where
-  _Cons = prism' (uncurry StrictB.cons) StrictB.uncons
+  _Cons = prism' (uncurry' StrictB.cons) StrictB.uncons
   {-# INLINE _Cons #-}
 
 instance Cons LazyB.ByteString LazyB.ByteString Word8 Word8 where
-  _Cons = prism' (uncurry LazyB.cons) LazyB.uncons
+  _Cons = prism' (uncurry' LazyB.cons) LazyB.uncons
   {-# INLINE _Cons #-}
 
 instance Cons StrictT.Text StrictT.Text Char Char where
-  _Cons = prism' (uncurry StrictT.cons) StrictT.uncons
+  _Cons = prism' (uncurry' StrictT.cons) StrictT.uncons
   {-# INLINE _Cons #-}
 
 instance Cons LazyT.Text LazyT.Text Char Char where
-  _Cons = prism' (uncurry LazyT.cons) LazyT.uncons
+  _Cons = prism' (uncurry' LazyT.cons) LazyT.uncons
   {-# INLINE _Cons #-}
 
 instance Cons (Vector a) (Vector b) a b where
-  _Cons = prism (uncurry Vector.cons) $ \v ->
+  _Cons = prism (uncurry' Vector.cons) $ \v ->
     if Vector.null v
     then Left Vector.empty
     else Right (Vector.unsafeHead v, Vector.unsafeTail v)
   {-# INLINE _Cons #-}
 
 instance (Prim a, Prim b) => Cons (Prim.Vector a) (Prim.Vector b) a b where
-  _Cons = prism (uncurry Prim.cons) $ \v ->
+  _Cons = prism (uncurry' Prim.cons) $ \v ->
     if Prim.null v
     then Left Prim.empty
     else Right (Prim.unsafeHead v, Prim.unsafeTail v)
   {-# INLINE _Cons #-}
 
 instance (Storable a, Storable b) => Cons (Storable.Vector a) (Storable.Vector b) a b where
-  _Cons = prism (uncurry Storable.cons) $ \v ->
+  _Cons = prism (uncurry' Storable.cons) $ \v ->
     if Storable.null v
     then Left Storable.empty
     else Right (Storable.unsafeHead v, Storable.unsafeTail v)
   {-# INLINE _Cons #-}
 
 instance (Unbox a, Unbox b) => Cons (Unbox.Vector a) (Unbox.Vector b) a b where
-  _Cons = prism (uncurry Unbox.cons) $ \v ->
+  _Cons = prism (uncurry' Unbox.cons) $ \v ->
     if Unbox.null v
     then Left Unbox.empty
     else Right (Unbox.unsafeHead v, Unbox.unsafeTail v)
@@ -90,49 +91,49 @@ instance (Unbox a, Unbox b) => Cons (Unbox.Vector a) (Unbox.Vector b) a b where
 -- Snoc
 
 instance Snoc (Vector a) (Vector b) a b where
-  _Snoc = prism (uncurry Vector.snoc) $ \v -> if Vector.null v
+  _Snoc = prism (uncurry' Vector.snoc) $ \v -> if Vector.null v
     then Left Vector.empty
     else Right (Vector.unsafeInit v, Vector.unsafeLast v)
   {-# INLINE _Snoc #-}
 
 instance (Prim a, Prim b) => Snoc (Prim.Vector a) (Prim.Vector b) a b where
-  _Snoc = prism (uncurry Prim.snoc) $ \v -> if Prim.null v
+  _Snoc = prism (uncurry' Prim.snoc) $ \v -> if Prim.null v
     then Left Prim.empty
     else Right (Prim.unsafeInit v, Prim.unsafeLast v)
   {-# INLINE _Snoc #-}
 
 instance (Storable a, Storable b) => Snoc (Storable.Vector a) (Storable.Vector b) a b where
-  _Snoc = prism (uncurry Storable.snoc) $ \v -> if Storable.null v
+  _Snoc = prism (uncurry' Storable.snoc) $ \v -> if Storable.null v
     then Left Storable.empty
     else Right (Storable.unsafeInit v, Storable.unsafeLast v)
   {-# INLINE _Snoc #-}
 
 instance (Unbox a, Unbox b) => Snoc (Unbox.Vector a) (Unbox.Vector b) a b where
-  _Snoc = prism (uncurry Unbox.snoc) $ \v -> if Unbox.null v
+  _Snoc = prism (uncurry' Unbox.snoc) $ \v -> if Unbox.null v
     then Left Unbox.empty
     else Right (Unbox.unsafeInit v, Unbox.unsafeLast v)
   {-# INLINE _Snoc #-}
 
 instance Snoc StrictB.ByteString StrictB.ByteString Word8 Word8 where
-  _Snoc = prism (uncurry StrictB.snoc) $ \v -> if StrictB.null v
+  _Snoc = prism (uncurry' StrictB.snoc) $ \v -> if StrictB.null v
     then Left StrictB.empty
     else Right (StrictB.init v, StrictB.last v)
   {-# INLINE _Snoc #-}
 
 instance Snoc LazyB.ByteString LazyB.ByteString Word8 Word8 where
-  _Snoc = prism (uncurry LazyB.snoc) $ \v -> if LazyB.null v
+  _Snoc = prism (uncurry' LazyB.snoc) $ \v -> if LazyB.null v
     then Left LazyB.empty
     else Right (LazyB.init v, LazyB.last v)
   {-# INLINE _Snoc #-}
 
 instance Snoc StrictT.Text StrictT.Text Char Char where
-  _Snoc = prism (uncurry StrictT.snoc) $ \v -> if StrictT.null v
+  _Snoc = prism (uncurry' StrictT.snoc) $ \v -> if StrictT.null v
     then Left StrictT.empty
     else Right (StrictT.init v, StrictT.last v)
   {-# INLINE _Snoc #-}
 
 instance Snoc LazyT.Text LazyT.Text Char Char where
-  _Snoc = prism (uncurry LazyT.snoc) $ \v -> if LazyT.null v
+  _Snoc = prism (uncurry' LazyT.snoc) $ \v -> if LazyT.null v
     then Left LazyT.empty
     else Right (LazyT.init v, LazyT.last v)
   {-# INLINE _Snoc #-}


### PR DESCRIPTION
I noticed when comparing `isingular` to `ipre` that the latter was 15% slower, tracked it down to the fact that `iafolding` that `ipre` uses was using `uncurry` whereas `isingular` has regular pattern matching on a pair.