### PR TITLE
Document monoidal structures of Folds

### DIFF
--- a/optics-core/src/Optics/AffineFold.hs
+++ b/optics-core/src/Optics/AffineFold.hs
@@ -33,7 +33,16 @@ module Optics.AffineFold
   , atraverseOf_
   , isn't
 
-    -- * Semigroup structure
+  -- * Monoid structure
+  -- | 'AffineFold' admits a monoid structure where 'afailing' combines folds
+  -- (returning a result from the second fold only if the first returns none)
+  -- and the identity element is 'Optics.IxAffineTraversal.ignored' (which
+  -- returns no results).
+  --
+  -- /Note:/ There is no 'Optics.Fold.summing' equivalent that returns an
+  -- 'AffineFold', because it would not need to return more than one result.
+  --
+  -- There is no 'Semigroup' or 'Monoid' instance for 'AffineFold'.
   , afailing
 
   -- * Subtyping
@@ -115,8 +124,6 @@ filtered p = afoldVL (\point f a -> if p a then f a else point a)
 --
 -- >>> preview (ix 42 % re _Left `afailing` ix 2 % re _Right) [0,1,2,3]
 -- Just (Right 2)
---
--- /Note:/ There is no 'Optics.Fold.summing' equivalent, because @asumming = afailing@.
 --
 afailing
   :: (Is k An_AffineFold, Is l An_AffineFold)

--- a/optics-core/src/Optics/AffineFold.hs
+++ b/optics-core/src/Optics/AffineFold.hs
@@ -42,7 +42,10 @@ module Optics.AffineFold
   -- /Note:/ There is no 'Optics.Fold.summing' equivalent that returns an
   -- 'AffineFold', because it would not need to return more than one result.
   --
-  -- There is no 'Semigroup' or 'Monoid' instance for 'AffineFold'.
+  -- There is no 'Semigroup' or 'Monoid' instance for 'AffineFold', because
+  -- there is not a unique choice of monoid to use that works for all optics,
+  -- and the ('<>') operator could not be used to combine optics of different
+  -- kinds.
   , afailing
 
   -- * Subtyping

--- a/optics-core/src/Optics/Fold.hs
+++ b/optics-core/src/Optics/Fold.hs
@@ -76,7 +76,7 @@ module Optics.Fold
   , backwards_
 
   -- * Monoid structures
-  -- | 'Fold' admits (at least) two monoid structures:
+  -- | 'Fold' admits (at least) two monoid structures: #monoids#
   --
   -- * 'summing' concatenates results from both folds.
   --
@@ -86,8 +86,10 @@ module Optics.Fold
   -- In both cases, the identity element of the monoid is
   -- `Optics.IxAffineTraversal.ignored`, which returns no results.
   --
-  -- There is no 'Semigroup' or 'Monoid' instance for 'Fold'.  When porting code
-  -- from @lens@ that uses '<>' to combine folds, use 'summing' instead.
+  -- There is no 'Semigroup' or 'Monoid' instance for 'Fold', because there is
+  -- not a unique choice of monoid to use, and the ('<>') operator could not be
+  -- used to combine optics of different kinds.  When porting code from @lens@
+  -- that uses '<>' to combine folds, use 'summing' instead.
   , summing
   , failing
 

--- a/optics-core/src/Optics/Fold.hs
+++ b/optics-core/src/Optics/Fold.hs
@@ -75,7 +75,19 @@ module Optics.Fold
   , pre
   , backwards_
 
-  -- * Semigroup structure
+  -- * Monoid structures
+  -- | 'Fold' admits (at least) two monoid structures:
+  --
+  -- * 'summing' concatenates results from both folds.
+  --
+  -- * 'failing' returns results from the second fold only if the first returns
+  --   no results.
+  --
+  -- In both cases, the identity element of the monoid is
+  -- `Optics.IxAffineTraversal.ignored`, which returns no results.
+  --
+  -- There is no 'Semigroup' or 'Monoid' instance for 'Fold'.  When porting code
+  -- from @lens@ that uses '<>' to combine folds, use 'summing' instead.
   , summing
   , failing
 
@@ -263,6 +275,12 @@ infixr 6 `summing` -- Same as (<>)
 {-# INLINE summing #-}
 
 -- | Try the first 'Fold'. If it returns no entries, try the second one.
+--
+-- >>> toListOf (ix 1 `failing` ix 0) [4,7]
+-- [7]
+-- >>> toListOf (ix 1 `failing` ix 0) [4]
+-- [4]
+--
 failing
   :: (Is k A_Fold, Is l A_Fold)
   => Optic' k is s a

--- a/optics-core/src/Optics/IxAffineFold.hs
+++ b/optics-core/src/Optics/IxAffineFold.hs
@@ -44,7 +44,10 @@ module Optics.IxAffineFold
   -- /Note:/ There is no 'Optics.IxFold.isumming' equivalent that returns an
   -- 'IxAffineFold', because it would not need to return more than one result.
   --
-  -- There is no 'Semigroup' or 'Monoid' instance for 'IxAffineFold'.
+  -- There is no 'Semigroup' or 'Monoid' instance for 'IxAffineFold', because
+  -- there is not a unique choice of monoid to use that works for all optics,
+  -- and the ('<>') operator could not be used to combine optics of different
+  -- kinds.
   , iafailing
 
   -- * Subtyping

--- a/optics-core/src/Optics/IxAffineFold.hs
+++ b/optics-core/src/Optics/IxAffineFold.hs
@@ -35,7 +35,16 @@ module Optics.IxAffineFold
   -- * Combinators
   , filteredBy
 
-  -- * Semigroup structure
+  -- * Monoid structure
+  -- | 'IxAffineFold' admits a monoid structure where 'iafailing' combines folds
+  -- (returning a result from the second fold only if the first returns none)
+  -- and the identity element is 'Optics.IxAffineTraversal.ignored' (which
+  -- returns no results).
+  --
+  -- /Note:/ There is no 'Optics.IxFold.isumming' equivalent that returns an
+  -- 'IxAffineFold', because it would not need to return more than one result.
+  --
+  -- There is no 'Semigroup' or 'Monoid' instance for 'IxAffineFold'.
   , iafailing
 
   -- * Subtyping
@@ -110,7 +119,6 @@ filteredBy p = iafoldVL $ \point f s -> case preview p s of
 
 -- | Try the first 'IxAffineFold'. If it returns no entry, try the second one.
 --
--- /Note:/ There is no 'Optics.IxFold.isumming' equivalent, because @iasumming = iafailing@.
 iafailing
   :: (Is k An_AffineFold, Is l An_AffineFold,
       is1 `HasSingleIndex` i, is2 `HasSingleIndex` i)

--- a/optics-core/src/Optics/IxAffineTraversal.hs
+++ b/optics-core/src/Optics/IxAffineTraversal.hs
@@ -112,7 +112,12 @@ unsafeFilteredBy p = iatraversalVL $ \point f s -> case preview p s of
   Nothing -> point s
 {-# INLINE unsafeFilteredBy #-}
 
--- | This is the trivial empty 'IxAffineTraversal'.
+-- | This is the trivial empty 'IxAffineTraversal', i.e. the optic that targets
+-- no substructures.
+--
+-- This is the identity element when a 'Optics.Fold.Fold',
+-- 'Optics.AffineFold.AffineFold', 'Optics.IxFold.IxFold' or
+-- 'Optics.IxAffineFold.IxAffineFold' is viewed as a monoid.
 --
 -- >>> 6 & ignored %~ absurd
 -- 6

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -55,7 +55,9 @@ module Optics.IxFold
   -- In both cases, the identity element of the monoid is
   -- `Optics.IxAffineTraversal.ignored`, which returns no results.
   --
-  -- There is no 'Semigroup' or 'Monoid' instance for 'IxFold'.
+  -- There is no 'Semigroup' or 'Monoid' instance for 'IxFold', because there is
+  -- not a unique choice of monoid to use, and the ('<>') operator could not be
+  -- used to combine optics of different kinds.
   , isumming
   , ifailing
 

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -44,7 +44,18 @@ module Optics.IxFold
   , ifiltered
   , ibackwards_
 
-  -- * Semigroup structure
+  -- * Monoid structures
+  -- | 'IxFold' admits (at least) two monoid structures:
+  --
+  -- * 'isumming' concatenates results from both folds.
+  --
+  -- * 'ifailing' returns results from the second fold only if the first returns
+  --   no results.
+  --
+  -- In both cases, the identity element of the monoid is
+  -- `Optics.IxAffineTraversal.ignored`, which returns no results.
+  --
+  -- There is no 'Semigroup' or 'Monoid' instance for 'IxFold'.
   , isumming
   , ifailing
 
@@ -228,6 +239,10 @@ ibackwards_ o = conjoined (backwards_ o) $ ifoldVL $ \f ->
 {-# INLINE ibackwards_ #-}
 
 -- | Return entries of the first 'IxFold', then the second one.
+--
+-- >>> itoListOf (ifolded `isumming` ibackwards_ ifolded) ["a","b"]
+-- [(0,"a"),(1,"b"),(1,"b"),(0,"a")]
+--
 isumming
   :: (Is k A_Fold, Is l A_Fold,
       is1 `HasSingleIndex` i, is2 `HasSingleIndex` i)
@@ -240,6 +255,12 @@ infixr 6 `isumming` -- Same as (<>)
 {-# INLINE isumming #-}
 
 -- | Try the first 'IxFold'. If it returns no entries, try the second one.
+--
+-- >>> itoListOf (_1 % ifolded `ifailing` _2 % ifolded) (["a"], ["b","c"])
+-- [(0,"a")]
+-- >>> itoListOf (_1 % ifolded `ifailing` _2 % ifolded) ([], ["b","c"])
+-- [(0,"b"),(1,"c")]
+--
 ifailing
   :: (Is k A_Fold, Is l A_Fold, is1 `HasSingleIndex` i, is2 `HasSingleIndex` i)
   => Optic' k is1 s a

--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -34,6 +34,14 @@ module Optics.Optic
   , Join
 
   -- * Composition
+  -- | The usual operator for composing optics is ('%'), which allows different
+  -- optic kinds to be composed, automatically calculating the resulting optic
+  -- kind using 'Join'.
+  --
+  -- The ('.') function composition operator cannot be used to compose optics,
+  -- because /optics are not functions/.  The ('Control.Category..') operator
+  -- from "Control.Category" cannot be used either, because it would not support
+  -- type-changing optics or composing optics of different kinds.
   , (%)
   , (%%)
   , (%&)

--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -38,6 +38,13 @@ module Optics.Optic
   , (%%)
   , (%&)
 
+  -- * Monoid structures
+  -- | 'Optics.Fold.Fold'-like optics admit various monoid structures (e.g. see
+  -- "Optics.Fold#monoids").  There is no 'Semigroup' or 'Monoid' instance for
+  -- 'Optic', however, because there is not a unique choice of monoid to use,
+  -- and the ('<>') operator could not be used to combine optics of different
+  -- kinds.
+
   -- * Indexed optics
   -- | See the "Indexed optics" section of the overview documentation in the
   -- @Optics@ module of the main @optics@ package for more details on indexed

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -541,6 +541,10 @@ import Data.Either.Optics                    as P
 -- ...
 -- ...A_Setter cannot be composed with A_Fold
 -- ...
+--
+-- The ('Control.Category..') operator from "Control.Category" cannot be used to
+-- compose optics either, because it would not support type-changing optics or
+-- composing optics of different kinds.
 
 -- $lens_comparison
 --

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -716,6 +716,9 @@ import Data.Either.Optics                    as P
 --
 -- * 'singular' ('isingular' for indexed optics) doesn't produce a partial lens
 --   that might fail with a runtime error, but an affine traversal.
+--
+-- * '<>' cannot be used to combine 'Fold's, so 'summing' should be used
+--   instead.
 
 
 -- $otherresources


### PR DESCRIPTION
Fixes #244. I came across some `lens` code using `<>` and wondered what the equivalent in `optics` would look like...