### PR TITLE
WIP: generic-optics-labels experiment

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,6 +7,7 @@ packages:
   optics-vl/*.cabal
   indexed-profunctors/*.cabal
   template-haskell-optics/*.cabal
+  generic-optics-labels/*.cabal
 
 -- An example, using optics to generate optics diagrams
 packages:

--- a/generic-optics-labels/generic-optics-labels.cabal
+++ b/generic-optics-labels/generic-optics-labels.cabal
@@ -1,0 +1,51 @@
+name:          generic-optics-labels
+version:       0.2
+license:       BSD3
+license-file:  LICENSE
+build-type:    Simple
+cabal-version: 1.24
+maintainer:    optics@well-typed.com
+author:        Adam Gundry
+tested-with:   GHC ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.2 || ==8.10.1, GHCJS ==8.4
+synopsis:      TODO
+category:      Data, Optics, Lenses
+description:
+  TODO
+
+extra-doc-files:
+  CHANGELOG.md
+
+bug-reports:   https://github.com/well-typed/optics/issues
+source-repository head
+  type:     git
+  location: https://github.com/well-typed/optics.git
+  subdir:   generic-optics-labels
+
+library
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  ghc-options:      -Wall
+
+  build-depends: base >= 4.9 && <5
+               , optics-core == 0.2
+               , generic-optics == 2.0.*
+
+  exposed-modules: Optics.Label.Test
+                   Optics.Label.Generic
+
+  default-extensions: BangPatterns
+                      DefaultSignatures
+                      DeriveFunctor
+                      FlexibleContexts
+                      FlexibleInstances
+                      FunctionalDependencies
+                      GADTs
+                      InstanceSigs
+                      LambdaCase
+                      MultiParamTypeClasses
+                      RankNTypes
+                      ScopedTypeVariables
+                      TupleSections
+                      TypeApplications
+                      TypeFamilies
+                      TypeOperators

--- a/generic-optics-labels/src/Optics/Label/Generic.hs
+++ b/generic-optics-labels/src/Optics/Label/Generic.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Optics.Label.Generic
+  () where
+
+import Data.Generics.Product.Fields (HasField(field))
+
+import Optics.Internal.Optic
+
+instance (k ~ A_Lens, HasField name s t a b) => GeneralLabelOptic name k s t a b 'True where
+  generalLabelOptic = field @name @s @t @a @b

--- a/generic-optics-labels/src/Optics/Label/Generic.hs
+++ b/generic-optics-labels/src/Optics/Label/Generic.hs
@@ -1,12 +1,74 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Optics.Label.Generic
   () where
 
-import Data.Generics.Product.Fields (HasField(field))
+import Data.Generics.Product.Fields
+import Data.Generics.Sum.Constructors
+import Data.Type.Equality
+import Data.Type.Bool
+import GHC.TypeLits
 
 import Optics.Internal.Optic
+import Optics.Lens
+import Optics.Prism
 
-instance (k ~ A_Lens, HasField name s t a b) => GeneralLabelOptic name k s t a b 'True where
-  generalLabelOptic = field @name @s @t @a @b
+type family GenericOpticKind (name :: Symbol) :: OpticKind where
+  GenericOpticKind name =
+    If (CmpSymbol "_@" name == 'LT && CmpSymbol "_[" name == 'GT)
+      A_Prism
+      A_Lens
+
+instance
+  ( k ~ GenericOpticKind name
+  , GenericOptic name k s t a b
+  ) => GeneralLabelOptic name k s t a b 'True where
+  generalLabelOptic = genericOptic @name @k @s @t @a @b
+
+----------------------------------------
+
+class GenericOptic name k s t a b where
+  genericOptic :: Optic k NoIx s t a b
+
+instance Field name s t a b => GenericOptic name A_Lens s t a b where
+  genericOptic = fieldLens @name @s @t @a @b
+
+instance
+  ( Constructor name s t a b
+  , _name ~ AppendSymbol "_" name
+  ) => GenericOptic _name A_Prism s t a b where
+  genericOptic = constructorPrism @name @s @t @a @b
+
+----------------------------------------
+
+-- | 'Field' is morally the same as 'HasField', but it is constructed from an
+-- incoherent combination of 'HasField' and 'HasField''. In this way, it can be
+-- seamlessly used even when dealing with data types that don't have 'HasField'
+-- instances (like data instances).
+class Field name s t a b where
+  fieldLens :: Lens s t a b
+
+instance {-# INCOHERENT #-} HasField name s t a b => Field name s t a b where
+  fieldLens = field @name @s @t @a @b
+
+instance HasField' name s a => Field name s s a a where
+  fieldLens = field' @name @s @a
+
+----------------------------------------
+
+-- | 'Constructor' is morally the same as 'AsConstructor', but it is constructed
+-- from an incoherent combination of 'AsConstructor' and 'AsConstructor''. In
+-- this way, it can be seamlessly used even when dealing with data types that
+-- don't have 'AsConstructor' instances (like data instances).
+class Constructor name s t a b where
+  constructorPrism :: Prism s t a b
+
+instance {-# INCOHERENT #-} AsConstructor name s t a b => Constructor name s t a b where
+  constructorPrism = _Ctor @name @s @t @a @b
+
+instance AsConstructor' name s a => Constructor name s s a a where
+  constructorPrism = _Ctor' @name @s @a

--- a/generic-optics-labels/src/Optics/Label/Generic.hs
+++ b/generic-optics-labels/src/Optics/Label/Generic.hs
@@ -55,7 +55,10 @@ class Field name s t a b where
 instance {-# INCOHERENT #-} HasField name s t a b => Field name s t a b where
   fieldLens = field @name @s @t @a @b
 
-instance HasField' name s a => Field name s s a a where
+-- Use field' when appropriate for faster compile times. Note that if a ~ b,
+-- then necessarily s ~ t. This doesn't apply in general because of phantom type
+-- variables, but 'LabelOptic' doesn't support them.
+instance (HasField' name s a, s ~ t) => Field name s t a a where
   fieldLens = field' @name @s @a
 
 ----------------------------------------
@@ -70,5 +73,8 @@ class Constructor name s t a b where
 instance {-# INCOHERENT #-} AsConstructor name s t a b => Constructor name s t a b where
   constructorPrism = _Ctor @name @s @t @a @b
 
-instance AsConstructor' name s a => Constructor name s s a a where
+-- Use Ctor' when appropriate for faster compile times. Note that if a ~ b, then
+-- necessarily s ~ t. This doesn't apply in general because of phantom type
+-- variables, but 'LabelOptic' doesn't support them.
+instance (AsConstructor' name s a, s ~ t) => Constructor name s t a a where
   constructorPrism = _Ctor' @name @s @a

--- a/generic-optics-labels/src/Optics/Label/Test.hs
+++ b/generic-optics-labels/src/Optics/Label/Test.hs
@@ -39,6 +39,8 @@ e6 = view #foo
 -- e7 :: Int
 e7 = e6 (MkT 3)
 
+-- e8 :: Maybe Int
+e8 = preview #_MkT (MkT 1)
 
 {-
 *Optics.Label.Test> :set -XOverloadedLabels

--- a/generic-optics-labels/src/Optics/Label/Test.hs
+++ b/generic-optics-labels/src/Optics/Label/Test.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Optics.Label.Test where
+
+import GHC.Generics (Generic)
+import Optics.Core
+import Optics.Label.Generic ()
+
+data T = MkT { foo :: Int }
+  deriving (Show, Generic)
+
+-- e1 :: Int
+e1 = view #foo (MkT 42)
+
+-- e2 :: T
+e2 = set #foo 3 (MkT undefined)
+
+-- e3 :: T -> T
+e3 x = set #foo 11 x :: T
+
+
+instance (a ~ Int, b ~ Int) => LabelOptic "bar" A_Lens T T a b where
+  labelOptic = lensVL $ \ f s -> (\v -> s { foo = v}) <$> f (foo s)
+
+-- e4 :: Int
+e4 = view #bar (MkT 42)
+
+
+data U = MkU { woo :: Int }
+
+e5 :: LabelOptic' "woo" A_Lens U Int => Int
+e5 = view #woo (MkU 42)
+
+e6 :: LabelOptic' "foo" A_Lens s a => s -> a
+e6 = view #foo
+
+-- e7 :: Int
+e7 = e6 (MkT 3)
+
+
+{-
+*Optics.Label.Test> :set -XOverloadedLabels
+*Optics.Label.Test> view #missing (MkT 3)
+
+<interactive>:2:6: error:
+    • The type T does not contain a field named 'missing'.
+    • In the first argument of ‘view’, namely ‘#missing’
+      In the expression: view #missing (MkT 3)
+      In an equation for ‘it’: it = view #missing (MkT 3)
+*Optics.Label.Test> view #missing (MkU 3)
+
+<interactive>:3:1: error:
+    • No instance for LabelOptic "missing" ‘k’ ‘U’ ‘U’ ‘a’ ‘a’
+        (maybe you forgot to define it or misspelled a name?)
+    • When checking the inferred type
+        it :: forall (k :: OpticKind) a.
+              ((TypeError ...), Is k A_Getter) =>
+              a
+*Optics.Label.Test> \ x -> set #foo 11 x
+
+<interactive>:4:1: error:
+    • No instance for LabelOptic "foo" ‘k’ ‘s’ ‘t’ ‘a’ ‘b’
+        (maybe you forgot to define it or misspelled a name?)
+    • When checking the inferred type
+        it :: forall (k :: OpticKind) s t a b.
+              ((TypeError ...), Is k A_Setter, Num b) =>
+              s -> t
+-}

--- a/generic-optics-labels/src/Optics/Label/Test.hs
+++ b/generic-optics-labels/src/Optics/Label/Test.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
 module Optics.Label.Test where
 
 import GHC.Generics (Generic)


### PR DESCRIPTION
See #140 and kcsongor/generic-lens#108. This uses nasty tricks to make it possible to extend `LabelOptic` downstream, and adds a package `generic-optics-labels` that does so using `generic-optics`. We retain the custom error message if a `Generic` instance does not exist or the orphan instance in `generic-optics-labels` has not been imported.

Basic tests seem to work, although it needs more prodding to see if the wheel falls off somewhere. It turns out that my worries about polymorphism are already an issue with `LabelOptic`: if you use a polymorphic expression such as `view #foo` without a type signature, you will hit the custom type error rather than remaining polymorphic in a `LabelOptic` constraint. But that's not entirely unreasonable, perhaps.

If we go for this approach, I think we should rename `Optics.Label` to `Optics.Label.Core` in `optics-core` and make `optics` depend on `generic-optics-labels` so it can expose an `Optics.Label` module including the instance.