### PR TITLE
Replace bndrName with tvName from th-abstraction

### DIFF
--- a/optics-th/src/Optics/TH/Internal/Product.hs
+++ b/optics-th/src/Optics/TH/Internal/Product.hs
@@ -444,7 +444,7 @@ buildStab forClassInstance s categorizedFields = do
         procTF tf args = case tf of
           TypeFamilyHead _ varBndrs _ (Just (InjectivityAnn _ ins)) -> do
             let insSet = S.fromList ins
-                vars   = map bndrName varBndrs
+                vars   = map D.tvName varBndrs
             --lift . runIO $ do
             --  putStrLn $ "INS:  " ++ show ins
             --  putStrLn $ "VARS: " ++ show vars

--- a/optics-th/src/Optics/TH/Internal/Utils.hs
+++ b/optics-th/src/Optics/TH/Internal/Utils.hs
@@ -37,11 +37,6 @@ toTupleP xs = tupP xs
 conAppsT :: Name -> [Type] -> Type
 conAppsT conName = foldl AppT (ConT conName)
 
--- | Return 'Name' contained in a 'TyVarBndr'.
-bndrName :: TyVarBndr -> Name
-bndrName (PlainTV  n  ) = n
-bndrName (KindedTV n _) = n
-
 -- | Generate many new names from a given base name.
 newNames :: String {- ^ base name -} -> Int {- ^ count -} -> Q [Name]
 newNames base n = sequence [ newName (base++show i) | i <- [1..n] ]
@@ -74,7 +69,7 @@ quantifyType = quantifyType' S.empty
 quantifyType' :: S.Set Name -> [TyVarBndr] -> Cxt -> Type -> Type
 quantifyType' exclude vars cx t = ForallT vs cx t
   where
-    vs = filter (\v -> bndrName v `S.notMember` exclude)
+    vs = filter (\v -> D.tvName v `S.notMember` exclude)
        . D.freeVariablesWellScoped
        $ map bndrToType vars ++ S.toList (setOf typeVarsKinded t)
 


### PR DESCRIPTION
`Optics.TH.Internal.Utils` defines `bndrName`, whose functionality duplicates that of `tvName` from `th-abstraction`. Since `optics-th` already depends on `th-abstraction`, this seemed like a good opportunity to consolidate some code.

Besides reducing code duplication, this patch will also make it slightly easier to make `optics-th` compile with `template-haskell-2.17.0.0` (GHC 9.0), which changes the definition of `TyVarBndr`. (In fact, I originally noticed this when [patching `optics-th`](https://gitlab.haskell.org/ghc/head.hackage/-/merge_requests/110) to work with `template-haskell-2.17.0.0`.)