### PR TITLE
Add GeneralLabelOptic for pluggable generic optics as labels

### DIFF
--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -25,6 +25,14 @@ type WithIx i = ('[i] :: IxList)
 type family QuoteType (x :: Type) :: ErrorMessage where
   QuoteType x = 'Text "‘" ':<>: 'ShowType x ':<>: 'Text "’"
 
+data RepDefined = RepDefined
+-- | This type family should be called with applications of 'Rep' on both sides,
+-- and will reduce to 'RepDefined' if at least one of them is defined; otherwise
+-- it is stuck.
+type family AnyHasRep (s :: Type -> Type) (t :: Type -> Type) :: RepDefined
+type instance AnyHasRep (s x) t = 'RepDefined
+type instance AnyHasRep s (t x) = 'RepDefined
+
 -- | Curry a type-level list.
 --
 -- In pseudo (dependent-)Haskell:


### PR DESCRIPTION
Extracts from #290 stuff needed to plug in generic optics as labels.

I modified it slightly, i.e. added `RepDefined` type as a witness for clarity.

Looks like https://gitlab.haskell.org/ghc/ghc/-/merge_requests/2965 will go in after a few adjustments, so generic optics might be a viable choice (eventually).