### PR TITLE
Improve error message in catch-all GeneralLabelOptic instance

### DIFF
--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -256,7 +256,7 @@ instance {-# INCOHERENT #-}
     ':<>: 'Text " " ':<>: QuoteType t
     ':<>: 'Text " " ':<>: QuoteType a
     ':<>: 'Text " " ':<>: QuoteType b
-    ':$$: 'Text "  (maybe you forgot to define it or misspelled a name?)")
+    ':$$: 'Text "Perhaps you forgot to define it or misspelled its name?")
    => GeneralLabelOptic name k s t a b repDefined where
   generalLabelOptic = error "unreachable"
 


### PR DESCRIPTION
`Perhaps` is used by GHC and error message in `.Subtyping` module.