### PR TITLE
Make optic kind a type equality for better type inference / errors

### DIFF
--- a/metametapost/src/MetaMetaPost.hs
+++ b/metametapost/src/MetaMetaPost.hs
@@ -267,10 +267,14 @@ data St s = St
     , stVars  :: PerTy Int
     }
 
-instance (a ~ b, s ~ s', a ~ ([Stmt s] -> [Stmt s])) => LabelOptic "stmts" A_Lens (St s) (St s') a b where
+instance
+  (k ~ A_Lens, s ~ s', a ~ ([Stmt s] -> [Stmt s]), a ~ b
+  ) => LabelOptic "stmts" k (St s) (St s') a b where
     labelOptic = lens stStmts $ \s x -> s { stStmts = x }
 
-instance (a ~ b, s ~ s', a ~ PerTy Int) => LabelOptic "vars" A_Lens (St s) (St s') a b where
+instance
+  (k ~ A_Lens, s ~ s', a ~ PerTy Int, a ~ b
+  ) => LabelOptic "vars" k (St s) (St s') a b where
     labelOptic = lens stVars $ \s x -> s { stVars = x }
 
 emptyS :: St s

--- a/optics-core/src/Optics/Label.hs
+++ b/optics-core/src/Optics/Label.hs
@@ -37,17 +37,17 @@
 -- @Optics.TH@ in the @optics-th@ package:
 --
 -- >>> :{
--- instance (a ~ String, b ~ String) => LabelOptic "name" A_Lens Human Human a b where
+-- instance (k ~ A_Lens, a ~ String, b ~ String) => LabelOptic "name" k Human Human a b where
 --   labelOptic = lensVL $ \f s -> (\v -> s { humanName = v }) <$> f (humanName s)
--- instance (a ~ Integer, b ~ Integer) => LabelOptic "age" A_Lens Human Human a b where
+-- instance (k ~ A_Lens, a ~ Integer, b ~ Integer) => LabelOptic "age" k Human Human a b where
 --   labelOptic = lensVL $ \f s -> (\v -> s { humanAge = v }) <$> f (humanAge s)
--- instance (a ~ [Pet], b ~ [Pet]) => LabelOptic "pets" A_Lens Human Human a b where
+-- instance (k ~ A_Lens, a ~ [Pet], b ~ [Pet]) => LabelOptic "pets" k Human Human a b where
 --   labelOptic = lensVL $ \f s -> (\v -> s { humanPets = v }) <$> f (humanPets s)
--- instance (a ~ String, b ~ String) => LabelOptic "name" A_Lens Pet Pet a b where
+-- instance (k ~ A_Lens, a ~ String, b ~ String) => LabelOptic "name" k Pet Pet a b where
 --   labelOptic = lensVL $ \f s -> (\v -> s { petName = v }) <$> f (petName s)
--- instance (a ~ Int, b ~ Int) => LabelOptic "age" A_Lens Pet Pet a b where
+-- instance (k ~ A_Lens, a ~ Int, b ~ Int) => LabelOptic "age" k Pet Pet a b where
 --   labelOptic = lensVL $ \f s -> (\v -> s { petAge = v }) <$> f (petAge s)
--- instance (a ~ Bool, b ~ Bool) => LabelOptic "lazy" An_AffineTraversal Pet Pet a b where
+-- instance (k ~ An_AffineTraversal, a ~ Bool, b ~ Bool) => LabelOptic "lazy" k Pet Pet a b where
 --   labelOptic = atraversalVL $ \point f s -> case s of
 --     Cat name age lazy -> (\lazy' -> Cat name age lazy') <$> f lazy
 --     _                 -> point s
@@ -94,7 +94,7 @@
 -- You might wonder why instances above are written in form
 --
 -- @
--- instance (a ~ [Pet], b ~ [Pet]) => LabelOptic "pets" A_Lens Human Human a b where
+-- instance (k ~ A_Lens, a ~ [Pet], b ~ [Pet]) => LabelOptic "pets" k Human Human a b where
 -- @
 --
 -- instead of
@@ -103,10 +103,10 @@
 -- instance LabelOptic "pets" A_Lens Human Human [Pet] [Pet] where
 -- @
 --
--- The reason is that using the first form ensures that GHC always matches on
--- the instance if either @s@ or @t@ is known and verifies type equalities
--- later, which not only makes type inference better, but also allows it to
--- generate good error messages.
+-- The reason is that using the first form ensures that it is enough for GHC to
+-- match on the instance if either @s@ or @t@ is known (as type equalities are
+-- verified after the instance matches), which not only makes type inference
+-- better, but also allows it to generate better error messages.
 --
 -- For example, if you try to write @peter & set #pets []@ with the appropriate
 -- LabelOptic instance in the second form, you get the following:
@@ -144,6 +144,14 @@
 --         (maybe you forgot to define it or misspelled a name?)
 --     • When checking the inferred type
 --         it :: forall k b a. ((TypeError ...), Is k A_Setter) => b
+--
+-- λ> age = #age :: Iso' Human Int
+--
+-- <interactive>:7:7: error:
+--     • No instance for LabelOptic "age" ‘An_Iso’ ‘Human’ ‘Human’ ‘Int’ ‘Int’
+--         (maybe you forgot to define it or misspelled a name?)
+--     • In the expression: #age :: Iso' Human Int
+--       In an equation for ‘age’: age = #age :: Iso' Human Int
 -- @
 --
 -- If we use the first form, error messages become more accurate:
@@ -164,6 +172,13 @@
 --     • In the first argument of ‘set’, namely ‘#age’
 --       In the second argument of ‘(&)’, namely ‘set #age "hi"’
 --       In the expression: peter & set #age "hi"
+-- λ> age = #age :: Iso' Human Int
+--
+-- <interactive>:9:7: error:
+--     • Couldn't match type ‘An_Iso’ with ‘A_Lens’
+--         arising from the overloaded label ‘#age’
+--     • In the expression: #age :: Iso' Human Int
+--       In an equation for ‘age’: age = #age :: Iso' Human Int
 -- @
 --
 -- == Limitations arising from functional dependencies

--- a/optics-th/src/Optics/TH.hs
+++ b/optics-th/src/Optics/TH.hs
@@ -110,15 +110,15 @@ import Optics.TH.Internal.Sum
 --
 -- @
 -- instance
---   (a ~ Int, b ~ Int
---   ) => LabelOptic "age" A_Lens Animal Animal a b where
+--   (k ~ A_Lens, a ~ Int, b ~ Int
+--   ) => LabelOptic "age" k Animal Animal a b where
 --   labelOptic = lensVL $ \\f s -> case s of
 --     Cat x1 x2 -> fmap (\\y -> Cat y x2) (f x1)
 --     Dog x1 x2 -> fmap (\\y -> Dog y x2) (f x1)
 --
 -- instance
---   (a ~ String, b ~ String
---   ) => LabelOptic "name" An_AffineTraversal Animal Animal a b where
+--   (k ~ An_AffineTraversal, a ~ String, b ~ String
+--   ) => LabelOptic "name" k Animal Animal a b where
 --   labelOptic = atraversalVL $ \\point f s -> case s of
 --     Cat x1 x2 -> fmap (\\y -> Cat x1 y) (f x2)
 --     Dog x1 x2 -> point (Dog x1 x2)
@@ -169,8 +169,8 @@ makeFieldLabelsFor fields = makeFieldLabelsWith (fieldLabelsRulesFor fields)
 -- @
 -- data Dog = Dog String Int
 --   deriving Show
--- instance LabelOptic "name" A_Lens Dog Dog ...
--- instance LabelOptic "age" A_Lens Dog Dog ...
+-- instance (k ~ A_Lens, ...) => LabelOptic "name" k Dog Dog ...
+-- instance (k ~ A_Lens, ...) => LabelOptic "age" k Dog Dog ...
 -- @
 declareFieldLabels :: DecsQ -> DecsQ
 declareFieldLabels

--- a/optics-th/src/Optics/TH/Internal/Product.hs
+++ b/optics-th/src/Optics/TH/Internal/Product.hs
@@ -145,21 +145,23 @@ makeFieldLabel
 makeFieldLabel rules (defName, (defType, cons)) = do
   (context, instHead) <- case defType of
     OpticSa _ _ otype s a -> do
+      (k,  cxtK) <- eqSubst (ConT $ opticTypeToTag otype) "k"
       (a', cxtA) <- eqSubst a "a"
       (b', cxtB) <- eqSubst a "b"
-      pure (pure [cxtA, cxtB], pure $ conAppsT ''LabelOptic
-        [LitT (StrTyLit fieldName), ConT $ opticTypeToTag otype, s, s, a', b'])
+      pure (pure [cxtK, cxtA, cxtB], pure $ conAppsT ''LabelOptic
+        [LitT (StrTyLit fieldName), k, s, s, a', b'])
     OpticStab otype s t a b -> do
       ambiguousTypeFamilies <- containsAmbiguousTypeFamilyApplications s a
       -- If 'a' contains ambiguous type family applications, generate type
       -- preserving version as functional dependencies on LabelOptic demand it.
       let t' = if ambiguousTypeFamilies then s else t
+      (k,  cxtK) <- eqSubst (ConT $ opticTypeToTag otype) "k"
       (a', cxtA) <- eqSubst a "a"
       (b', cxtB) <- if ambiguousTypeFamilies
                     then eqSubst a "b"
                     else eqSubst b "b"
-      pure (pure [cxtA, cxtB], pure $ conAppsT ''LabelOptic
-        [LitT (StrTyLit fieldName), ConT $ opticTypeToTag otype, s, t', a', b'])
+      pure (pure [cxtK, cxtA, cxtB], pure $ conAppsT ''LabelOptic
+        [LitT (StrTyLit fieldName), k, s, t', a', b'])
   instanceD context instHead (fun 'labelOptic)
   where
     opticTypeToTag AffineFoldType      = ''An_AffineFold

--- a/optics-th/src/Optics/TH/Internal/Sum.hs
+++ b/optics-th/src/Optics/TH/Internal/Sum.hs
@@ -94,12 +94,15 @@ makePrismLabels typeName = do
         -- into OpticLabel because of functional dependencies, just skip them.
         ReviewType -> pure Nothing
         _ -> do
+          (k,  cxtK) <- eqSubst (ConT $ opticTypeToTag otype) "k"
           (a', cxtA) <- eqSubst a "a"
           (b', cxtB) <- eqSubst b "b"
           let label = nameBase . prismName $ view nconName con
               instHead = pure $ conAppsT ''LabelOptic
-                [LitT (StrTyLit label), ConT $ opticTypeToTag otype, s, t, a', b']
-          Just <$> instanceD (pure $ cx ++ [cxtA, cxtB]) instHead (fun stab 'labelOptic)
+                [LitT (StrTyLit label), k, s, t, a', b']
+          Just <$> instanceD (pure $ cx ++ [cxtK, cxtA, cxtB])
+                             instHead
+                             (fun stab 'labelOptic)
       where
         ty        = D.datatypeType info
         isNewtype = D.datatypeVariant info == D.Newtype

--- a/optics/tests/Optics/Tests/Labels.hs
+++ b/optics/tests/Optics/Tests/Labels.hs
@@ -135,8 +135,8 @@ type HasConfig k s = (LabelOptic' "config" k s Config, Is k A_Getter)
 
 data Config = Config
 instance
-  (a ~ Config, b ~ Config
-  ) => LabelOptic "config" An_Iso Config Config a b where
+  (k ~ An_Iso, a ~ Config, b ~ Config
+  ) => LabelOptic "config" k Config Config a b where
   labelOptic = equality
 
 data Env = Env { envConfig :: Config, envRng :: R.StdGen }
@@ -146,8 +146,8 @@ data Nested = Nested { nestedName :: String, nestedEnv :: Env }
 makeFieldLabels ''Nested
 
 instance
-  (a ~ Config, b ~ Config
-  ) => LabelOptic "config" A_Lens Nested Nested a b where
+  (k ~ A_Lens, a ~ Config, b ~ Config
+  ) => LabelOptic "config" k Nested Nested a b where
   labelOptic = #env % #config
 
 doStuff :: (MonadReader r m, HasConfig k r) => m ()


### PR DESCRIPTION
```haskell
data Test = Test { testX :: Int }
makeFieldLabels ''Test

x :: Lens' Test Int
x = #x
```

Before:
```
    • No instance for LabelOptic "x" ‘A_Lens’ ‘Test’ ‘Test’ ‘Int’ ‘Int’
        (maybe you forgot to define it or misspelled a name?)
    • In the expression: #x
      In an equation for ‘x’: x = #x
```

After:
```
    • Couldn't match type ‘A_Lens’ with ‘An_Iso’
        arising from the overloaded label ‘#x’
    • In the expression: #x
      In an equation for ‘x’: x = #x
```