### PR TITLE
Port generalized gplate from lens

### DIFF
--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -65,6 +65,12 @@ type family ShowEliminations forms :: ErrorMessage where
 ----------------------------------------
 
 data RepDefined = RepDefined
+
+-- | This type family should be called with an application of 'Rep' and will
+-- reduce to 'RepDefined' if it's defined; otherwise it is stuck.
+type family HasRep (s :: Type -> Type) :: RepDefined
+type instance HasRep (s x) = 'RepDefined
+
 -- | This type family should be called with applications of 'Rep' on both sides,
 -- and will reduce to 'RepDefined' if at least one of them is defined; otherwise
 -- it is stuck.

--- a/optics/tests/Optics/Tests/Misc.hs
+++ b/optics/tests/Optics/Tests/Misc.hs
@@ -35,6 +35,10 @@ miscTests = testGroup "Miscellaneous"
     -- GHC <= 8.4 doesn't optimize away profunctor classes
   , testCase "optimized iadjoin" $
     ghcLE84failure $(inspectTest $ hasNoProfunctors 'checkIxAdjoin)
+  , testCase "optimized gplate (profunctors)" $
+    assertSuccess $(inspectTest $ hasNoProfunctors 'checkGplate)
+  , testCase "optimized gplate (generics)" $
+    ghc80failure $(inspectTest $ hasNoGenericRep 'checkGplate)
   ]
 
 simpleMapIx
@@ -83,3 +87,8 @@ checkAdjoin = over (_1 % _Just `adjoin` _2 % chosen `adjoin` _3 % traversed)
 
 checkIxAdjoin :: (Int -> a -> a) -> ((Int, a), [a], (Int, Maybe a)) -> ((Int, a), [a], (Int, Maybe a))
 checkIxAdjoin = iover (_1 % itraversed `iadjoin` _2 % itraversed `iadjoin` _3 % itraversed % _Just)
+
+checkGplate
+  :: (Char, ([Either Char ()], Char, Maybe Char), [Char], Either Char Int)
+  -> [Char]
+checkGplate = toListOf gplate

--- a/optics/tests/Optics/Tests/Utils.hs
+++ b/optics/tests/Optics/Tests/Utils.hs
@@ -5,6 +5,7 @@ module Optics.Tests.Utils where
 import Language.Haskell.TH (Name)
 import Test.Tasty.HUnit
 import Test.Inspection
+import qualified GHC.Generics as G
 
 import qualified Data.Profunctor.Indexed as P
 
@@ -33,6 +34,21 @@ hasNoProfunctors name = mkObligation name $ NoUseOf
   , 'P.iwander
   , 'P.roam
   , 'P.iroam
+  ]
+
+-- | 'hasNoGenerics' from 'Test.Inspection' checks for lack of data types, but
+-- they show up in coercions even though the representation was optimized away;
+-- check for functions and data constructors instead.
+hasNoGenericRep :: Name -> Obligation
+hasNoGenericRep name = mkObligation name $ NoUseOf
+  [ 'G.from
+  , 'G.to
+  , '(G.:*:)
+  , 'G.K1
+  , 'G.L1
+  , 'G.M1
+  , 'G.R1
+  , 'G.U1
   ]
 
 assertSuccess :: Result -> IO ()


### PR DESCRIPTION
It's a modified `gplate` from lens that behaves like `template` from `Data.Data.Lens`, but without the weirdness observed in https://github.com/ekmett/lens/issues/907.

We can port `Control.Lens.Plated` with that.