### PR TITLE
Leverage HasField to obtain field getters

### DIFF
--- a/optics/tests/Optics/Tests/Labels.hs
+++ b/optics/tests/Optics/Tests/Labels.hs
@@ -59,6 +59,8 @@ labelsTests = testGroup "Labels"
     assertSuccess $(inspectTest $ 'label4lhs ==- 'label4rhs)
   , testCase "multiple set with labels = multiple set with record syntax" $
     assertSuccess $(inspectTest $ 'label5lhs ==- 'label5rhs)
+  , testCase "generic getter = field accessor" $
+    assertSuccess $(inspectTest $ 'name === 'getName)
   ]
 
 label1lhs, label1rhs :: Human a -> String
@@ -127,6 +129,13 @@ oldestPet = maximumByOf (#pets % folded) (comparing $ view #age) human
 
 luckyDog :: Human Mammal
 luckyDog = human & set (#pets % mapped % #_Dog % _1) "Lucky"
+
+----------------------------------------
+
+data User = User { name :: String }
+
+getName :: User -> String
+getName user = user ^. #name
 
 ----------------------------------------
 -- Generalization of Has* classes


### PR DESCRIPTION
I wonder if it makes sense to do that instead of reporting an error about lack of instance.

I'm tentatively positive about this though:

```haskell
λ> :set -XOverloadedLabels 
λ> data User = User { name :: String, age :: Int }
λ> let user = User "Tom" 23
λ> user ^. #name
"Tom"
λ> user ^. #namey

<interactive>:7:1: error:
    • No instance for (GHC.Records.HasField "namey" User ())
        arising from a use of ‘it’
    • In the first argument of ‘print’, namely ‘it’
      In a stmt of an interactive GHCi command: print it
λ> user & #name .~ "Bob"

<interactive>:6:8: error:
    • A_Getter cannot be used as A_Setter
      Perhaps you meant one of these:
        ‘view’ (from Optics.Getter)
        ‘(^.)’ (from Optics.Operators)
    • In the second argument of ‘(&)’, namely ‘#name .~ "Bob"’
      In the expression: user & #name .~ "Bob"
      In an equation for ‘it’: it = user & #name .~ "Bob"
```
