### PR TITLE
Simplify the error generated by the GeneralLabelOptic instance

### DIFF
--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -217,15 +217,13 @@ instance {-# OVERLAPPABLE #-}
 -- variables and overlapping instances which are irrelevant and confusing. Use
 -- incoherent instance providing a custom type error to cut its efforts short.
 instance {-# INCOHERENT #-}
-  TypeError
-   ('Text "No instance for LabelOptic " ':<>: 'ShowType name
-    ':<>: 'Text " " ':<>: QuoteType k
-    ':<>: 'Text " " ':<>: QuoteType s
-    ':<>: 'Text " " ':<>: QuoteType t
-    ':<>: 'Text " " ':<>: QuoteType a
-    ':<>: 'Text " " ':<>: QuoteType b
-    ':$$: 'Text "Perhaps you forgot to define it or misspelled its name?")
-   => GeneralLabelOptic name k s t a b repDefined where
+  ( s `HasShapeOf` t
+  , t `HasShapeOf` s
+  , TypeError
+    ('Text "Type " ':<>: QuoteType s ':<>: 'Text " has no label " ':<>:
+     QuoteSymbol name ':<>: 'Text " as an optic for " ':<>: QuoteType a
+    )
+  ) => GeneralLabelOptic name k s t a b repDefined where
   generalLabelOptic = error "unreachable"
 
 instance

--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -142,3 +142,8 @@ instance CurryCompose '[] where
 instance CurryCompose xs => CurryCompose (x ': xs) where
   composeN ij f = composeN @xs ij . f
   {-# INLINE composeN #-}
+
+-- | Derive the shape of @a@ from the shape of @b@.
+class HasShapeOf (a :: k) (b :: k)
+instance {-# OVERLAPPING #-} (fa ~ f a, HasShapeOf f g) => HasShapeOf fa (g b)
+instance (a ~ b) => HasShapeOf a b


### PR DESCRIPTION
Requested in feedback after the Haskell Exchange talk.

Before:
```
λ> data User = User { name :: String } deriving Show
λ> User "Tom" & #name .~ ("x")

<interactive>:2:1: error:
    • No instance for LabelOptic "name" ‘k’ ‘User’ ‘b’ ‘a’ ‘[Char]’
      Perhaps you forgot to define it or misspelled its name?
    • When checking the inferred type
        it :: forall (k :: OpticKind) b a.
              ((TypeError ...), Is k A_Setter) =>
              b
```

After:
```
λ> data User = User { name :: String } deriving Show
λ> User "Tom" & #name .~ ("x")

<interactive>:2:14: error:
    • Type ‘User’ has no label ‘name’ as an optic for ‘a0’
    • In the first argument of ‘(.~)’, namely ‘#name’
      In the second argument of ‘(&)’, namely ‘#name .~ ("x")’
      In the expression: User "Tom" & #name .~ ("x")
```