### PR TITLE
Make optics break less with simplified subsumption

### DIFF
--- a/codegen/Subtypes.hs
+++ b/codegen/Subtypes.hs
@@ -146,7 +146,7 @@ genSubtypes = either (fail . show) id $ runG opticsKind $ \g -> do
                     [ "instance Is"
                     , leftpad (show k)
                     , leftpad (show k')
-                    , "where implies _ = id"
+                    , "where implies _ r = r"
                     ]
 
 -------------------------------------------------------------------------------

--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -145,11 +145,13 @@ infixl 9 %%
 Optic o %% Optic o' = Optic oo
   where
     -- unsafeCoerce to the rescue, for a proof see below.
-    oo :: forall p i. Profunctor p => Optic_ k p i (Curry ks i) s t a b
+    oo :: forall p i. (Profunctor p, Constraints k p) => Optic__ p i (Curry ks i) s t a b
     oo = (unsafeCoerce
-           :: Optic_ k p i (Curry is (Curry js i)) s t a b
-           -> Optic_ k p i (Curry ks i           ) s t a b)
-      (o . o')
+           :: Optic__ p i (Curry is (Curry js i)) s t a b
+           -> Optic__ p i (Curry ks i           ) s t a b)
+      ( (o  :: Optic__ p (Curry js i) (Curry is (Curry js i)) s t u v)
+      . (o' :: Optic__ p i            (Curry js i)            u v a b)
+      )
 {-# INLINE (%%) #-}
 
 -- | Flipped function application, specialised to optics and binding tightly.

--- a/optics-core/src/Optics/Internal/Optic/Subtyping.hs
+++ b/optics-core/src/Optics/Internal/Optic/Subtyping.hs
@@ -24,7 +24,10 @@ import Optics.Internal.Optic.Types
 class Is k l where
   -- | Witness of the subtyping relationship.
   implies ::
-    proxy k l p -> (Constraints k p => r) -> (Constraints l p => r)
+    -- morally:
+    --   proxy k l p -> (Constraints k p => r) -> (Constraints l p => r)
+    -- but we make the type less "RankN".
+    Constraints l p => proxy k l p -> (Constraints k p => r) -> r
 
 -- | Overlappable instance for a custom type error.
 instance {-# OVERLAPPABLE #-} TypeError ('ShowType k
@@ -35,57 +38,57 @@ instance {-# OVERLAPPABLE #-} TypeError ('ShowType k
 
 -- | Every kind of optic can be used as itself.
 instance Is k k where
-  implies _ = id
+  implies _ r = r
 
 ----------------------------------------
 
 -- BEGIN GENERATED CONTENT
 
 -- An_Iso
-instance Is An_Iso             A_ReversedLens     where implies _ = id
-instance Is An_Iso             A_ReversedPrism    where implies _ = id
-instance Is An_Iso             A_Prism            where implies _ = id
-instance Is An_Iso             A_Review           where implies _ = id
-instance Is An_Iso             A_Lens             where implies _ = id
-instance Is An_Iso             A_Getter           where implies _ = id
-instance Is An_Iso             An_AffineTraversal where implies _ = id
-instance Is An_Iso             An_AffineFold      where implies _ = id
-instance Is An_Iso             A_Traversal        where implies _ = id
-instance Is An_Iso             A_Fold             where implies _ = id
-instance Is An_Iso             A_Setter           where implies _ = id
+instance Is An_Iso             A_ReversedLens     where implies _ r = r
+instance Is An_Iso             A_ReversedPrism    where implies _ r = r
+instance Is An_Iso             A_Prism            where implies _ r = r
+instance Is An_Iso             A_Review           where implies _ r = r
+instance Is An_Iso             A_Lens             where implies _ r = r
+instance Is An_Iso             A_Getter           where implies _ r = r
+instance Is An_Iso             An_AffineTraversal where implies _ r = r
+instance Is An_Iso             An_AffineFold      where implies _ r = r
+instance Is An_Iso             A_Traversal        where implies _ r = r
+instance Is An_Iso             A_Fold             where implies _ r = r
+instance Is An_Iso             A_Setter           where implies _ r = r
 -- A_ReversedLens
-instance Is A_ReversedLens     A_Review           where implies _ = id
+instance Is A_ReversedLens     A_Review           where implies _ r = r
 -- A_ReversedPrism
-instance Is A_ReversedPrism    A_Getter           where implies _ = id
-instance Is A_ReversedPrism    An_AffineFold      where implies _ = id
-instance Is A_ReversedPrism    A_Fold             where implies _ = id
+instance Is A_ReversedPrism    A_Getter           where implies _ r = r
+instance Is A_ReversedPrism    An_AffineFold      where implies _ r = r
+instance Is A_ReversedPrism    A_Fold             where implies _ r = r
 -- A_Prism
-instance Is A_Prism            A_Review           where implies _ = id
-instance Is A_Prism            An_AffineTraversal where implies _ = id
-instance Is A_Prism            An_AffineFold      where implies _ = id
-instance Is A_Prism            A_Traversal        where implies _ = id
-instance Is A_Prism            A_Fold             where implies _ = id
-instance Is A_Prism            A_Setter           where implies _ = id
+instance Is A_Prism            A_Review           where implies _ r = r
+instance Is A_Prism            An_AffineTraversal where implies _ r = r
+instance Is A_Prism            An_AffineFold      where implies _ r = r
+instance Is A_Prism            A_Traversal        where implies _ r = r
+instance Is A_Prism            A_Fold             where implies _ r = r
+instance Is A_Prism            A_Setter           where implies _ r = r
 -- A_Lens
-instance Is A_Lens             A_Getter           where implies _ = id
-instance Is A_Lens             An_AffineTraversal where implies _ = id
-instance Is A_Lens             An_AffineFold      where implies _ = id
-instance Is A_Lens             A_Traversal        where implies _ = id
-instance Is A_Lens             A_Fold             where implies _ = id
-instance Is A_Lens             A_Setter           where implies _ = id
+instance Is A_Lens             A_Getter           where implies _ r = r
+instance Is A_Lens             An_AffineTraversal where implies _ r = r
+instance Is A_Lens             An_AffineFold      where implies _ r = r
+instance Is A_Lens             A_Traversal        where implies _ r = r
+instance Is A_Lens             A_Fold             where implies _ r = r
+instance Is A_Lens             A_Setter           where implies _ r = r
 -- A_Getter
-instance Is A_Getter           An_AffineFold      where implies _ = id
-instance Is A_Getter           A_Fold             where implies _ = id
+instance Is A_Getter           An_AffineFold      where implies _ r = r
+instance Is A_Getter           A_Fold             where implies _ r = r
 -- An_AffineTraversal
-instance Is An_AffineTraversal An_AffineFold      where implies _ = id
-instance Is An_AffineTraversal A_Traversal        where implies _ = id
-instance Is An_AffineTraversal A_Fold             where implies _ = id
-instance Is An_AffineTraversal A_Setter           where implies _ = id
+instance Is An_AffineTraversal An_AffineFold      where implies _ r = r
+instance Is An_AffineTraversal A_Traversal        where implies _ r = r
+instance Is An_AffineTraversal A_Fold             where implies _ r = r
+instance Is An_AffineTraversal A_Setter           where implies _ r = r
 -- An_AffineFold
-instance Is An_AffineFold      A_Fold             where implies _ = id
+instance Is An_AffineFold      A_Fold             where implies _ r = r
 -- A_Traversal
-instance Is A_Traversal        A_Fold             where implies _ = id
-instance Is A_Traversal        A_Setter           where implies _ = id
+instance Is A_Traversal        A_Fold             where implies _ r = r
+instance Is A_Traversal        A_Setter           where implies _ r = r
 
 -- END GENERATED CONTENT
 


### PR DESCRIPTION
Patch mostly by Ryan Scott, see
https://gitlab.haskell.org/RyanGlScott/head.hackage/blob/9fadfda472c80007e7a52471cf891587aa6b7465/patches/optics-core-0.2.patch

I rewrote `%%` def to make type-checker guess less