### PR TITLE
Fix cabal-version for template-haskell-optics

### DIFF
--- a/template-haskell-optics/template-haskell-optics.cabal
+++ b/template-haskell-optics/template-haskell-optics.cabal
@@ -5,7 +5,7 @@ license-file:  LICENSE
 build-type:    Simple
 maintainer:    optics@well-typed.com
 author:        Andrzej Rybczak
-cabal-version: >=1.10
+cabal-version: 1.18
 tested-with:   ghc ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.2, GHCJS ==8.4
 synopsis:      Optics for template-haskell types
 category:      Data, Optics, Lenses


### PR DESCRIPTION
Currently `cabal check` objects due to the presence of `extra-doc-files`.