### PR TITLE
Make IxList a dedicated type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -221,7 +221,7 @@ script:
   - if ! $GHCJS ; then ${CABAL} v2-test $WITHCOMPILER ${TEST} ${BENCH} all ; fi
   # Doctest...
   - if ! $GHCJS ; then (cd ${PKGDIR_optics} && doctest  src) ; fi
-  - if ! $GHCJS ; then (cd ${PKGDIR_optics_core} && doctest  -XBangPatterns -XDefaultSignatures -XDeriveFunctor -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XInstanceSigs -XLambdaCase -XMultiParamTypeClasses -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators src) ; fi
+  - if ! $GHCJS ; then (cd ${PKGDIR_optics_core} && doctest  -XBangPatterns -XDataKinds -XDefaultSignatures -XDeriveFunctor -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XInstanceSigs -XLambdaCase -XMultiParamTypeClasses -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators src) ; fi
   - if ! $GHCJS ; then (cd ${PKGDIR_optics_extra} && doctest  -XBangPatterns -XDefaultSignatures -XDeriveFunctor -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XInstanceSigs -XLambdaCase -XMultiParamTypeClasses -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators src) ; fi
   - if ! $GHCJS ; then (cd ${PKGDIR_optics_sop} && doctest  src) ; fi
   - if ! $GHCJS ; then (cd ${PKGDIR_optics_th} && doctest  src) ; fi

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -124,6 +124,7 @@ library
                    Optics.Internal.Utils
 
   default-extensions: BangPatterns
+                      DataKinds
                       DefaultSignatures
                       DeriveFunctor
                       FlexibleContexts

--- a/optics-core/src/Data/Tuple/Optics.hs
+++ b/optics-core/src/Data/Tuple/Optics.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 -- |
 -- Module: Data.Tuple.Optics
 -- Description: 'Lens'es for tuple types.

--- a/optics-core/src/Optics/AffineFold.hs
+++ b/optics-core/src/Optics/AffineFold.hs
@@ -61,7 +61,7 @@ import Optics.Internal.Bi
 import Optics.Internal.Optic
 
 -- | Type synonym for an affine fold.
-type AffineFold s a = Optic' An_AffineFold NoIx s a
+type AffineFold s a = Optic' An_AffineFold 'NoIx s a
 
 -- | Obtain an 'AffineFold' by lifting 'traverse_' like function.
 --

--- a/optics-core/src/Optics/AffineTraversal.hs
+++ b/optics-core/src/Optics/AffineTraversal.hs
@@ -65,10 +65,10 @@ import Data.Profunctor.Indexed
 import Optics.Internal.Optic
 
 -- | Type synonym for a type-modifying affine traversal.
-type AffineTraversal s t a b = Optic An_AffineTraversal NoIx s t a b
+type AffineTraversal s t a b = Optic An_AffineTraversal 'NoIx s t a b
 
 -- | Type synonym for a type-preserving affine traversal.
-type AffineTraversal' s a = Optic' An_AffineTraversal NoIx s a
+type AffineTraversal' s a = Optic' An_AffineTraversal 'NoIx s a
 
 -- | Type synonym for a type-modifying van Laarhoven affine traversal.
 --

--- a/optics-core/src/Optics/At/Core.hs
+++ b/optics-core/src/Optics/At/Core.hs
@@ -146,8 +146,8 @@ class Ixed m where
   --
   -- >>> [] ^? ix 2
   -- Nothing
-  ix :: Index m -> Optic' (IxKind m) NoIx m (IxValue m)
-  default ix :: (At m, IxKind m ~ An_AffineTraversal) => Index m -> Optic' (IxKind m) NoIx m (IxValue m)
+  ix :: Index m -> Optic' (IxKind m) 'NoIx m (IxValue m)
+  default ix :: (At m, IxKind m ~ An_AffineTraversal) => Index m -> Optic' (IxKind m) 'NoIx m (IxValue m)
   ix = ixAt
   {-# INLINE ix #-}
 

--- a/optics-core/src/Optics/Fold.hs
+++ b/optics-core/src/Optics/Fold.hs
@@ -115,7 +115,7 @@ import Optics.Internal.Optic
 import Optics.Internal.Utils
 
 -- | Type synonym for a fold.
-type Fold s a = Optic' A_Fold NoIx s a
+type Fold s a = Optic' A_Fold 'NoIx s a
 
 -- | Obtain a 'Fold' by lifting 'traverse_' like function.
 --

--- a/optics-core/src/Optics/Generic.hs
+++ b/optics-core/src/Optics/Generic.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- |
@@ -316,5 +315,5 @@ instance GPlate Void0 a where
   gplate = error "unreachable"
 
 -- $setup
--- >>> :set -XDataKinds -XDeriveGeneric -XStandaloneDeriving -XOverloadedLabels
+-- >>> :set -XDeriveGeneric -XStandaloneDeriving -XOverloadedLabels
 -- >>> import Optics.Core

--- a/optics-core/src/Optics/Getter.hs
+++ b/optics-core/src/Optics/Getter.hs
@@ -45,7 +45,7 @@ import Optics.Internal.Bi
 import Optics.Internal.Optic
 
 -- | Type synonym for a getter.
-type Getter s a = Optic' A_Getter NoIx s a
+type Getter s a = Optic' A_Getter 'NoIx s a
 
 -- | View the value pointed to by a getter.
 --

--- a/optics-core/src/Optics/Indexed/Core.hs
+++ b/optics-core/src/Optics/Indexed/Core.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 -- |
 -- Module: Optics.Indexed.Core
 -- Description: Core definitions for indexed optics.

--- a/optics-core/src/Optics/Indexed/Core.hs
+++ b/optics-core/src/Optics/Indexed/Core.hs
@@ -77,9 +77,9 @@ infixl 9 <%>
 (<%>)
   :: (m ~ Join k l, Is k m, Is l m, IxOptic m s t a b,
       is `HasSingleIndex` i, js `HasSingleIndex` j)
-  => Optic k is              s t u v
-  -> Optic l js              u v a b
-  -> Optic m (WithIx (i, j)) s t a b
+  => Optic k is               s t u v
+  -> Optic l js               u v a b
+  -> Optic m ('WithIx (i, j)) s t a b
 o <%> o' = icompose (,) (o % o')
 {-# INLINE (<%>) #-}
 
@@ -124,8 +124,8 @@ o <% o' = o % noIx o'
 reindexed
   :: is `HasSingleIndex` i
   => (i -> j)
-  -> Optic k is         s t a b
-  -> Optic k (WithIx j) s t a b
+  -> Optic k is          s t a b
+  -> Optic k ('WithIx j) s t a b
 reindexed = icomposeN
 {-# INLINE reindexed #-}
 
@@ -136,8 +136,8 @@ reindexed = icomposeN
 --
 icompose
   :: (i -> j -> ix)
-  -> Optic k '[i, j]     s t a b
-  -> Optic k (WithIx ix) s t a b
+  -> Optic k ('MultiIx i j '[]) s t a b
+  -> Optic k ('WithIx ix)       s t a b
 icompose = icomposeN
 {-# INLINE icompose #-}
 
@@ -148,24 +148,24 @@ icompose = icomposeN
 --
 icompose3
   :: (i1 -> i2 -> i3 -> ix)
-  -> Optic k '[i1, i2, i3] s t a b
-  -> Optic k (WithIx ix)   s t a b
+  -> Optic k ('MultiIx i1 i2 '[i3]) s t a b
+  -> Optic k ('WithIx ix)           s t a b
 icompose3 = icomposeN
 {-# INLINE icompose3 #-}
 
 -- | Flatten indices obtained from four indexed optics.
 icompose4
   :: (i1 -> i2 -> i3 -> i4 -> ix)
-  -> Optic k '[i1, i2, i3, i4] s t a b
-  -> Optic k (WithIx ix)       s t a b
+  -> Optic k ('MultiIx i1 i2 '[i3, i4]) s t a b
+  -> Optic k ('WithIx ix)               s t a b
 icompose4 = icomposeN
 {-# INLINE icompose4 #-}
 
 -- | Flatten indices obtained from five indexed optics.
 icompose5
   :: (i1 -> i2 -> i3 -> i4 -> i5 -> ix)
-  -> Optic k '[i1, i2, i3, i4, i5] s t a b
-  -> Optic k (WithIx ix)           s t a b
+  -> Optic k ('MultiIx i1 i2 '[i3, i4, i5]) s t a b
+  -> Optic k ('WithIx ix)                   s t a b
 icompose5 = icomposeN
 {-# INLINE icompose5 #-}
 
@@ -174,9 +174,9 @@ icomposeN
   :: forall k i is s t a b
   . (CurryCompose is, NonEmptyIndices is)
   => Curry is i
-  -> Optic k is         s t a b
-  -> Optic k (WithIx i) s t a b
-icomposeN f (Optic o) = Optic (ixcontramap (\ij -> composeN @is ij f) . o)
+  -> Optic k is          s t a b
+  -> Optic k ('WithIx i) s t a b
+icomposeN f (Optic o) = Optic (ixcontramap (\ij -> curryCompose @is ij f) . o)
 {-# INLINE icomposeN #-}
 
 ----------------------------------------
@@ -187,8 +187,8 @@ class IxOptic k s t a b where
   -- | Convert an indexed optic to its unindexed equivalent.
   noIx
     :: NonEmptyIndices is
-    => Optic k is   s t a b
-    -> Optic k NoIx s t a b
+    => Optic k is    s t a b
+    -> Optic k 'NoIx s t a b
 
 instance (s ~ t, a ~ b) => IxOptic A_Getter s t a b where
   noIx o = to (view o)

--- a/optics-core/src/Optics/Internal/Generic.hs
+++ b/optics-core/src/Optics/Internal/Generic.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK not-home #-}

--- a/optics-core/src/Optics/Internal/Generic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Generic/TypeLevel.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK not-home #-}

--- a/optics-core/src/Optics/Internal/Indexed.hs
+++ b/optics-core/src/Optics/Internal/Indexed.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeInType #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK not-home #-}

--- a/optics-core/src/Optics/Internal/Magic.hs
+++ b/optics-core/src/Optics/Internal/Magic.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK not-home #-}

--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeInType #-}
 {-# OPTIONS_HADDOCK not-home #-}
 

--- a/optics-core/src/Optics/Internal/Optic/Subtyping.hs
+++ b/optics-core/src/Optics/Internal/Optic/Subtyping.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeInType #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK not-home #-}

--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeInType #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK not-home #-}

--- a/optics-core/src/Optics/Internal/Optic/Types.hs
+++ b/optics-core/src/Optics/Internal/Optic/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeInType #-}
 {-# OPTIONS_HADDOCK not-home #-}
 

--- a/optics-core/src/Optics/Iso.hs
+++ b/optics-core/src/Optics/Iso.hs
@@ -103,10 +103,10 @@ import Optics.Review
 import Optics.Internal.Optic
 
 -- | Type synonym for a type-modifying iso.
-type Iso s t a b = Optic An_Iso NoIx s t a b
+type Iso s t a b = Optic An_Iso 'NoIx s t a b
 
 -- | Type synonym for a type-preserving iso.
-type Iso' s a = Optic' An_Iso NoIx s a
+type Iso' s a = Optic' An_Iso 'NoIx s a
 
 -- | Build an iso from a pair of inverse functions.
 --

--- a/optics-core/src/Optics/IxAffineFold.hs
+++ b/optics-core/src/Optics/IxAffineFold.hs
@@ -63,7 +63,7 @@ import Optics.Internal.Optic
 import Optics.Internal.Utils
 
 -- | Type synonym for an indexed affine fold.
-type IxAffineFold i s a = Optic' An_AffineFold (WithIx i) s a
+type IxAffineFold i s a = Optic' An_AffineFold ('WithIx i) s a
 
 -- | Obtain an 'IxAffineFold' by lifting 'itraverse_' like function.
 --

--- a/optics-core/src/Optics/IxAffineTraversal.hs
+++ b/optics-core/src/Optics/IxAffineTraversal.hs
@@ -54,10 +54,10 @@ import Optics.Internal.Optic
 import Optics.Internal.Utils
 
 -- | Type synonym for a type-modifying indexed affine traversal.
-type IxAffineTraversal i s t a b = Optic An_AffineTraversal (WithIx i) s t a b
+type IxAffineTraversal i s t a b = Optic An_AffineTraversal ('WithIx i) s t a b
 
 -- | Type synonym for a type-preserving indexed affine traversal.
-type IxAffineTraversal' i s a = Optic' An_AffineTraversal (WithIx i) s a
+type IxAffineTraversal' i s a = Optic' An_AffineTraversal ('WithIx i) s a
 
 -- | Type synonym for a type-modifying van Laarhoven indexed affine traversal.
 --

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
 -- |
 -- Module: Optics.IxFold
 -- Description: An indexed version of a 'Optics.Fold.Fold'.

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -84,7 +84,7 @@ import Optics.IxAffineFold
 import Optics.Fold
 
 -- | Type synonym for an indexed fold.
-type IxFold i s a = Optic' A_Fold (WithIx i) s a
+type IxFold i s a = Optic' A_Fold ('WithIx i) s a
 
 -- | Obtain an indexed fold by lifting 'itraverse_' like function.
 --

--- a/optics-core/src/Optics/IxGetter.hs
+++ b/optics-core/src/Optics/IxGetter.hs
@@ -31,7 +31,7 @@ import Optics.Internal.Optic
 import Optics.Internal.Utils
 
 -- | Type synonym for an indexed getter.
-type IxGetter i s a = Optic' A_Getter (WithIx i) s a
+type IxGetter i s a = Optic' A_Getter ('WithIx i) s a
 
 -- | Build an indexed getter from a function.
 --

--- a/optics-core/src/Optics/IxLens.hs
+++ b/optics-core/src/Optics/IxLens.hs
@@ -52,10 +52,10 @@ import Optics.Internal.Optic
 import Optics.Internal.Utils
 
 -- | Type synonym for a type-modifying indexed lens.
-type IxLens i s t a b = Optic A_Lens (WithIx i) s t a b
+type IxLens i s t a b = Optic A_Lens ('WithIx i) s t a b
 
 -- | Type synonym for a type-preserving indexed lens.
-type IxLens' i s a = Optic' A_Lens (WithIx i) s a
+type IxLens' i s a = Optic' A_Lens ('WithIx i) s a
 
 -- | Type synonym for a type-modifying van Laarhoven indexed lens.
 type IxLensVL i s t a b =

--- a/optics-core/src/Optics/IxSetter.hs
+++ b/optics-core/src/Optics/IxSetter.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 -- |
 -- Module: Optics.IxSetter
 -- Description: An indexed version of a 'Optics.Setter.Setter'.

--- a/optics-core/src/Optics/IxSetter.hs
+++ b/optics-core/src/Optics/IxSetter.hs
@@ -66,10 +66,10 @@ import Optics.Internal.Optic
 import Optics.Internal.Utils
 
 -- | Type synonym for a type-modifying indexed setter.
-type IxSetter i s t a b = Optic A_Setter (WithIx i) s t a b
+type IxSetter i s t a b = Optic A_Setter ('WithIx i) s t a b
 
 -- | Type synonym for a type-preserving indexed setter.
-type IxSetter' i s a = Optic' A_Setter (WithIx i) s a
+type IxSetter' i s a = Optic' A_Setter ('WithIx i) s a
 
 -- | Apply an indexed setter as a modifier.
 iover

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 -- |
 -- Module: Optics.IxTraversal
 -- Description: An indexed version of a 'Optics.Traversal.Traversal'.

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -110,10 +110,10 @@ import Optics.ReadOnly
 import Optics.Traversal
 
 -- | Type synonym for a type-modifying indexed traversal.
-type IxTraversal i s t a b = Optic A_Traversal (WithIx i) s t a b
+type IxTraversal i s t a b = Optic A_Traversal ('WithIx i) s t a b
 
 -- | Type synonym for a type-preserving indexed traversal.
-type IxTraversal' i s a = Optic' A_Traversal (WithIx i) s a
+type IxTraversal' i s a = Optic' A_Traversal ('WithIx i) s a
 
 -- | Type synonym for a type-modifying van Laarhoven indexed traversal.
 type IxTraversalVL i s t a b =

--- a/optics-core/src/Optics/Label.hs
+++ b/optics-core/src/Optics/Label.hs
@@ -498,7 +498,7 @@ class LabelOptic (name :: Symbol) k s t a b | name s -> k a
                                             , name t a -> s where
   -- | Used to interpret overloaded label syntax.  An overloaded label @#foo@
   -- corresponds to @'labelOptic' \@"foo"@.
-  labelOptic :: Optic k NoIx s t a b
+  labelOptic :: Optic k 'NoIx s t a b
 
 -- | Type synonym for a type-preserving optic as overloaded label.
 type LabelOptic' name k s a = LabelOptic name k s s a a
@@ -586,7 +586,7 @@ class Generic a => GenericLabelOptics a where
 ----------------------------------------
 
 class GenericOptic name k s t a b where
-  genericOptic :: Optic k NoIx s t a b
+  genericOptic :: Optic k 'NoIx s t a b
 
 instance
   ( GFieldImpl name s t a b
@@ -602,7 +602,7 @@ instance
 ----------------------------------------
 
 instance
-  (LabelOptic name k s t a b, is ~ NoIx
+  (LabelOptic name k s t a b, is ~ 'NoIx
   ) => IsLabel name (Optic k is s t a b) where
   fromLabel = labelOptic @name
 

--- a/optics-core/src/Optics/Label.hs
+++ b/optics-core/src/Optics/Label.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeInType #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/optics-core/src/Optics/Lens.hs
+++ b/optics-core/src/Optics/Lens.hs
@@ -120,10 +120,10 @@ import Data.Profunctor.Indexed
 import Optics.Internal.Optic
 
 -- | Type synonym for a type-modifying lens.
-type Lens s t a b = Optic A_Lens NoIx s t a b
+type Lens s t a b = Optic A_Lens 'NoIx s t a b
 
 -- | Type synonym for a type-preserving lens.
-type Lens' s a = Optic' A_Lens NoIx s a
+type Lens' s a = Optic' A_Lens 'NoIx s a
 
 -- | Type synonym for a type-modifying van Laarhoven lens.
 type LensVL s t a b = forall f. Functor f => (a -> f b) -> s -> f t

--- a/optics-core/src/Optics/Mapping.hs
+++ b/optics-core/src/Optics/Mapping.hs
@@ -6,7 +6,6 @@
 -- @'Optic'' ('MappedOptic' k) 'NoIx' (f s) (f a)@, in other words optic operating on values
 -- in a 'Functor'.
 --
-{-# LANGUAGE DataKinds #-}
 module Optics.Mapping
   ( MappingOptic (..)
   ) where

--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -57,9 +57,7 @@ module Optics.Optic
   -- | See the "Indexed optics" section of the overview documentation in the
   -- @Optics@ module of the main @optics@ package for more details on indexed
   -- optics.
-  , IxList
-  , NoIx
-  , WithIx
+  , IxList(..)
   , Append
   , NonEmptyIndices
   , HasSingleIndex

--- a/optics-core/src/Optics/Prism.hs
+++ b/optics-core/src/Optics/Prism.hs
@@ -83,10 +83,10 @@ import Data.Profunctor.Indexed
 import Optics.Internal.Optic
 
 -- | Type synonym for a type-modifying prism.
-type Prism s t a b = Optic A_Prism NoIx s t a b
+type Prism s t a b = Optic A_Prism 'NoIx s t a b
 
 -- | Type synonym for a type-preserving prism.
-type Prism' s a = Optic' A_Prism NoIx s a
+type Prism' s a = Optic' A_Prism 'NoIx s a
 
 -- | Build a prism from a constructor and a matcher, which must respect the
 -- well-formedness laws.

--- a/optics-core/src/Optics/Re.hs
+++ b/optics-core/src/Optics/Re.hs
@@ -22,7 +22,6 @@
 --
 -- <<diagrams/reoptics.png Reversed Optics>>
 --
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 module Optics.Re
   ( ReversibleOptic(..)

--- a/optics-core/src/Optics/Re.hs
+++ b/optics-core/src/Optics/Re.hs
@@ -98,8 +98,8 @@ instance ReversibleOptic A_Review where
 -- | Internal implementation of re.
 re__
   :: (Profunctor p, Constraints k (Re p a b))
-  => Optic k  NoIx s t a b
-  -> Optic__ p i i b a t s
+  => Optic k  'NoIx s t a b
+  -> Optic__ p i i  b a t s
 re__ o = unRe (getOptic o (Re id))
 {-# INLINE re__ #-}
 

--- a/optics-core/src/Optics/ReversedLens.hs
+++ b/optics-core/src/Optics/ReversedLens.hs
@@ -57,7 +57,7 @@ module Optics.ReversedLens
 import Optics.Internal.Optic
 
 -- | Type synonym for a type-modifying reversed lens.
-type ReversedLens s t a b = Optic A_ReversedLens NoIx s t a b
+type ReversedLens s t a b = Optic A_ReversedLens 'NoIx s t a b
 
 -- | Type synonym for a type-preserving reversed lens.
-type ReversedLens' t b = Optic' A_ReversedLens NoIx t b
+type ReversedLens' t b = Optic' A_ReversedLens 'NoIx t b

--- a/optics-core/src/Optics/ReversedPrism.hs
+++ b/optics-core/src/Optics/ReversedPrism.hs
@@ -57,7 +57,7 @@ module Optics.ReversedPrism
 import Optics.Internal.Optic
 
 -- | Type synonym for a type-modifying reversed prism.
-type ReversedPrism s t a b = Optic A_ReversedPrism NoIx s t a b
+type ReversedPrism s t a b = Optic A_ReversedPrism 'NoIx s t a b
 
 -- | Type synonym for a type-preserving reversed prism.
-type ReversedPrism' s a = Optic' A_ReversedPrism NoIx s a
+type ReversedPrism' s a = Optic' A_ReversedPrism 'NoIx s a

--- a/optics-core/src/Optics/Review.hs
+++ b/optics-core/src/Optics/Review.hs
@@ -35,7 +35,7 @@ import Optics.Internal.Bi
 import Optics.Internal.Optic
 
 -- | Type synonym for a review.
-type Review t b = Optic' A_Review NoIx t b
+type Review t b = Optic' A_Review 'NoIx t b
 
 -- | Retrieve the value targeted by a 'Review'.
 --

--- a/optics-core/src/Optics/Setter.hs
+++ b/optics-core/src/Optics/Setter.hs
@@ -67,10 +67,10 @@ import Optics.Internal.Setter
 import Optics.Internal.Utils
 
 -- | Type synonym for a type-modifying setter.
-type Setter s t a b = Optic A_Setter NoIx s t a b
+type Setter s t a b = Optic A_Setter 'NoIx s t a b
 
 -- | Type synonym for a type-preserving setter.
-type Setter' s a = Optic' A_Setter NoIx s a
+type Setter' s a = Optic' A_Setter 'NoIx s a
 
 -- | Apply a setter as a modifier.
 over

--- a/optics-core/src/Optics/Traversal.hs
+++ b/optics-core/src/Optics/Traversal.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE EmptyCase #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- |
 -- Module: Optics.Traversal

--- a/optics-core/src/Optics/Traversal.hs
+++ b/optics-core/src/Optics/Traversal.hs
@@ -113,10 +113,10 @@ import Optics.Lens
 import Optics.ReadOnly
 
 -- | Type synonym for a type-modifying traversal.
-type Traversal s t a b = Optic A_Traversal NoIx s t a b
+type Traversal s t a b = Optic A_Traversal 'NoIx s t a b
 
 -- | Type synonym for a type-preserving traversal.
-type Traversal' s a = Optic' A_Traversal NoIx s a
+type Traversal' s a = Optic' A_Traversal 'NoIx s a
 
 -- | Type synonym for a type-modifying van Laarhoven traversal.
 type TraversalVL s t a b = forall f. Applicative f => (a -> f b) -> s -> f t

--- a/optics/tests/Optics/Tests.hs
+++ b/optics/tests/Optics/Tests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fplugin=Test.Inspection.Plugin -dsuppress-all #-}
 module Main (main) where
@@ -14,19 +15,19 @@ import Optics.Tests.Misc
 import Optics.Tests.Properties
 
 -- | Composing a lens and a traversal yields a traversal
-_comp1 :: Traversable t => Optic A_Traversal NoIx (t a, y) (t b, y) a b
+_comp1 :: Traversable t => Optic A_Traversal 'NoIx (t a, y) (t b, y) a b
 _comp1 = _1 % traversed
 
 -- | Composing two lenses yields a lens
-_comp2 :: Optic A_Lens NoIx ((a, y), y1) ((b, y), y1) a b
+_comp2 :: Optic A_Lens 'NoIx ((a, y), y1) ((b, y), y1) a b
 _comp2 = _1 % _1
 
 -- | Composing a getter and a lens yields a getter
-_comp3 :: Optic A_Getter NoIx ((b, y), b1) ((b, y), b1) b b
+_comp3 :: Optic A_Getter 'NoIx ((b, y), b1) ((b, y), b1) b b
 _comp3 = to fst % _1
 
 -- | Composing a prism and a lens yields a traversal
-_comp4 :: Optic An_AffineTraversal NoIx (Either c (a, y)) (Either c (b, y)) a b
+_comp4 :: Optic An_AffineTraversal 'NoIx (Either c (a, y)) (Either c (b, y)) a b
 _comp4 = _Right % _1
 
 -- | An iso can be used as a getter

--- a/optics/tests/Optics/Tests/Properties.hs
+++ b/optics/tests/Optics/Tests/Properties.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 module Optics.Tests.Properties (propertiesTests) where
 
 import Data.Either (isRight)
@@ -82,5 +83,5 @@ propertiesTests = testGroup "properties"
     ]
   ]
 
-reviewing :: Optic A_Review NoIx s t a b -> Review t b
+reviewing :: Optic A_Review 'NoIx s t a b -> Review t b
 reviewing (Optic o) = Optic (lphantom . o . lphantom)


### PR DESCRIPTION
Another attempt to improve the current `IxList` situation and fix #260.

Before:

```haskell
λ> :t traversed % _Left
traversed % _Left
  :: Traversable t =>
     Optic A_Traversal '[] (t (Either a b1)) (t (Either b2 b1)) a b2

λ> :t itraversed % _Left
itraversed % _Left
  :: TraversableWithIndex i f =>
     Optic A_Traversal '[i] (f (Either a b1)) (f (Either b2 b1)) a b2

λ> :t itraversed % _Left % itraversed
itraversed % _Left % itraversed
  :: (TraversableWithIndex i1 f1, TraversableWithIndex i2 f2) =>
     Optic
       A_Traversal
       '[i1, i2]
       (f1 (Either (f2 a) b1))
       (f1 (Either (f2 b2) b1))
       a
       b2
```

After:

```haskell
λ> :t traversed % _Left
traversed % _Left
  :: Traversable t =>
     Optic A_Traversal 'NoIx (t (Either a b1)) (t (Either b2 b1)) a b2

λ> :t itraversed % _Left
itraversed % _Left
  :: TraversableWithIndex i f =>
     Optic
       A_Traversal ('WithIx i) (f (Either a b1)) (f (Either b2 b1)) a b2

λ> :t itraversed % _Left % itraversed
itraversed % _Left % itraversed
  :: (TraversableWithIndex i1 f1, TraversableWithIndex i2 f2) =>
     Optic
       A_Traversal
       ('MultiIx i1 i2 '[])
       (f1 (Either (f2 a) b1))
       (f1 (Either (f2 b2) b1))
       a
       b2
```

etc.