### PR TITLE
Add filteredBy/unsafeFilteredBy

### DIFF
--- a/optics-core/src/Optics/AffineTraversal.hs
+++ b/optics-core/src/Optics/AffineTraversal.hs
@@ -56,7 +56,7 @@ module Optics.AffineTraversal
   , AffineTraversalVL
   , AffineTraversalVL'
   , atraversalVL
-  , toAtraversalVL
+  , atraverseOf
   )
   where
 
@@ -143,14 +143,15 @@ atraversalVL :: AffineTraversalVL s t a b -> AffineTraversal s t a b
 atraversalVL f = Optic (visit f)
 {-# INLINE atraversalVL #-}
 
--- | Convert an affine traversal to its van Laarhoven representation.
-toAtraversalVL
-  :: Is k An_AffineTraversal
+-- | Traverse over the target of an 'AffineTraversal' and compute a
+-- 'Functor'-based answer.
+atraverseOf
+  :: (Is k An_AffineTraversal, Functor f)
   => Optic k is s t a b
-  -> AffineTraversalVL s t a b
-toAtraversalVL o point =
+  -> (forall r. r -> f r) -> (a -> f b) -> s -> f t
+atraverseOf o point =
   runStarA . getOptic (castOptic @An_AffineTraversal o) . StarA point
-{-# INLINE toAtraversalVL #-}
+{-# INLINE atraverseOf #-}
 
 -- | Retrieve the value targeted by an 'AffineTraversal' or return the original
 -- value while allowing the type to change if it does not match.

--- a/optics-core/src/Optics/Indexed/Core.hs
+++ b/optics-core/src/Optics/Indexed/Core.hs
@@ -197,7 +197,7 @@ instance IxOptic A_Lens s t a b where
   {-# INLINE noIx #-}
 
 instance IxOptic An_AffineTraversal s t a b where
-  noIx o = atraversalVL (toAtraversalVL o)
+  noIx o = atraversalVL (atraverseOf o)
   {-# INLINE noIx #-}
 
 instance (s ~ t, a ~ b) => IxOptic An_AffineFold s t a b where

--- a/optics-core/src/Optics/IxAffineFold.hs
+++ b/optics-core/src/Optics/IxAffineFold.hs
@@ -26,6 +26,12 @@ module Optics.IxAffineFold
   -- 'ipreview' ('iafolding' f) ≡ f
   -- @
 
+  -- * Additional introduction forms
+  , iafoldVL
+
+  -- * Additional elimination forms
+  , iatraverseOf_
+
   -- * Semigroup structure
   , iafailing
 
@@ -43,6 +49,18 @@ import Optics.Internal.Utils
 
 -- | Type synonym for an indexed affine fold.
 type IxAffineFold i s a = Optic' An_AffineFold (WithIx i) s a
+
+-- | Obtain an 'IxAffineFold' by lifting 'itraverse_' like function.
+--
+-- @
+-- 'aifoldVL' '.' 'iatraverseOf_' ≡ 'id'
+-- 'aitraverseOf_' '.' 'iafoldVL' ≡ 'id'
+-- @
+iafoldVL
+  :: (forall f. Functor f => (forall r. r -> f r) -> (i -> a -> f u) -> s -> f v)
+  -> IxAffineFold i s a
+iafoldVL f = Optic (rphantom . ivisit f . rphantom)
+{-# INLINE iafoldVL #-}
 
 -- | Retrieve the value along with its index targeted by an 'IxAffineFold'.
 ipreview
@@ -63,11 +81,20 @@ ipreviews o = \f -> runIxForgetM
   id
 {-# INLINE ipreviews #-}
 
+-- | Traverse over the target of an 'IxAffineFold', computing a 'Functor'-based
+-- answer, but unlike 'Optics.IxAffineTraversal.iatraverseOf' do not construct a
+-- new structure.
+iatraverseOf_
+  :: (Is k An_AffineFold, Functor f, is `HasSingleIndex` i)
+  => Optic' k is s a
+  -> (forall r. r -> f r) -> (i -> a -> f u) -> s -> f ()
+iatraverseOf_ o point f s = case ipreview o s of
+  Just (i, a) -> () <$ f i a
+  Nothing     -> point ()
+
 -- | Create an 'IxAffineFold' from a partial function.
 iafolding :: (s -> Maybe (i, a)) -> IxAffineFold i s a
-iafolding g = Optic
-  $ ivisit (\point f s -> maybe (point s) (uncurry' f) $ g s)
-  . rphantom
+iafolding g = iafoldVL (\point f s -> maybe (point s) (uncurry' f) $ g s)
 {-# INLINE iafolding #-}
 
 -- | Try the first 'IxAffineFold'. If it returns no entry, try the second one.

--- a/optics-core/src/Optics/IxAffineFold.hs
+++ b/optics-core/src/Optics/IxAffineFold.hs
@@ -32,6 +32,9 @@ module Optics.IxAffineFold
   -- * Additional elimination forms
   , iatraverseOf_
 
+  -- * Combinators
+  , filteredBy
+
   -- * Semigroup structure
   , iafailing
 
@@ -96,6 +99,14 @@ iatraverseOf_ o point f s = case ipreview o s of
 iafolding :: (s -> Maybe (i, a)) -> IxAffineFold i s a
 iafolding g = iafoldVL (\point f s -> maybe (point s) (uncurry' f) $ g s)
 {-# INLINE iafolding #-}
+
+-- | Obtain a potentially empty 'IxAffineFold' by taking the element from
+-- another 'AffineFold' and using it as an index.
+filteredBy :: Is k An_AffineFold  => Optic' k is a i -> IxAffineFold i a a
+filteredBy p = iafoldVL $ \point f s -> case preview p s of
+  Just i  -> f i s
+  Nothing -> point s
+{-# INLINE filteredBy #-}
 
 -- | Try the first 'IxAffineFold'. If it returns no entry, try the second one.
 --

--- a/optics-core/src/Optics/IxAffineTraversal.hs
+++ b/optics-core/src/Optics/IxAffineTraversal.hs
@@ -37,7 +37,7 @@ module Optics.IxAffineTraversal
   , IxAffineTraversalVL
   , IxAffineTraversalVL'
   , iatraversalVL
-  , toIxAtraversalVL
+  , iatraverseOf
   ) where
 
 import Data.Profunctor.Indexed
@@ -80,11 +80,12 @@ iatraversalVL :: IxAffineTraversalVL i s t a b -> IxAffineTraversal i s t a b
 iatraversalVL f = Optic (ivisit f)
 {-# INLINE iatraversalVL #-}
 
--- | Convert an indexed affine traversal to its van Laarhoven representation.
-toIxAtraversalVL
-  :: (Is k An_AffineTraversal, is `HasSingleIndex` i)
+-- | Traverse over the target of an 'IxAffineTraversal' and compute a
+-- 'Functor'-based answer.
+iatraverseOf
+  :: (Is k An_AffineTraversal, Functor f, is `HasSingleIndex` i)
   => Optic k is s t a b
-  -> IxAffineTraversalVL i s t a b
-toIxAtraversalVL o point = \f ->
+  -> (forall r. r -> f r) -> (i -> a -> f b) -> s -> f t
+iatraverseOf o point = \f ->
   runIxStarA (getOptic (castOptic @An_AffineTraversal o) (IxStarA point f)) id
-{-# INLINE toIxAtraversalVL #-}
+{-# INLINE iatraverseOf #-}

--- a/optics/tests/Optics/Tests/Misc.hs
+++ b/optics/tests/Optics/Tests/Misc.hs
@@ -25,6 +25,10 @@ miscTests = testGroup "Miscellaneous"
     ghc80failure $(inspectTest $ hasNoProfunctors 'checkPartsOf)
   , testCase "optimized singular" $
     ghc80failure $(inspectTest $ hasNoProfunctors 'checkSingular)
+  , testCase "optimized filteredBy" $
+    assertSuccess $(inspectTest $ hasNoProfunctors 'checkFilteredBy)
+  , testCase "optimized unsafeFilteredBy" $
+    assertSuccess $(inspectTest $ hasNoProfunctors 'checkUnsafeFilteredBy)
   ]
 
 simpleMapIx
@@ -53,3 +57,17 @@ checkSingular
   => Either (f (a, Char)) b
   -> Either (f (a, Char)) b
 checkSingular = singular (_Left % traversed % _2) .~ 'x'
+
+checkFilteredBy
+  :: Applicative f
+  => ((Maybe i, b) -> f r)
+  -> (Maybe i, b)
+  -> f ()
+checkFilteredBy = atraverseOf_ (filteredBy (_1 % _Just)) pure
+
+checkUnsafeFilteredBy
+  :: Applicative f
+  => (i -> Either a1 (a, Maybe i) -> f (Either a1 (a, Maybe i)))
+  -> Either a1 (a, Maybe i)
+  -> f (Either a1 (a, Maybe i))
+checkUnsafeFilteredBy = iatraverseOf (unsafeFilteredBy (_Right % _2 % _Just)) pure


### PR DESCRIPTION
Fixes #293.

Note that the first commit breaks API as it renames two existing functions, but they're obscure enough that I'm pretty sure (almost) no one has used them.

Their new names correspond nicely with appropriate Fold/Traversal functions, so IMO it's worth it.