### PR TITLE
Add (i)adjoin

### DIFF
--- a/optics-core/src/Optics/Fold.hs
+++ b/optics-core/src/Optics/Fold.hs
@@ -267,6 +267,7 @@ backwards_ o = foldVL $ \f -> forwards #. traverseOf_ o (Backwards #. f)
 -- >>> toListOf (_1 % ix 0 `summing` _2 % ix 1) ([1,2], [4,7,1])
 -- [1,7]
 --
+-- For the traversal version see 'Optics.Traversal.adjoin'.
 summing
   :: (Is k A_Fold, Is l A_Fold)
   => Optic' k is s a

--- a/optics-core/src/Optics/Fold.hs
+++ b/optics-core/src/Optics/Fold.hs
@@ -75,8 +75,8 @@ module Optics.Fold
   , pre
   , backwards_
 
-  -- * Monoid structures
-  -- | 'Fold' admits (at least) two monoid structures: #monoids#
+  -- * Monoid structures #monoids#
+  -- | 'Fold' admits (at least) two monoid structures:
   --
   -- * 'summing' concatenates results from both folds.
   --

--- a/optics-core/src/Optics/IxAffineTraversal.hs
+++ b/optics-core/src/Optics/IxAffineTraversal.hs
@@ -120,8 +120,9 @@ unsafeFilteredBy p = iatraversalVL $ \point f s -> case preview p s of
 -- no substructures.
 --
 -- This is the identity element when a 'Optics.Fold.Fold',
--- 'Optics.AffineFold.AffineFold', 'Optics.IxFold.IxFold' or
--- 'Optics.IxAffineFold.IxAffineFold' is viewed as a monoid.
+-- 'Optics.AffineFold.AffineFold', 'Optics.IxFold.IxFold',
+-- 'Optics.IxAffineFold.IxAffineFold', 'Optics.Traversal.Traversal' or
+-- 'Optics.IxTraversal.IxTraversal' is viewed as a monoid.
 --
 -- >>> 6 & ignored %~ absurd
 -- 6

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -44,7 +44,7 @@ module Optics.IxFold
   , ifiltered
   , ibackwards_
 
-  -- * Monoid structures
+  -- * Monoid structures #monoids#
   -- | 'IxFold' admits (at least) two monoid structures:
   --
   -- * 'isumming' concatenates results from both folds.

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -246,6 +246,7 @@ ibackwards_ o = conjoined (backwards_ o) $ ifoldVL $ \f ->
 -- >>> itoListOf (ifolded `isumming` ibackwards_ ifolded) ["a","b"]
 -- [(0,"a"),(1,"b"),(1,"b"),(0,"a")]
 --
+-- For the traversal version see 'Optics.IxTraversal.iadjoin'.
 isumming
   :: (Is k A_Fold, Is l A_Fold,
       is1 `HasSingleIndex` i, is2 `HasSingleIndex` i)

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -59,6 +59,7 @@ module Optics.IxTraversal
   , ibackwards
   , ipartsOf
   , isingular
+  , iadjoin
 
   -- * Subtyping
   , A_Traversal
@@ -338,6 +339,110 @@ isingular o = conjoined (singular o) $ iatraversalVL $ \point f s ->
       Just a' -> put Nothing >> pure a'
       Nothing ->                pure a
 {-# INLINE isingular #-}
+
+-- | Adjoin two disjoint indexed traversals together.
+--
+-- /Note:/ traversing the same entry twice is illegal.
+--
+-- >>> iover (_1 % itraversed `iadjoin` _2 % itraversed) (+) ([0, 0, 0], (3, 5))
+-- ([0,1,2],(3,8))
+--
+-- For the fold version see 'Optics.IxFold.isumming'.
+iadjoin
+  :: (Is k A_Traversal, Is l A_Traversal, is `HasSingleIndex` i)
+  => Optic' k is s a
+  -> Optic' l is s a
+  -> IxTraversal' i s a
+iadjoin o1 o2 = conjoined (adjoin o1 o2) (combined % traversed % itraversed)
+  where
+    combined = traversalVL $ \f s0 ->
+      (\r1 r2 ->
+         let s1 = evalState (traverseOf o1 update s0) r1
+             s2 = evalState (traverseOf o2 update s1) r2
+         in s2
+      )
+      <$> f (itoListOf (castOptic @A_Traversal o1) s0)
+      <*> f (itoListOf (castOptic @A_Traversal o2) s0)
+
+    update a = get >>= \case
+      (_, a') : as' -> put as' >> pure a'
+      []            ->            pure a
+infixr 6 `iadjoin` -- Same as (<>)
+{-# INLINE [1] iadjoin #-}
+
+{-# RULES
+
+"iadjoin_12_3" forall o1 o2 o3. iadjoin o1 (iadjoin o2 o3) = iadjoin3 o1 o2 o3
+"iadjoin_21_3" forall o1 o2 o3. iadjoin (iadjoin o1 o2) o3 = iadjoin3 o1 o2 o3
+
+"iadjoin_13_4" forall o1 o2 o3 o4. iadjoin o1 (iadjoin3 o2 o3 o4) = iadjoin4 o1 o2 o3 o4
+"iadjoin_31_4" forall o1 o2 o3 o4. iadjoin (iadjoin3 o1 o2 o3) o4 = iadjoin4 o1 o2 o3 o4
+
+#-}
+
+-- | Triple 'iadjoin' for optimizing multiple 'iadjoin's with rewrite rules.
+iadjoin3
+  :: (Is k1 A_Traversal, Is k2 A_Traversal, Is k3 A_Traversal, is `HasSingleIndex` i )
+  => Optic' k1 is s a
+  -> Optic' k2 is s a
+  -> Optic' k3 is s a
+  -> IxTraversal' i s a
+iadjoin3 o1 o2 o3 = conjoined (o1 `adjoin` o2 `adjoin` o3)
+                              (combined % traversed % itraversed)
+  where
+    combined = traversalVL $ \f s0 ->
+      (\r1 r2 r3 ->
+         let s1 = evalState (traverseOf o1 update s0) r1
+             s2 = evalState (traverseOf o2 update s1) r2
+             s3 = evalState (traverseOf o3 update s2) r3
+         in s3
+      )
+      <$> f (itoListOf (castOptic @A_Traversal o1) s0)
+      <*> f (itoListOf (castOptic @A_Traversal o2) s0)
+      <*> f (itoListOf (castOptic @A_Traversal o3) s0)
+
+    update a = get >>= \case
+      (_, a') : as' -> put as' >> pure a'
+      []            ->            pure a
+{-# INLINE [1] iadjoin3 #-}
+
+{-# RULES
+
+"iadjoin_211_4" forall o1 o2 o3 o4. iadjoin3 (iadjoin o1 o2) o3 o4 = iadjoin4 o1 o2 o3 o4
+"iadjoin_121_4" forall o1 o2 o3 o4. iadjoin3 o1 (iadjoin o2 o3) o4 = iadjoin4 o1 o2 o3 o4
+"iadjoin_112_4" forall o1 o2 o3 o4. iadjoin3 o1 o2 (iadjoin o3 o4) = iadjoin4 o1 o2 o3 o4
+
+#-}
+
+-- | Quadruple 'iadjoin' for optimizing multiple 'iadjoin's with rewrite rules.
+iadjoin4
+  :: ( Is k1 A_Traversal, Is k2 A_Traversal, Is k3 A_Traversal, Is k4 A_Traversal
+     , is `HasSingleIndex` i)
+  => Optic' k1 is s a
+  -> Optic' k2 is s a
+  -> Optic' k3 is s a
+  -> Optic' k4 is s a
+  -> IxTraversal' i s a
+iadjoin4 o1 o2 o3 o4 = conjoined (o1 `adjoin` o2 `adjoin` o3 `adjoin` o4)
+                                 (combined % traversed % itraversed)
+  where
+    combined = traversalVL $ \f s0 ->
+      (\r1 r2 r3 r4 ->
+         let s1 = evalState (traverseOf o1 update s0) r1
+             s2 = evalState (traverseOf o2 update s1) r2
+             s3 = evalState (traverseOf o3 update s2) r3
+             s4 = evalState (traverseOf o4 update s3) r4
+         in s4
+      )
+      <$> f (itoListOf (castOptic @A_Traversal o1) s0)
+      <*> f (itoListOf (castOptic @A_Traversal o2) s0)
+      <*> f (itoListOf (castOptic @A_Traversal o3) s0)
+      <*> f (itoListOf (castOptic @A_Traversal o4) s0)
+
+    update a = get >>= \case
+      (_, a') : as' -> put as' >> pure a'
+      []            ->            pure a
+{-# INLINE [1] iadjoin4 #-}
 
 -- $setup
 -- >>> import Data.Void

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -163,6 +163,9 @@ module Optics
   -- $indexed
   , module Optics.Indexed
 
+  -- * Monoid structures #monoids#
+  -- $monoids
+
   -- * Generation of optics
   -- ** ...with Template Haskell
   , module Optics.TH
@@ -721,8 +724,8 @@ import Data.Either.Optics                    as P
 -- * 'singular' ('isingular' for indexed optics) doesn't produce a partial lens
 --   that might fail with a runtime error, but an affine traversal.
 --
--- * '<>' cannot be used to combine 'Fold's, so 'summing' should be used
---   instead.
+-- * '<>' cannot be used to combine 'Fold's, so 'summing' should be used instead
+--   (see the "Monoid structures" section below in "Optics#monoids").
 
 
 -- $otherresources
@@ -865,6 +868,30 @@ import Data.Either.Optics                    as P
 --      Optic A_Traversal '[i] (f a, c) (f b, c) a b
 --
 -- <<diagrams/indexedoptics.png Indexed Optics>>
+
+
+-- $monoids
+--
+-- There are two ways to combine (possibly indexed) folds, traversals and
+-- related optics with the same outer and inner types:
+--
+-- * Visit all the targets of the first optic, then all the targets of the
+--   second optic.  This makes sense for folds ('summing' or 'isumming') and
+--   traversals ('adjoin' or 'iadjoin'), provided in the latter case that the
+--   targets are disjoint.
+--
+-- * Visit the targets of the first optic if there are any, or if not, visit the
+--   targets of the second optic.  This makes sense for folds ('failing' or
+--   'ifailing') and affine folds ('afailing' or 'iafailing').
+--
+-- These operations form monoid structures on the appropriate optic kinds, with
+-- the identity element 'ignored', which visits no targets.
+--
+-- There is no 'Semigroup' or 'Monoid' instance for 'Optic', because there is
+-- not a unique choice of monoid to use, and the ('<>') operator could not be
+-- used to combine optics of different kinds. When porting code from @lens@ that
+-- uses ('<>') to combine folds, use 'summing' instead.
+
 
 -- $cheatsheet
 --

--- a/optics/tests/Optics/Tests/Misc.hs
+++ b/optics/tests/Optics/Tests/Misc.hs
@@ -29,6 +29,12 @@ miscTests = testGroup "Miscellaneous"
     assertSuccess $(inspectTest $ hasNoProfunctors 'checkFilteredBy)
   , testCase "optimized unsafeFilteredBy" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'checkUnsafeFilteredBy)
+    -- GHC <= 8.4 doesn't optimize away profunctor classes
+  , testCase "optimized adjoin" $
+    ghcLE84failure $(inspectTest $ hasNoProfunctors 'checkAdjoin)
+    -- GHC <= 8.4 doesn't optimize away profunctor classes
+  , testCase "optimized iadjoin" $
+    ghcLE84failure $(inspectTest $ hasNoProfunctors 'checkIxAdjoin)
   ]
 
 simpleMapIx
@@ -71,3 +77,9 @@ checkUnsafeFilteredBy
   -> Either a1 (a, Maybe i)
   -> f (Either a1 (a, Maybe i))
 checkUnsafeFilteredBy = iatraverseOf (unsafeFilteredBy (_Right % _2 % _Just)) pure
+
+checkAdjoin :: (a -> a) -> (Maybe a, Either a a, [a]) -> (Maybe a, Either a a, [a])
+checkAdjoin = over (_1 % _Just `adjoin` _2 % chosen `adjoin` _3 % traversed)
+
+checkIxAdjoin :: (Int -> a -> a) -> ((Int, a), [a], (Int, Maybe a)) -> ((Int, a), [a], (Int, Maybe a))
+checkIxAdjoin = iover (_1 % itraversed `iadjoin` _2 % itraversed `iadjoin` _3 % itraversed % _Just)

--- a/optics/tests/Optics/Tests/Utils.hs
+++ b/optics/tests/Optics/Tests/Utils.hs
@@ -77,3 +77,10 @@ ghcGE86failure = assertFailure'
 #else
 ghcGE86failure = assertSuccess
 #endif
+
+ghcLE84failure :: Result -> IO ()
+#if __GLASGOW_HASKELL__ <= 804
+ghcLE84failure = assertFailure'
+#else
+ghcLE84failure = assertSuccess
+#endif


### PR DESCRIPTION
Fixes #331.

It's reasonably fast when compared to a hand-written version (and obliterates `lens`):

```
benchmarking misc/adjoin/hand-written
time                 30.16 ns   (29.32 ns .. 31.73 ns)
                     0.991 R²   (0.978 R² .. 1.000 R²)
mean                 30.34 ns   (29.49 ns .. 32.66 ns)
std dev              2.938 ns   (876.6 ps .. 5.151 ns)
variance introduced by outliers: 90% (severely inflated)

benchmarking misc/adjoin/adjoin
time                 65.72 ns   (65.14 ns .. 66.25 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 65.72 ns   (65.10 ns .. 66.22 ns)
std dev              1.131 ns   (853.5 ps .. 1.562 ns)
variance introduced by outliers: 21% (moderately inflated)

benchmarking misc/adjoin/adjoin/lens
time                 3.952 μs   (3.911 μs .. 4.019 μs)
                     0.997 R²   (0.991 R² .. 1.000 R²)
mean                 4.016 μs   (3.930 μs .. 4.307 μs)
std dev              309.4 ns   (65.82 ns .. 594.4 ns)
variance introduced by outliers: 78% (severely inflated)
```

When adjoining traversals that overlap I'm not sure which laws might be violated though. I suspect traversal composition law can be violated when the traversing function is stateful. I don't think setter laws can be violated.

Because of this I'm for exporting it normally.