### PR TITLE
Print missing language extensions on TH generation of labels

### DIFF
--- a/optics-th/src/Optics/TH/Internal/Sum.hs
+++ b/optics-th/src/Optics/TH/Internal/Sum.hs
@@ -82,6 +82,7 @@ makeClassyPrisms = makePrisms' False
 
 makePrismLabels :: Name -> DecsQ
 makePrismLabels typeName = do
+  requireExtensionsForLabels
   info <- D.reifyDatatype typeName
   let cons = map (normalizeCon info) $ D.datatypeCons info
   catMaybes <$> traverse (makeLabel info cons) cons

--- a/optics-th/src/Optics/TH/Internal/Utils.hs
+++ b/optics-th/src/Optics/TH/Internal/Utils.hs
@@ -105,8 +105,8 @@ requireExtensions what extLists = do
       , intercalate "\n" (map (("- " ++) . show) extensions)
       , "\n\nPlease enable the extensions by copy/pasting these lines into the top of your file:\n\n"
       , intercalate "\n" (map extensionToPragma extensions)
-      , "\n\nTo enable them in the GHCi session, use the following command:\n\n"
-      , ":set " ++ unwords (map (("-X" ++) . show) extensions)
+      , "\n\nTo enable them in a GHCi session, use the following command:\n\n"
+      , ":seti " ++ unwords (map (("-X" ++) . show) extensions)
       ]
   where
     extensionToPragma ext = "{-# LANGUAGE " ++ show ext ++ " #-}"

--- a/optics-th/src/Optics/TH/Internal/Utils.hs
+++ b/optics-th/src/Optics/TH/Internal/Utils.hs
@@ -1,6 +1,8 @@
 module Optics.TH.Internal.Utils where
 
+import Control.Monad
 import Data.Maybe
+import Data.List
 import Language.Haskell.TH
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -75,6 +77,48 @@ quantifyType' exclude vars cx t = ForallT vs cx t
 
     bndrToType (PlainTV n)    = VarT n
     bndrToType (KindedTV n k) = SigT (VarT n) k
+
+-- | Pass in a list of lists of extensions, where any of the given extensions
+-- will satisfy it. For example, you might need either GADTs or
+-- ExistentialQuantification, so you'd write:
+--
+-- > requireExtensions [[GADTs, ExistentialQuantification]]
+--
+-- But if you need TypeFamilies and MultiParamTypeClasses, then you'd write:
+--
+-- > requireExtensions [[TypeFamilies], [MultiParamTypeClasses]]
+--
+requireExtensions :: String -> [[Extension]] -> Q ()
+requireExtensions what extLists = do
+  -- Taken from the persistent library
+  required <- filterM (fmap (not . or) . traverse isExtEnabled) extLists
+  case mapMaybe listToMaybe required of
+    [] -> pure ()
+    [extension] -> fail $ mconcat
+      [ "Generating " ++ what ++ " requires the "
+      , show extension
+      , " language extension. Please enable it by copy/pasting this line to the top of your file:\n\n"
+      , extensionToPragma extension
+      ]
+    extensions -> fail $ mconcat
+      [ "Generating " ++ what ++ " requires the following language extensions:\n\n"
+      , intercalate "\n" (map (("- " ++) . show) extensions)
+      , "\n\nPlease enable the extensions by copy/pasting these lines into the top of your file:\n\n"
+      , intercalate "\n" (map extensionToPragma extensions)
+      , "\n\nTo enable them in the GHCi session, use the following command:\n\n"
+      , ":set " ++ unwords (map (("-X" ++) . show) extensions)
+      ]
+  where
+    extensionToPragma ext = "{-# LANGUAGE " ++ show ext ++ " #-}"
+
+requireExtensionsForLabels :: Q ()
+requireExtensionsForLabels = requireExtensions "LabelOptic instances"
+  [ [DataKinds]
+  , [FlexibleInstances]
+  , [MultiParamTypeClasses]
+  , [TypeFamilies, GADTs]
+  , [UndecidableInstances]
+  ]
 
 ------------------------------------------------------------------------
 -- Support for generating inline pragmas

--- a/optics-th/src/Optics/TH/Internal/Utils.hs
+++ b/optics-th/src/Optics/TH/Internal/Utils.hs
@@ -99,6 +99,8 @@ requireExtensions what extLists = do
       , show extension
       , " language extension. Please enable it by copy/pasting this line to the top of your file:\n\n"
       , extensionToPragma extension
+      , "\n\nTo enable it in a GHCi session, use the following command:\n\n"
+      , ":seti -X" ++ show extension
       ]
     extensions -> fail $ mconcat
       [ "Generating " ++ what ++ " requires the following language extensions:\n\n"

--- a/optics-th/src/Optics/TH/Internal/Utils.hs
+++ b/optics-th/src/Optics/TH/Internal/Utils.hs
@@ -122,6 +122,12 @@ requireExtensionsForLabels = requireExtensions "LabelOptic instances"
   , [UndecidableInstances]
   ]
 
+requireExtensionsForFields :: Q ()
+requireExtensionsForFields = requireExtensions "field optics"
+  [ [FlexibleInstances]
+  , [FunctionalDependencies]
+  ]
+
 ------------------------------------------------------------------------
 -- Support for generating inline pragmas
 ------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #342.

```haskell
unknown@electronics optics $ cabal repl optics-th
Build profile: -w ghc-8.10.2 -O1
In order, the following will be built (use -v for more details):
 - optics-th-0.3.0.2 (lib) (file src/Optics/TH/Internal/Product.hs changed)
Preprocessing library for optics-th-0.3.0.2..
GHCi, version 8.10.2: https://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/unknown/.ghci
[1 of 5] Compiling Language.Haskell.TH.Optics.Internal ( src/Language/Haskell/TH/Optics/Internal.hs, interpreted )
[2 of 5] Compiling Optics.TH.Internal.Utils ( src/Optics/TH/Internal/Utils.hs, interpreted )
[3 of 5] Compiling Optics.TH.Internal.Sum ( src/Optics/TH/Internal/Sum.hs, interpreted )
[4 of 5] Compiling Optics.TH.Internal.Product ( src/Optics/TH/Internal/Product.hs, interpreted )
[5 of 5] Compiling Optics.TH        ( src/Optics/TH.hs, interpreted )
Ok, five modules loaded.
λ> :set -XTemplateHaskell
λ> data X = X { xX :: Int };
λ> ; makeFieldLabels ''X;

<interactive>:3:3: error:
    Generating LabelOptic instances requires the following language extensions:

- DataKinds
- FlexibleInstances
- MultiParamTypeClasses
- TypeFamilies
- UndecidableInstances

Please enable the extensions by copy/pasting these lines into the top of your file:

{-# LANGUAGE DataKinds #-}
{-# LANGUAGE FlexibleInstances #-}
{-# LANGUAGE MultiParamTypeClasses #-}
{-# LANGUAGE TypeFamilies #-}
{-# LANGUAGE UndecidableInstances #-}

To enable them in the GHCi session, use the following command:

:set -XDataKinds -XFlexibleInstances -XMultiParamTypeClasses -XTypeFamilies -XUndecidableInstances
```