### PR TITLE
Make generation of LabelOptic instances aware of injective type families  and polymorphic kinds

### DIFF
--- a/optics-th/optics-th.cabal
+++ b/optics-th/optics-th.cabal
@@ -54,6 +54,7 @@ test-suite optics-th-tests
   build-depends: base
                , optics-core
                , optics-th
+               , tagged
 
   type:    exitcode-stdio-1.0
   main-is: Optics/TH/Tests.hs

--- a/optics-th/src/Language/Haskell/TH/Optics/Internal.hs
+++ b/optics-th/src/Language/Haskell/TH/Optics/Internal.hs
@@ -5,7 +5,7 @@ module Language.Haskell.TH.Optics.Internal
   -- * Traversals
     HasTypeVars(..)
   , typeVars      -- :: HasTypeVars t => Traversal' t Name
-  , typeVarBndrs
+  , typeVarsKinded
   , substTypeVars -- :: HasTypeVars t => Map Name Name -> t -> t
   , SubstType(..)
 
@@ -87,8 +87,8 @@ typeVars :: HasTypeVars t => Traversal' t Name
 typeVars = typeVarsEx mempty
 
 -- | Traverse /free/ type variables paired with their kinds if applicable.
-typeVarBndrs :: Fold Type Type
-typeVarBndrs = foldVL $ go mempty
+typeVarsKinded :: Fold Type Type
+typeVarsKinded = foldVL $ go mempty
   where
     go s f = \case
       var@(VarT n)          -> if n `Set.member` s then pure () else f var

--- a/optics-th/src/Language/Haskell/TH/Optics/Internal.hs
+++ b/optics-th/src/Language/Haskell/TH/Optics/Internal.hs
@@ -55,7 +55,8 @@ instance HasTypeVars Type where
     VarT n            -> VarT <$> traverseOf (typeVarsEx s) f n
     AppT l r          -> AppT <$> traverseOf (typeVarsEx s) f l
                               <*> traverseOf (typeVarsEx s) f r
-    SigT t k          -> (`SigT` k) <$> traverseOf (typeVarsEx s) f t
+    SigT t k          -> SigT <$> traverseOf (typeVarsEx s) f t
+                              <*> traverseOf (typeVarsEx s) f k
     ForallT bs ctx ty -> let s' = s `Set.union` setOf typeVars bs
                          in ForallT bs <$> traverseOf (typeVarsEx s') f ctx
                                        <*> traverseOf (typeVarsEx s') f ty

--- a/optics-th/src/Optics/TH/Internal/Product.hs
+++ b/optics-th/src/Optics/TH/Internal/Product.hs
@@ -878,22 +878,3 @@ addFieldClassName n = modify $ S.insert n
 -- We want to catch type families, but not *data* families. See #799.
 typeFamilyHead :: AffineFold Dec TypeFamilyHead
 typeFamilyHead = _OpenTypeFamilyD `afailing` _ClosedTypeFamilyD % _1
-
--- | Template Haskell wants type variables declared in a forall, so
--- we find all free type variables in a given type and declare them.
-quantifyType :: [TyVarBndr] -> Cxt -> Type -> Type
-quantifyType = quantifyType' S.empty
-
--- | This function works like 'quantifyType' except that it takes
--- a list of variables to exclude from quantification.
-quantifyType' :: S.Set Name -> [TyVarBndr] -> Cxt -> Type -> Type
-quantifyType' exclude vars cx t = ForallT vs cx t
-  where
-    vs = filter (\v -> bndrName v `S.notMember` exclude)
-       . D.freeVariablesWellScoped
-       . (map bndrToType vars ++)
-       . S.toList
-       $ setOf typeVarsKinded t
-
-    bndrToType (PlainTV n)    = VarT n
-    bndrToType (KindedTV n k) = SigT (VarT n) k

--- a/optics-th/src/Optics/TH/Internal/Product.hs
+++ b/optics-th/src/Optics/TH/Internal/Product.hs
@@ -893,7 +893,7 @@ quantifyType' exclude vars cx t = ForallT vs cx t
        . D.freeVariablesWellScoped
        . (map bndrToType vars ++)
        . S.toList
-       $ setOf typeVarBndrs t
+       $ setOf typeVarsKinded t
 
     bndrToType (PlainTV n)    = VarT n
     bndrToType (KindedTV n k) = SigT (VarT n) k

--- a/optics-th/src/Optics/TH/Internal/Sum.hs
+++ b/optics-th/src/Optics/TH/Internal/Sum.hs
@@ -83,7 +83,7 @@ makeClassyPrisms = makePrisms' False
 makePrismLabels :: Name -> DecsQ
 makePrismLabels typeName = do
   info <- D.reifyDatatype typeName
-  let cons = map normalizeCon $ D.datatypeCons info
+  let cons = map (normalizeCon info) $ D.datatypeCons info
   catMaybes <$> traverse (makeLabel info cons) cons
   where
     makeLabel :: D.DatatypeInfo -> [NCon] -> NCon -> Q (Maybe Dec)
@@ -104,7 +104,7 @@ makePrismLabels typeName = do
                              instHead
                              (fun stab 'labelOptic)
       where
-        ty        = D.datatypeType info
+        ty        = addKindVars info $ D.datatypeType info
         isNewtype = D.datatypeVariant info == D.Newtype
 
         opticTypeToTag IsoType    = ''An_Iso
@@ -126,7 +126,7 @@ makePrisms' normal typeName =
      let cls | normal    = Nothing
              | otherwise = Just (D.datatypeName info)
          cons = D.datatypeCons info
-     makeConsPrisms info (map normalizeCon cons) cls
+     makeConsPrisms info (map (normalizeCon info) cons) cls
 
 
 -- | Generate prisms for the given 'Dec'
@@ -136,7 +136,7 @@ makeDecPrisms normal dec =
      let cls | normal    = Nothing
              | otherwise = Just (D.datatypeName info)
          cons = D.datatypeCons info
-     makeConsPrisms info (map normalizeCon cons) cls
+     makeConsPrisms info (map (normalizeCon info) cons) cls
 
 -- | Generate prisms for the given type, normalized constructors, and an
 -- optional name to be used for generating a prism class. This function
@@ -156,7 +156,7 @@ makeConsPrisms info cons Nothing = fmap concat . for cons $ \con -> do
     , valD (varP n) (normalB body) []
     ] ++ inlinePragma n
   where
-    ty        = D.datatypeType info
+    ty        = addKindVars info $ D.datatypeType info
     isNewtype = D.datatypeVariant info == D.Newtype
 
 -- classy prism class and instance
@@ -216,9 +216,9 @@ stabToType stab@(Stab cx ty s t a b) = ForallT vs cx $
     ReviewType                   -> ''Review  `conAppsT` [t,b]
 
   where
-  vs = map PlainTV
-     $ nub -- stable order
-     $ toListOf typeVars cx
+    vs = D.freeVariablesWellScoped
+       . S.toList
+       $ setOf (folded % typeVarBndrs) cx
 
 stabType :: Stab -> OpticType
 stabType (Stab _ o _ _ _ _) = o
@@ -249,6 +249,12 @@ computePrismType conf t cx cons con = do
   sub <- sequenceA (M.fromSet (newName . nameBase) unbound)
   b   <- toTupleT (map return ts)
   a   <- toTupleT (map return (substTypeVars sub ts))
+  --runIO $ do
+  --  putStrLn $ "T:        " ++ show t
+  --  putStrLn $ "B:        " ++ show b
+  --  putStrLn $ "FIXED:    " ++ show fixed
+  --  putStrLn $ "PHANTOMS: " ++ show phantoms
+  --  putStrLn $ "UNBOUND:  " ++ show unbound
   let s = substTypeVars sub t
       otype = if null cons && scAllowIsos conf
               then IsoType
@@ -477,11 +483,11 @@ nconTypes = lensVL $ \f x -> fmap (\y -> x {_nconTypes = y}) (f (_nconTypes x))
 
 
 -- | Normalize a single 'Con' to its constructor name and field types.
-normalizeCon :: D.ConstructorInfo -> NCon
-normalizeCon info = NCon (D.constructorName info)
-                         (D.tvName <$> D.constructorVars info)
-                         (D.constructorContext info)
-                         (D.constructorFields info)
+normalizeCon :: D.DatatypeInfo -> D.ConstructorInfo -> NCon
+normalizeCon di info = NCon (D.constructorName info)
+                            (D.tvName <$> D.constructorVars info)
+                            (D.constructorContext info)
+                            (map (addKindVars di) $ D.constructorFields info)
 
 
 -- | Compute a prism's name by prefixing an underscore for normal
@@ -495,6 +501,8 @@ prismName n = case nameBase n of
 
 -- | Quantify all the free variables in a type.
 close :: Type -> TypeQ
-close t = forallT (map PlainTV (S.toList vs)) (cxt[]) (return t)
+close t = forallT vs (cxt[]) (return t)
   where
-  vs = setOf typeVars t
+    vs = D.freeVariablesWellScoped
+       . S.toList
+       $ setOf typeVarBndrs t

--- a/optics-th/src/Optics/TH/Internal/Sum.hs
+++ b/optics-th/src/Optics/TH/Internal/Sum.hs
@@ -218,7 +218,7 @@ stabToType stab@(Stab cx ty s t a b) = ForallT vs cx $
   where
     vs = D.freeVariablesWellScoped
        . S.toList
-       $ setOf (folded % typeVarBndrs) cx
+       $ setOf (folded % typeVarsKinded) cx
 
 stabType :: Stab -> OpticType
 stabType (Stab _ o _ _ _ _) = o
@@ -505,4 +505,4 @@ close t = forallT vs (cxt[]) (return t)
   where
     vs = D.freeVariablesWellScoped
        . S.toList
-       $ setOf typeVarBndrs t
+       $ setOf typeVarsKinded t

--- a/optics-th/src/Optics/TH/Internal/Utils.hs
+++ b/optics-th/src/Optics/TH/Internal/Utils.hs
@@ -1,7 +1,12 @@
 module Optics.TH.Internal.Utils where
 
+import Data.Maybe
 import Language.Haskell.TH
+import qualified Data.Map as M
 import qualified Language.Haskell.TH.Datatype as D
+
+import Language.Haskell.TH.Optics.Internal
+import Optics.Core
 
 -- | Apply arguments to a type constructor
 appsT :: TypeQ -> [TypeQ] -> TypeQ
@@ -48,6 +53,14 @@ eqSubst ty n = do
   placeholder <- VarT <$> newName n
   pure (placeholder, D.equalPred placeholder ty)
 
+-- | Fill in kind variables using info from datatype type parameters.
+addKindVars :: D.DatatypeInfo -> Type -> Type
+addKindVars = substType . M.fromList . mapMaybe var . D.datatypeInstTypes
+  where
+    var t@(SigT (VarT n) k)
+      | has typeVars k = Just (n, t)
+      | otherwise      = Nothing
+    var _              = Nothing
 
 ------------------------------------------------------------------------
 -- Support for generating inline pragmas

--- a/optics-th/src/Optics/TH/Internal/Utils.hs
+++ b/optics-th/src/Optics/TH/Internal/Utils.hs
@@ -3,8 +3,10 @@ module Optics.TH.Internal.Utils where
 import Data.Maybe
 import Language.Haskell.TH
 import qualified Data.Map as M
+import qualified Data.Set as S
 import qualified Language.Haskell.TH.Datatype as D
 
+import Data.Set.Optics
 import Language.Haskell.TH.Optics.Internal
 import Optics.Core
 
@@ -61,6 +63,23 @@ addKindVars = substType . M.fromList . mapMaybe var . D.datatypeInstTypes
       | has typeVars k = Just (n, t)
       | otherwise      = Nothing
     var _              = Nothing
+
+-- | Template Haskell wants type variables declared in a forall, so
+-- we find all free type variables in a given type and declare them.
+quantifyType :: [TyVarBndr] -> Cxt -> Type -> Type
+quantifyType = quantifyType' S.empty
+
+-- | This function works like 'quantifyType' except that it takes
+-- a list of variables to exclude from quantification.
+quantifyType' :: S.Set Name -> [TyVarBndr] -> Cxt -> Type -> Type
+quantifyType' exclude vars cx t = ForallT vs cx t
+  where
+    vs = filter (\v -> bndrName v `S.notMember` exclude)
+       . D.freeVariablesWellScoped
+       $ map bndrToType vars ++ S.toList (setOf typeVarsKinded t)
+
+    bndrToType (PlainTV n)    = VarT n
+    bndrToType (KindedTV n k) = SigT (VarT n) k
 
 ------------------------------------------------------------------------
 -- Support for generating inline pragmas

--- a/optics-th/tests/Optics/TH/Tests.hs
+++ b/optics-th/tests/Optics/TH/Tests.hs
@@ -464,6 +464,14 @@ checkThing2 = thing
 checkThing2_ :: Lens (Lebowski a) (Lebowski b) (Maybe a) (Maybe b)
 checkThing2_ = #thing
 
+data Kinded0 k = Kinded0
+  { _kinded0Thing :: forall a. Proxy (a :: k)
+  }
+makeLenses ''Kinded0
+
+checkKinded0Thing :: Getter (Kinded0 k) (Proxy (a :: k))
+checkKinded0Thing = kinded0Thing
+
 data Kinded1 (a :: k1) (b :: k2) = Kinded
   { _kinded1Thing :: Tagged '(a, b) Int
   }

--- a/optics-th/tests/Optics/TH/Tests.hs
+++ b/optics-th/tests/Optics/TH/Tests.hs
@@ -142,13 +142,52 @@ checkClassyT2 = _ClassyT2
 checkClassyT3 :: AsClassyTest r => Prism' r Char
 checkClassyT3 = _ClassyT3
 
-data Weird1 (a :: k -> Type) (b :: k -> Type) = Weird1
-data WeirdThing a b = WeirdThing (Weird1 a (Const b))
-makePrisms ''WeirdThing
+data WeirdThing (a :: k -> Type) (b :: k -> Type) = WeirdThing
+data Weird1 a b = Weird1 (WeirdThing a (Const b))
+makePrisms ''Weird1
+makePrismLabels ''Weird1
 
---data FooZ (a :: k -> Type) (b :: k -> Type) where
---  FooZ :: FooZ (a :: Type -> Type) b
---makePrisms ''FooZ
+checkWeird1 :: Iso (Weird1 a  b )
+                   (Weird1 a' b')
+                   (WeirdThing a  (Const b))
+                   (WeirdThing a' (Const b'))
+checkWeird1 = _Weird1
+
+checkWeird1_ :: Iso (Weird1 a  b )
+                    (Weird1 a' b')
+                    (WeirdThing a  (Const b))
+                    (WeirdThing a' (Const b'))
+checkWeird1_ = #_Weird1
+
+data Weird2 (a :: k -> Type) (b :: k -> Type) where
+  Weird2 :: Weird2 (a :: Type -> Type) b
+makePrisms ''Weird2
+makePrismLabels ''Weird2
+
+checkWeird2
+  :: forall k (a  :: k    -> Type)
+              (b  :: k    -> Type)
+              (a' :: Type -> Type)
+              (b' :: Type -> Type)
+   . Iso (Weird2 a b) (Weird2 a' b') () ()
+checkWeird2 = _Weird2
+
+checkWeird2_
+  :: forall (a  :: Type -> Type)
+            (b  :: Type -> Type)
+   . Iso (Weird2 a b) (Weird2 a b) () ()
+checkWeird2_ = #_Weird2
+
+data Weird3 (a :: k) where
+  Weird3 :: Weird3 (a :: Type)
+makePrisms ''Weird3
+makePrismLabels ''Weird3
+
+checkWeird3 :: forall k (a :: k) (b :: Type). Iso (Weird3 a) (Weird3 b) () ()
+checkWeird3 = _Weird3
+
+checkWeird3_ :: forall (a :: Type). Iso (Weird3 a) (Weird3 a) () ()
+checkWeird3_ = #_Weird3
 
 ----------------------------------------
 

--- a/optics-th/tests/Optics/TH/Tests.hs
+++ b/optics-th/tests/Optics/TH/Tests.hs
@@ -8,11 +8,14 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeInType #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- {-# OPTIONS_GHC -ddump-splices #-}
 module Main where
 
+import Data.Functor.Const
+import Data.Kind (Type)
 import Data.Tagged
 import Data.Typeable
 
@@ -138,6 +141,14 @@ checkClassyT2 = _ClassyT2
 
 checkClassyT3 :: AsClassyTest r => Prism' r Char
 checkClassyT3 = _ClassyT3
+
+data Weird1 (a :: k -> Type) (b :: k -> Type) = Weird1
+data WeirdThing a b = WeirdThing (Weird1 a (Const b))
+makePrisms ''WeirdThing
+
+--data FooZ (a :: k -> Type) (b :: k -> Type) where
+--  FooZ :: FooZ (a :: Type -> Type) b
+--makePrisms ''FooZ
 
 ----------------------------------------
 
@@ -453,16 +464,27 @@ checkThing2 = thing
 checkThing2_ :: Lens (Lebowski a) (Lebowski b) (Maybe a) (Maybe b)
 checkThing2_ = #thing
 
-data Kinded (a :: k1) (b :: k2) = Kinded
-  { _kindedThing :: Tagged '(a, b) Int
+data Kinded1 (a :: k1) (b :: k2) = Kinded
+  { _kinded1Thing :: Tagged '(a, b) Int
   }
-makeFieldLabels ''Kinded
+makeFieldLabels ''Kinded1
 
-checkKindedThing :: Iso (Kinded (a  :: k1 ) (b  :: k2 ))
-                        (Kinded (a' :: k1') (b' :: k2'))
-                        (Tagged '(a , b ) Int)
-                        (Tagged '(a', b') Int)
-checkKindedThing = #thing
+checkKinded1Thing :: Iso (Kinded1 (a  :: k1 ) (b  :: k2 ))
+                         (Kinded1 (a' :: k1') (b' :: k2'))
+                         (Tagged '(a , b ) Int)
+                         (Tagged '(a', b') Int)
+checkKinded1Thing = #thing
+
+data Kinded2 k a = Kinded2
+  { _kinded2Thing :: Proxy (a :: k)
+  }
+makeFieldLabels ''Kinded2
+
+checkKinded2Thing :: Iso (Kinded2 k  a )
+                         (Kinded2 k' a')
+                         (Proxy (a  :: k ))
+                         (Proxy (a' :: k'))
+checkKinded2Thing = #thing
 
 type family Fam (a :: k)
 type instance Fam Int = String

--- a/optics-th/tests/Optics/TH/Tests.hs
+++ b/optics-th/tests/Optics/TH/Tests.hs
@@ -3,13 +3,17 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- {-# OPTIONS_GHC -ddump-splices #-}
 module Main where
 
+import Data.Tagged
 import Data.Typeable
 
 import Optics.Core
@@ -452,11 +456,70 @@ checkThing2_ = #thing
 type family Fam a
 type instance Fam Int = String
 
+-- unambiguous type family application
 data FamRec1 a = FamRec1 { _famRec1Thing :: a -> Fam a }
 makeFieldLabels ''FamRec1
 
 checkFamRec1Thing :: Iso (FamRec1 a) (FamRec1 b) (a -> Fam a) (b -> Fam b)
 checkFamRec1Thing = #thing
+
+type family FamInj1 a b = r | r -> a
+
+-- type family injective in its first parameter
+data FamRec2 a b = FamRec2 { _famRec2Thing :: FamInj1 a b }
+makeFieldLabels ''FamRec2
+
+checkFamRec2Thing :: Iso (FamRec2 a b) (FamRec2 a' b) (FamInj1 a b) (FamInj1 a' b)
+checkFamRec2Thing = #thing
+
+type family a :#: b = r | r -> b
+
+-- infix type family injective in its second parameter
+data FamRec3 a b = FamRec3 { _famRec3Thing :: a :#: b }
+makeFieldLabels ''FamRec3
+
+checkFamRec3Thing :: Iso (FamRec3 a b) (FamRec3 a b') (a :#: b) (a :#: b')
+checkFamRec3Thing = #thing
+
+-- ambiguous type family application, type-preserving optic
+data FamRec4 a = FamRec4 { _famRec4Thing :: FamInj1 (Fam a) a }
+makeFieldLabels ''FamRec4 -- no error
+
+-- no type changing optic here
+checkFamRec4Thing :: Iso' (FamRec4 a) (FamInj1 (Fam a) a)
+checkFamRec4Thing = #thing
+
+type family FamInj2 a b (c :: k) = r | r -> a b c
+
+-- poly kinded shenenigans
+data FamRec5 a b (c :: k) = FamRec5 { _famRec5Thing :: FamInj2 a b '[c] }
+makeFieldLabels ''FamRec5
+
+checkFamRec5Thing :: Iso (FamRec5 a  b  (c  :: k))
+                         (FamRec5 a' b' (c' :: k))
+                         (FamInj2 a  b  '[c ])
+                         (FamInj2 a' b' '[c'])
+checkFamRec5Thing = #thing
+
+-- ambiguous type family application + Tagged = type-changing optic
+data FamRec6 a = FamRec6 { _famRec6Thing :: Tagged a (Fam a) }
+makeFieldLabels ''FamRec6
+
+checkFamRec6Thing
+  :: Iso (FamRec6 a) (FamRec6 b) (Tagged a (Fam a)) (Tagged b (Fam b))
+checkFamRec6Thing = #thing
+
+-- nested injective type family application
+data FamRec7 a b = FamRec7
+  { _famRec7Thing :: FamInj1 (Int :#: (a -> FamInj1 b (Fam a))) b
+  }
+makeFieldLabels ''FamRec7
+
+checkFamRec7Thing :: Iso (FamRec7 a b)
+                         (FamRec7 a' b')
+                         (FamInj1 (Int :#: (a -> FamInj1 b (Fam a))) b)
+                         (FamInj1 (Int :#: (a' -> FamInj1 b' (Fam a'))) b')
+checkFamRec7Thing = #thing
 
 data FamRec a = FamRec
   { _famRecThing :: Fam a

--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -452,7 +452,8 @@ instance HasTypeVars Type where
     VarT n            -> VarT <$> traverseOf (typeVarsEx s) f n
     AppT l r          -> AppT <$> traverseOf (typeVarsEx s) f l
                               <*> traverseOf (typeVarsEx s) f r
-    SigT t k          -> (`SigT` k) <$> traverseOf (typeVarsEx s) f t
+    SigT t k          -> SigT <$> traverseOf (typeVarsEx s) f t
+                              <*> traverseOf (typeVarsEx s) f k
     ForallT bs ctx ty -> let s' = s `Set.union` setOf typeVars bs
                          in ForallT bs <$> traverseOf (typeVarsEx s') f ctx
                                        <*> traverseOf (typeVarsEx s') f ty

--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -510,7 +510,7 @@ instance SubstType Type where
   substType m t@(VarT n)          = fromMaybe t (n `Map.lookup` m)
   substType m (ForallT bs ctx ty) = ForallT bs (substType m' ctx) (substType m' ty)
     where m' = foldrOf typeVars Map.delete m bs
-  substType m (SigT t k)          = SigT (substType m t) k
+  substType m (SigT t k)          = SigT (substType m t) (substType m k)
   substType m (AppT l r)          = AppT (substType m l) (substType m r)
   substType m (InfixT  t1 n t2)   = InfixT  (substType m t1) n (substType m t2)
   substType m (UInfixT t1 n t2)   = UInfixT (substType m t1) n (substType m t2)


### PR DESCRIPTION
Existing check wasn't taking injective type families into account (and wasn't working properly really).