### PR TITLE
Extend GHC 8.10 Template Haskell interface (#345)

### DIFF
--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -541,6 +541,23 @@ instance SubstType Type where
   substType m (InfixT  t1 n t2)   = InfixT  (substType m t1) n (substType m t2)
   substType m (UInfixT t1 n t2)   = UInfixT (substType m t1) n (substType m t2)
   substType m (ParensT t)         = ParensT (substType m t)
+  substType _ t@ArrowT{}          = t
+  substType _ t@ConT{}            = t
+  substType _ t@ConstraintT{}     = t
+  substType _ t@EqualityT{}       = t
+  substType _ t@ListT{}           = t
+  substType _ t@LitT{}            = t
+  substType _ t@PromotedConsT{}   = t
+  substType _ t@PromotedNilT{}    = t
+  substType _ t@PromotedTupleT{}  = t
+  substType _ t@PromotedT{}       = t
+  substType _ t@StarT{}           = t
+  substType _ t@TupleT{}          = t
+  substType _ t@UnboxedTupleT{}   = t
+  substType _ t@WildCardT{}       = t
+#if MIN_VERSION_template_haskell(2,12,0)
+  substType _ t@UnboxedSumT{}   = t
+#endif
 #if MIN_VERSION_template_haskell(2,15,0)
   substType m (AppKindT t k)       = AppKindT (substType m t) (substType m k)
   substType m (ImplicitParamT n t) = ImplicitParamT n (substType m t)

--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -255,7 +255,7 @@ module Language.Haskell.TH.Optics
   , _DoublePrimL
   , _StringPrimL
   , _CharPrimL
-#if MIN_VERSION_template_haskell(2, 16, 0)
+#if MIN_VERSION_template_haskell(2,16,0)
   , _BytesPrimL
 #endif
   -- ** Pat Prisms

--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP              #-}
 {-# LANGUAGE LambdaCase       #-}
-{-# OPTIONS_GHC -Werror #-}
 module Language.Haskell.TH.Optics
   (
   -- * Traversals

--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -530,6 +530,10 @@ instance SubstType Type where
   substType m (AppKindT t k)       = AppKindT (substType m t) (substType m k)
   substType m (ImplicitParamT n t) = ImplicitParamT n (substType m t)
 #endif
+#if MIN_VERSION_template_haskell(2,16,0)
+  substType m (ForallVisT bs ty)   = ForallVisT bs (substType m' ty)
+    where m' = foldrOf typeVars Map.delete m bs
+#endif
   substType _ t                   = t
 
 instance SubstType t => SubstType [t] where

--- a/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
+++ b/template-haskell-optics/src/Language/Haskell/TH/Optics.hs
@@ -482,9 +482,11 @@ instance HasTypeVars Type where
     t@PromotedT{}      -> pure t
     t@StarT{}          -> pure t
     t@TupleT{}         -> pure t
-    t@UnboxedSumT{}    -> pure t
     t@UnboxedTupleT{}  -> pure t
     t@WildCardT{}      -> pure t
+#if MIN_VERSION_template_haskell(2,12,0)
+    t@UnboxedSumT{}    -> pure t
+#endif
 #if MIN_VERSION_template_haskell(2,15,0)
     AppKindT t k       -> AppKindT <$> traverseOf (typeVarsEx s) f t
                                    <*> traverseOf (typeVarsEx s) f k


### PR DESCRIPTION
This is largely a port of https://github.com/ekmett/lens/pull/912, as part of #337.

As regards the `case` statements associated with the body of the `HasTypeVars` and `SubstType` implementations: `lens` does not have a catchall `t -> pure t` case, instead electing to write out all the boring cases separately; this is indeed noisy and boring, but would have indicated the missing branch for the `ForallVisT` case, whereas the catchall case in this code hid it. I’m happy to write out the cases in toto should that be preferable.

Fixes #345.