### PR TITLE
Describe versioning differences in template-haskell-optics API.

### DIFF
--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -900,7 +900,7 @@ _RoleAnnotD
 
 -- |
 -- @
--- _StandaloneDerivD :: 'Prism'' 'Dec' ('Maybe' 'DerivStrategy', 'Cxt', 'Type') -- template-haskell 2.15+
+-- _StandaloneDerivD :: 'Prism'' 'Dec' ('Maybe' 'DerivStrategy', 'Cxt', 'Type') -- template-haskell 2.12+
 -- _StandaloneDerivD :: 'Prism'' 'Dec' ('Cxt', 'Type')                      -- Earlier versions
 -- @
 #if MIN_VERSION_template_haskell(2,12,0)
@@ -1034,7 +1034,7 @@ _OpenTypeFamilyD
 
 -- |
 -- @
--- _PatSynD :: 'Prism'' 'Dec' ('Name', 'PatSynArgs', 'PatSynDir', 'Pat') -- template-haskell-2.15+
+-- _PatSynD :: 'Prism'' 'Dec' ('Name', 'PatSynArgs', 'PatSynDir', 'Pat') -- template-haskell-2.12+
 -- _PatSynD :: 'Prism'' 'Dec' ('Name', 'PatSynType')                 -- Earlier versions
 -- @
 #if MIN_VERSION_template_haskell(2,12,0)

--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -112,7 +112,6 @@ module Language.Haskell.TH.Optics
 #if MIN_VERSION_template_haskell(2,15,0)
   , _ImplicitParamBindD
 #endif
-  , DataPrism'
 #if MIN_VERSION_template_haskell(2,12,0)
   -- ** PatSynDir Prisms
   , _Unidir

--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -939,8 +939,10 @@ _ClosedTypeFamilyD
 
 -- |
 -- @
--- type DataPrism' tys cons = 'Prism'' 'Dec' ('Cxt', 'Name', 'tys', 'Maybe' 'Kind', cons, ['DerivClause']) -- template-haskell-2.11+
--- type DataPrism' tys cons = 'Prism'' 'Dec' ('Cxt', 'Name', tys, 'Maybe' 'Kind', cons, 'Cxt')           -- Earlier versions
+-- -- template-haskell-2.12+:
+-- type DataPrism' tys cons = 'Prism'' 'Dec' ('Cxt', 'Name', 'tys', 'Maybe' 'Kind', cons, ['DerivClause'])
+-- Earlier versions:
+-- type DataPrism' tys cons = 'Prism'' 'Dec' ('Cxt', 'Name', tys, 'Maybe' 'Kind', cons, 'Cxt')
 -- @
 #if MIN_VERSION_template_haskell(2,12,0)
 type DataPrism' tys cons = Prism' Dec (Cxt, Name, tys, Maybe Kind, cons, [DerivClause])

--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -112,6 +112,7 @@ module Language.Haskell.TH.Optics
 #if MIN_VERSION_template_haskell(2,15,0)
   , _ImplicitParamBindD
 #endif
+  , DataPrism'
 #if MIN_VERSION_template_haskell(2,12,0)
   -- ** PatSynDir Prisms
   , _Unidir

--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -868,7 +868,7 @@ _PragmaD
 
 -- |
 -- @
--- _TySynInstD :: 'Prism'' 'Dec' 'TySynEqn'           -- template-haskell 2.15+
+-- _TySynInstD :: 'Prism'' 'Dec' 'TySynEqn'         -- template-haskell 2.15+
 -- _TySynInstD :: 'Prism'' 'Dec' ('Name', 'TySynEqn') -- Earlier versions
 -- @
 #if MIN_VERSION_template_haskell(2,15,0)
@@ -965,9 +965,9 @@ _NewtypeD
 
 -- |
 -- @
--- template-haskell-2.15+:
+-- -- template-haskell-2.15+:
 -- _DataInstD :: 'Prism'' 'Dec' ('Cxt', 'Maybe' ['TyVarBndr'], 'Type', 'Maybe' 'Kind', ['Con'], ['DerivClause'])
--- Earlier versions:
+-- -- Earlier versions:
 -- _DataInstD :: 'DataPrism'' ['Type'] ['Con']
 -- @
 #if MIN_VERSION_template_haskell(2,15,0)
@@ -990,9 +990,9 @@ _DataInstD
 
 -- |
 -- @
--- template-haskell-2.15+:
+-- -- template-haskell-2.15+:
 -- _NewtypeInstD :: 'Prism'' 'Dec' ('Cxt', 'Maybe' ['TyVarBndr'], 'Type', 'Maybe' 'Kind', ['Con'], ['DerivClause'])
--- Earlier versions:
+-- -- Earlier versions:
 -- _NewtypeInstD :: 'DataPrism'' ['Type'] 'Con'
 -- @
 #if MIN_VERSION_template_haskell(2,15,0)
@@ -1340,7 +1340,7 @@ _SpecialiseInstP
 
 -- |
 -- @
--- -- template-haskell >= 2.15:
+-- -- template-haskell 2.15+:
 -- _RuleP :: 'Prism'' 'Pragma' ('String', 'Maybe' ['TyVarBndr'], ['RuleBndr'], 'Exp', 'Exp', 'Phases')
 -- -- Earlier versions:
 -- _RuleP :: 'Prism'' 'Pragma' ('String', ['RuleBndr'], 'Exp', 'Exp', 'Phases') -- Earlier versions

--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -1,5 +1,16 @@
 {-# LANGUAGE CPP              #-}
 {-# LANGUAGE LambdaCase       #-}
+-- |
+-- Module: Language.Haskell.TH.Optics
+-- Description: Optics for types defined in "Language.Haskell.TH".
+--
+-- Note: the API offered in this module is subject to change, as
+-- it mirrors the API provided by the @template-haskell@ package,
+-- which changes between different releases of GHC. This module
+-- makes an effort to identify the functions that have different
+-- type signatures when compiled with different versions  of
+-- @template-haskell@.
+--
 module Language.Haskell.TH.Optics
   (
   -- * Traversals

--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -941,7 +941,7 @@ _ClosedTypeFamilyD
 -- @
 -- -- template-haskell-2.12+:
 -- type DataPrism' tys cons = 'Prism'' 'Dec' ('Cxt', 'Name', 'tys', 'Maybe' 'Kind', cons, ['DerivClause'])
--- Earlier versions:
+-- -- Earlier versions:
 -- type DataPrism' tys cons = 'Prism'' 'Dec' ('Cxt', 'Name', tys, 'Maybe' 'Kind', cons, 'Cxt')
 -- @
 #if MIN_VERSION_template_haskell(2,12,0)

--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -4,12 +4,12 @@
 -- Module: Language.Haskell.TH.Optics
 -- Description: Optics for types defined in "Language.Haskell.TH".
 --
--- Note: the API offered in this module is subject to change, as
+-- Note:
+-- The API offered in this module is subject to change, as
 -- it mirrors the API provided by the @template-haskell@ package,
 -- which changes between different releases of GHC. This module
--- makes an effort to identify the functions that have different
--- type signatures when compiled with different versions  of
--- @template-haskell@.
+-- makes an effort to identify the version of @template-haskell@
+-- associated with API differences or extensions.
 --
 module Language.Haskell.TH.Optics
   (
@@ -866,6 +866,11 @@ _PragmaD
       remitter (PragmaD x) = Just x
       remitter _ = Nothing
 
+-- |
+-- @
+-- _TySynInstD :: 'Prism'' 'Dec' 'TySynEqn'           -- template-haskell 2.15+
+-- _TySynInstD :: 'Prism'' 'Dec' ('Name', 'TySynEqn') -- Earlier versions
+-- @
 #if MIN_VERSION_template_haskell(2,15,0)
 _TySynInstD :: Prism' Dec TySynEqn
 _TySynInstD
@@ -892,6 +897,11 @@ _RoleAnnotD
       remitter (RoleAnnotD x y) = Just (x, y)
       remitter _ = Nothing
 
+-- |
+-- @
+-- _StandaloneDerivD :: 'Prism'' 'Dec' ('Maybe' 'DerivStrategy', 'Cxt', 'Type') -- template-haskell 2.15+
+-- _StandaloneDerivD :: 'Prism'' 'Dec' ('Cxt', 'Type')                      -- Earlier versions
+-- @
 #if MIN_VERSION_template_haskell(2,12,0)
 _StandaloneDerivD :: Prism' Dec (Maybe DerivStrategy, Cxt, Type)
 _StandaloneDerivD
@@ -926,6 +936,11 @@ _ClosedTypeFamilyD
       remitter (ClosedTypeFamilyD x y) = Just (x, y)
       remitter _ = Nothing
 
+-- |
+-- @
+-- type DataPrism' tys cons = 'Prism'' 'Dec' ('Cxt', 'Name', 'tys', 'Maybe' 'Kind', cons, ['DerivClause']) -- template-haskell-2.11+
+-- type DataPrism' tys cons = 'Prism'' 'Dec' ('Cxt', 'Name', tys, 'Maybe' 'Kind', cons, 'Cxt')           -- Earlier versions
+-- @
 #if MIN_VERSION_template_haskell(2,12,0)
 type DataPrism' tys cons = Prism' Dec (Cxt, Name, tys, Maybe Kind, cons, [DerivClause])
 #else
@@ -948,6 +963,13 @@ _NewtypeD
       remitter (NewtypeD x y z w u v) = Just (x, y, z, w, u, v)
       remitter _ = Nothing
 
+-- |
+-- @
+-- template-haskell-2.15+:
+-- _DataInstD :: 'Prism'' 'Dec' ('Cxt', 'Maybe' ['TyVarBndr'], 'Type', 'Maybe' 'Kind', ['Con'], ['DerivClause'])
+-- Earlier versions:
+-- _DataInstD :: 'DataPrism'' ['Type'] ['Con']
+-- @
 #if MIN_VERSION_template_haskell(2,15,0)
 _DataInstD :: Prism' Dec (Cxt, Maybe [TyVarBndr], Type, Maybe Kind, [Con], [DerivClause])
 _DataInstD
@@ -966,6 +988,13 @@ _DataInstD
       remitter _ = Nothing
 #endif
 
+-- |
+-- @
+-- template-haskell-2.15+:
+-- _NewtypeInstD :: 'Prism'' 'Dec' ('Cxt', 'Maybe' ['TyVarBndr'], 'Type', 'Maybe' 'Kind', ['Con'], ['DerivClause'])
+-- Earlier versions:
+-- _NewtypeInstD :: 'DataPrism'' ['Type'] 'Con'
+-- @
 #if MIN_VERSION_template_haskell(2,15,0)
 _NewtypeInstD :: Prism' Dec (Cxt, Maybe [TyVarBndr], Type, Maybe Kind, Con, [DerivClause])
 _NewtypeInstD
@@ -1000,6 +1029,11 @@ _OpenTypeFamilyD
       remitter (OpenTypeFamilyD x) = Just x
       remitter _ = Nothing
 
+-- |
+-- @
+-- _PatSynD :: 'Prism'' 'Dec' ('Name', 'PatSynArgs', 'PatSynDir', 'Pat') -- template-haskell-2.15+
+-- _PatSynD :: 'Prism'' 'Dec' ('Name', 'PatSynType')                 -- Earlier versions
+-- @
 #if MIN_VERSION_template_haskell(2,12,0)
 _PatSynD :: Prism' Dec (Name, PatSynArgs, PatSynDir, Pat)
 _PatSynD
@@ -1304,6 +1338,13 @@ _SpecialiseInstP
       remitter (SpecialiseInstP x) = Just x
       remitter _ = Nothing
 
+-- |
+-- @
+-- -- template-haskell >= 2.15:
+-- _RuleP :: 'Prism'' 'Pragma' ('String', 'Maybe' ['TyVarBndr'], ['RuleBndr'], 'Exp', 'Exp', 'Phases')
+-- -- Earlier versions:
+-- _RuleP :: 'Prism'' 'Pragma' ('String', ['RuleBndr'], 'Exp', 'Exp', 'Phases') -- Earlier versions
+-- @
 #if MIN_VERSION_template_haskell(2,15,0)
 _RuleP :: Prism' Pragma (String, Maybe [TyVarBndr], [RuleBndr], Exp, Exp, Phases)
 _RuleP


### PR DESCRIPTION
This is a port of the documentation changes in https://github.com/ekmett/lens/pull/856: the signatures of optics that differ between `template-haskell` versions are documented in Haddock.

Something that this refactor raised is whether `DataPrism’`’s definition should be exported, since it differs meaningfully between `template-haskell` versions, and indeed its accompanying comment to that effect is elided in the Haddock output. I’d be in favor of it, since it’s version-relevant, and there haven’t been any releases yet. I’ve chosen to do so here.

Fixes #252.