### PR TITLE
Add computation QuickCheck properties

### DIFF
--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -136,9 +136,11 @@ test-suite optics-tests
                , mtl
                , optics
                , optics-core
+               , QuickCheck
                , random
                , tasty
                , tasty-hunit
+               , tasty-quickcheck
                , template-haskell
 
   type:    exitcode-stdio-1.0
@@ -149,6 +151,7 @@ test-suite optics-tests
                  Optics.Tests.Eta
                  Optics.Tests.Labels
                  Optics.Tests.Misc
+                 Optics.Tests.Properties
                  Optics.Tests.Utils
 
 -- Benchmarking folds

--- a/optics/tests/Optics/Tests.hs
+++ b/optics/tests/Optics/Tests.hs
@@ -10,6 +10,7 @@ import Optics.Tests.Core
 import Optics.Tests.Eta
 import Optics.Tests.Labels
 import Optics.Tests.Misc
+import Optics.Tests.Properties
 
 -- | Composing a lens and a traversal yields a traversal
 _comp1 :: Traversable t => Optic A_Traversal NoIx (t a, y) (t b, y) a b
@@ -48,4 +49,5 @@ main = defaultMain $ testGroup "Tests"
     , miscTests
     ]
   , computationTests
+  , propertiesTests
   ]

--- a/optics/tests/Optics/Tests/Properties.hs
+++ b/optics/tests/Optics/Tests/Properties.hs
@@ -1,0 +1,86 @@
+module Optics.Tests.Properties (propertiesTests) where
+
+import Data.Either (isRight)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+import Test.QuickCheck (Fun, expectFailure, applyFun, applyFun2, Property, (===), (==>))
+import Test.QuickCheck.Poly (A, B, C, OrdA)
+
+import Optics
+import Optics.Internal.Optic
+import Optics.Internal.Bi
+
+type S = C
+type T = OrdA
+
+propertiesTests :: TestTree
+propertiesTests = testGroup "properties"
+  -- lens bundles /any/ two functions together
+  [ testGroup "Lens"
+    [ testProperty "view (lens f g) = f" $
+      let prop :: Fun S A -> Fun (S, B) T -> S -> Property
+          prop f g s =
+            view (getting (lens (applyFun f) (applyFun2 g))) s
+            ===
+            applyFun f s
+
+      in prop
+    , testProperty "set (lens f g) = g" $
+      let prop :: Fun S A -> Fun (S, B) T -> S -> B -> Property
+          prop f g s b =
+            set (lens (applyFun f) (applyFun2 g)) b s
+            ===
+            applyFun2 g s b
+
+      in prop
+    ]
+
+  -- also prisms
+  , testGroup "Prism"
+    [ testProperty "review (prism f g) = f" $
+      let prop :: Fun B T -> Fun S (Either T A) -> B -> Property
+          prop f g b =
+            review (reviewing (castOptic (prism (applyFun f) (applyFun g)))) b
+            ===
+            applyFun f b
+      in prop
+    , testProperty "matching (prism f g) = g" $
+      let prop :: Fun B T -> Fun S (Either T A) -> S -> Property
+          prop f g s =
+            matching (prism (applyFun f) (applyFun g)) s
+            ===
+            applyFun g s
+      in prop
+    ]
+
+    -- affine traversals are trickier, atraversal doesn't just bundle
+    -- two arbitrary functions together.
+  , testGroup "AffineTraversal"
+    [ testProperty "matching (atraversal f g) = g" $
+      let prop :: Fun S (Either T A) -> Fun (S, B) T -> S -> Property
+          prop f g s =
+            matching (atraversal (applyFun f) (applyFun2 g)) s
+            ===
+            applyFun f s
+      in prop
+    , testProperty "set (atraversal f g) ~= flip g" $
+      let prop :: Fun S (Either T A) -> Fun (S, B) T -> S -> B -> Property
+          prop f g s b =
+            set (atraversal (applyFun f) (applyFun2 g)) b s
+            ===
+            applyFun2 g s b
+          in expectFailure prop
+    , testProperty "isRight (f s) ==> set (atraversal f g) = flip g" $
+      let prop :: Fun S (Either T A) -> Fun (S, B) T -> S -> B -> Property
+          prop f g s b =
+            isRight (applyFun f s)
+            ==>
+            set (atraversal (applyFun f) (applyFun2 g)) b s
+            ===
+            applyFun2 g s b
+          in prop
+    ]
+  ]
+
+reviewing :: Optic A_Review NoIx s t a b -> Review t b
+reviewing (Optic o) = Optic (lphantom . o . lphantom)


### PR DESCRIPTION
We do have inspection tests for these,
yet QuickCheck finds counter-examples.