### PR TITLE
Release 0.3

### DIFF
--- a/optics-core/CHANGELOG.md
+++ b/optics-core/CHANGELOG.md
@@ -1,19 +1,25 @@
-# optics-core-0.3 (TBD)
+# optics-core-0.3 (2020-04-15)
 * GHC-8.10 support
 * Add `filteredBy` and `unsafeFilteredBy`
-* Add indexed instances for `Const` and `Constant`
+* Add `FunctorWithIndex`, `FoldableWithIndex` and `TraversableWithIndex`
+  instances for `Const` and `Constant`
 * Add `afoldVL` and `iafoldVL` constructors
 * Rename `toAtraversalVL` to `atraverseOf`, and `toIxAtraversalVL` to `iatraverseOf`
-* `element` and `elementOf` construct `(Ix)AffineTraversal`
-* Change `mapping` to work also on `Lens` and `Prism` degenerating to `Getter` and `Review`.
+* Generalise `element` and `elementOf` to construct `IxAffineTraversal`s
+  instead of `IxTraversal`s
+* Change `mapping` to work on optic kinds other than `Iso`: it now supports
+  `Lens` and `Prism` degenerating to `Getter` and `Review` respectively
 * Generalise `ignored` to be an `IxAffineTraversal` instead of an `IxTraversal`
 * Add `singular` and `isingular`
 * Add `(^?!)` operator
 * Expose `Curry` and `CurryCompose`
 * Show expected elimination forms on optic kind mismatch
-* Add GeneralLabelOptic for pluggable generic optics as labels
-* Document monoidal structures of Folds
-* Remove proxy argument from implies
+* Use stricter `uncurry'` for better performance
+* Add hidden `LabelOptic` instance to postpone instance resolution
+* Add `GeneralLabelOptic` for pluggable generic optics as labels
+* Document monoidal structures of `Fold`s
+* Remove proxy argument from `implies`
+* Add `itoList`
 
 # optics-core-0.2 (2019-10-18)
 * Add `non`, `non'` and `anon` to `Optics.Iso`

--- a/optics-core/src/Optics/IxAffineFold.hs
+++ b/optics-core/src/Optics/IxAffineFold.hs
@@ -118,6 +118,8 @@ iafolding g = iafoldVL (\point f s -> maybe (point s) (uncurry' f) $ g s)
 
 -- | Obtain a potentially empty 'IxAffineFold' by taking the element from
 -- another 'AffineFold' and using it as an index.
+--
+-- @since 0.3
 filteredBy :: Is k An_AffineFold  => Optic' k is a i -> IxAffineFold i a a
 filteredBy p = iafoldVL $ \point f s -> case preview p s of
   Just i  -> f i s

--- a/optics-extra/CHANGELOG.md
+++ b/optics-extra/CHANGELOG.md
@@ -1,12 +1,10 @@
-# optics-extra-0.3 (TBD)
+# optics-extra-0.3 (2020-04-15)
 * `optics-core-0.3` compatible release
 * GHC-8.10 support
-* Use stricter uncurry for better performance
+* Use stricter `uncurry'` for better performance
 
-# optics-extra-0.2
+# optics-extra-0.2 (2019-10-18)
 * `optics-core-0.2` compatible release
-
-# optics-extra-0.1 (2019-10-18)
 * Move `use` from `Optics.View` to `Optics.State` and restrict its type
 * Add `preuse` to `Optics.State`
 * Rename `use`, `uses`, `listening` and `listenings` to reflect the fact that

--- a/optics-th/CHANGELOG.md
+++ b/optics-th/CHANGELOG.md
@@ -1,6 +1,11 @@
-# optics-th-0.3 (TBD)
+# optics-th-0.3 (2020-04-15)
 * `optics-core-0.3` compatible release
 * GHC-8.10 support
+* Improvements to TH-generated optics:
+  - `LabelOptic` instances make optic kind a type equality for better type inference
+  - `LabelOptic` instances for field optics work properly in the presence of type families
+  - Fixed calculation of phantom types in `LabelOptic` prism instances
+  - Better support for generating optics in the presence of kind polymorphism
 
 # optics-th-0.2 (2019-10-18)
 * Add `noPrefixFieldLabels` and `noPrefixNamer` to `Optics.TH`

--- a/optics-vl/CHANGELOG.md
+++ b/optics-vl/CHANGELOG.md
@@ -1,5 +1,5 @@
-# optics-vl-0.2 (TBD)
-* Provide conversions from Iso/Prism to their VL representation
+# optics-vl-0.2.1 (2020-04-15)
+* Provide conversions from `Iso`/`Prism` to their VL representation
 
 # optics-vl-0.2 (2019-10-18)
 * Depend on new `indexed-profunctors` package

--- a/optics/CHANGELOG.md
+++ b/optics/CHANGELOG.md
@@ -1,20 +1,30 @@
-# optics-0.3 (TBD)
+# optics-0.3 (2020-04-15)
 * GHC-8.10 support
 * Add `filteredBy` and `unsafeFilteredBy`
-* Add indexed instances for `Const` and `Constant`
+* Add `FunctorWithIndex`, `FoldableWithIndex` and `TraversableWithIndex`
+  instances for `Const` and `Constant`
 * Add `afoldVL` and `iafoldVL` constructors
 * Rename `toAtraversalVL` to `atraverseOf`, and `toIxAtraversalVL` to `iatraverseOf`
-* `element` and `elementOf` construct `(Ix)AffineTraversal`
-* Change `mapping` to work also on `Lens` and `Prism` degenerating to `Getter` and `Review`.
+* Generalise `element` and `elementOf` to construct `IxAffineTraversal`s
+  instead of `IxTraversal`s
+* Change `mapping` to work on optic kinds other than `Iso`: it now supports
+  `Lens` and `Prism` degenerating to `Getter` and `Review` respectively
 * Generalise `ignored` to be an `IxAffineTraversal` instead of an `IxTraversal`
 * Add `singular` and `isingular`
 * Add `(^?!)` operator
 * Expose `Curry` and `CurryCompose`
 * Show expected elimination forms on optic kind mismatch
-* Use stricter uncurry for better performance
-* Add GeneralLabelOptic for pluggable generic optics as labels
-* Document monoidal structures of Folds
-* Remove proxy argument from implies
+* Use stricter `uncurry` for better performance
+* Add hidden `LabelOptic` instance to postpone instance resolution
+* Add `GeneralLabelOptic` for pluggable generic optics as labels
+* Document monoidal structures of `Fold`s
+* Remove proxy argument from `implies`
+* Add `itoList`
+* Improvements to TH-generated optics:
+  - `LabelOptic` instances make optic kind a type equality for better type inference
+  - `LabelOptic` instances for field optics work properly in the presence of type families
+  - Fixed calculation of phantom types in `LabelOptic` prism instances
+  - Better support for generating optics in the presence of kind polymorphism
 
 # optics-0.2 (2019-10-18)
 * Add `non`, `non'` and `anon` to `Optics.Iso`


### PR DESCRIPTION
I propose ~~Monday~~Wednesday as the release date and have updated things appropriately and uploaded tentative package candidates. ~~The only significant change is that I propose to release `optics-vl` as `0.3` instead of `0.2.1`. While in theory the latter is permissible, it doesn't seem worth deviating from the version numbering of the other packages at this point. Please shout if you disagree.~~

* https://hackage.haskell.org/package/optics-core-0.3/candidate
* https://hackage.haskell.org/package/optics-extra-0.3/candidate
* https://hackage.haskell.org/package/optics-th-0.3/candidate
* https://hackage.haskell.org/package/optics-0.3/candidate
* https://hackage.haskell.org/package/optics-vl-0.2.1/candidate