### PR TITLE
Remove unsafeCoerce from appendIndices and fix tests with GHC 9.0.1

### DIFF
--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -30,7 +30,6 @@ module Optics.Internal.Optic
   ) where
 
 import Data.Function ((&))
-import Data.Type.Equality
 
 import Data.Profunctor.Indexed
 
@@ -114,7 +113,7 @@ castOptic (Optic o) = Optic (cast o)
 -- indexed, the composition preserves all the indices.
 --
 infixl 9 %
-(%) :: (Is k m, Is l m, m ~ Join k l, ks ~ Append is js)
+(%) :: (Is k m, Is l m, m ~ Join k l, AppendIndices is js, ks ~ Append is js)
     => Optic k is s t u v
     -> Optic l js u v a b
     -> Optic m ks s t a b
@@ -127,14 +126,14 @@ o % o' = castOptic o %% castOptic o'
 -- type inference if the type of one of the optics is otherwise
 -- under-constrained.
 infixl 9 %%
-(%%) :: forall k is js ks s t u v a b. ks ~ Append is js
+(%%) :: forall k is js ks s t u v a b. (AppendIndices is js, ks ~ Append is js)
      => Optic k is s t u v
      -> Optic k js u v a b
      -> Optic k ks s t a b
 Optic o %% Optic o' = Optic oo
   where
     oo :: forall p i. (Profunctor p, Constraints k p) => Optic__ p i (Curry ks i) s t a b
-    oo | Refl <- appendIndices @is @js @i = o . o'
+    oo | IxEq <- appendIndices @is @js @i = o . o'
 
 -- | Flipped function application, specialised to optics and binding tightly.
 --

--- a/optics-core/src/Optics/Internal/Optic.hs
+++ b/optics-core/src/Optics/Internal/Optic.hs
@@ -113,7 +113,7 @@ castOptic (Optic o) = Optic (cast o)
 -- indexed, the composition preserves all the indices.
 --
 infixl 9 %
-(%) :: (Is k m, Is l m, m ~ Join k l, AppendIndices is js, ks ~ Append is js)
+(%) :: (Is k m, Is l m, m ~ Join k l, AppendIndices is js ks)
     => Optic k is s t u v
     -> Optic l js u v a b
     -> Optic m ks s t a b
@@ -126,14 +126,14 @@ o % o' = castOptic o %% castOptic o'
 -- type inference if the type of one of the optics is otherwise
 -- under-constrained.
 infixl 9 %%
-(%%) :: forall k is js ks s t u v a b. (AppendIndices is js, ks ~ Append is js)
+(%%) :: forall k is js ks s t u v a b. AppendIndices is js ks
      => Optic k is s t u v
      -> Optic k js u v a b
      -> Optic k ks s t a b
 Optic o %% Optic o' = Optic oo
   where
     oo :: forall p i. (Profunctor p, Constraints k p) => Optic__ p i (Curry ks i) s t a b
-    oo | IxEq <- appendIndices @is @js @i = o . o'
+    oo | IxEq <- appendIndices @is @js @ks @i = o . o'
 
 -- | Flipped function application, specialised to optics and binding tightly.
 --

--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -108,8 +108,8 @@ data IxEq i is js where
 class AppendIndices xs ys ks | xs ys -> ks where
   appendIndices :: IxEq i (Curry xs (Curry ys i)) (Curry ks i)
 
--- | If we know the second list is empty, we can pick the first list without
--- knowing anything about it, hence the instance is marked as INCOHERENT.
+-- | If the second list is empty, we can shortcircuit and pick the first list
+-- immediately.
 instance {-# INCOHERENT #-} AppendIndices xs '[] xs where
   appendIndices = IxEq
 

--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -105,23 +105,20 @@ data IxEq i is js where
 -- foldr f (foldr f init xs) ys = foldr f init (ys ++ xs)
 --    where f = (->)
 -- @
-class AppendIndices xs ys where
-  appendIndices :: IxEq i (Curry xs (Curry ys i)) (Curry (Append xs ys) i)
+class AppendIndices xs ys ks | xs ys -> ks where
+  appendIndices :: IxEq i (Curry xs (Curry ys i)) (Curry ks i)
 
 -- | If we know the second list is empty, we can pick the first list without
 -- knowing anything about it, hence the instance is marked as INCOHERENT.
-instance {-# INCOHERENT #-} AppendIndices xs '[] where
+instance {-# INCOHERENT #-} AppendIndices xs '[] xs where
   appendIndices = IxEq
 
-instance AppendIndices '[] ys where
+instance AppendIndices '[] ys ys where
   appendIndices = IxEq
 
-instance
-  (Append (x ': xs) ys ~ (x ': Append xs ys), AppendIndices xs ys
-  ) => AppendIndices (x ': xs) ys where
-  appendIndices :: forall i. IxEq i (Curry (x ': xs) (Curry ys i))
-                                    (Curry (x ': Append xs ys) i)
-  appendIndices | IxEq <- appendIndices @xs @ys @i = IxEq
+instance AppendIndices xs ys ks => AppendIndices (x ': xs) ys (x ': ks) where
+  appendIndices :: forall i. IxEq i (Curry (x ': xs) (Curry ys i)) (Curry (x ': ks) i)
+  appendIndices | IxEq <- appendIndices @xs @ys @ks @i = IxEq
 
 ----------------------------------------
 -- Either

--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -61,6 +61,7 @@ module Optics.Optic
   , NoIx
   , WithIx
   , Append
+  , AppendIndices
   , NonEmptyIndices
   , HasSingleIndex
   , AcceptsEmptyIndices

--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -60,7 +60,6 @@ module Optics.Optic
   , IxList
   , NoIx
   , WithIx
-  , Append
   , AppendIndices
   , NonEmptyIndices
   , HasSingleIndex

--- a/optics/tests/Optics/Tests/Core.hs
+++ b/optics/tests/Optics/Tests/Core.hs
@@ -66,8 +66,8 @@ coreTests = testGroup "Core"
   , testCase "optimized rhs09" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs09)
   , testCase "itraverseOf_ itraversed = itraverseOf_ ifolded" $
-    -- GHC >= 8.2 && =< 8.6 gives different order of let bindings
-    ghc82to86failure $(inspectTest $ 'lhs10 === 'rhs10)
+    -- GHC 8.2 gives a different order of let bindings
+    ghc82failure $(inspectTest $ 'lhs10 === 'rhs10)
   , testCase "optimized lhs10a" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs10a)
   , testCase "optimized rhs10a" $

--- a/optics/tests/Optics/Tests/Core.hs
+++ b/optics/tests/Optics/Tests/Core.hs
@@ -60,7 +60,8 @@ coreTests = testGroup "Core"
   , testCase "optimized rhs08a" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs08a)
   , testCase "iover (imapped <% imapped) = iover (imapped % mapped)" $
-    assertSuccess $(inspectTest $ 'lhs09 === 'rhs09)
+    -- GHC 9.0.1 splits the rhs into two bindings
+    ghc90failure $(inspectTest $ 'lhs09 === 'rhs09)
   , testCase "optimized lhs09" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs09)
   , testCase "optimized rhs09" $

--- a/optics/tests/Optics/Tests/Eta.hs
+++ b/optics/tests/Optics/Tests/Eta.hs
@@ -32,8 +32,8 @@ etaTests = testGroup "Eta expansion"
   , testCase "optimized eta5lhs" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'eta5lhs)
   , testCase "itraverseOf_ ifolded = \\f -> itraverseOf_ ifolded f" $
-    -- See the definition of itraverseOf_ for details.
-    ghc82failure $(inspectTest $ 'eta6lhs === 'eta6rhs)
+    -- The lhs has more lets which the rhs inlines.
+    ghc82and90failure $(inspectTest $ 'eta6lhs === 'eta6rhs)
   , testCase "optimized eta6lhs" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'eta6lhs)
   , testCase "over mapped = \\f -> over mapped f" $

--- a/optics/tests/Optics/Tests/Misc.hs
+++ b/optics/tests/Optics/Tests/Misc.hs
@@ -39,6 +39,8 @@ miscTests = testGroup "Miscellaneous"
     assertSuccess $(inspectTest $ hasNoProfunctors 'checkGplate)
   , testCase "optimized gplate (generics)" $
     assertSuccess $(inspectTest $ hasNoGenericRep 'checkGplate)
+  , testCase "optimized icomposeN/appendIndices" $
+    assertSuccess $ $(inspectTest $ hasNoIndexClasses 'checkNoIndexFunctions)
   ]
 
 simpleMapIx
@@ -92,3 +94,18 @@ checkGplate
   :: (Char, ([Either Char ()], Char, Maybe Char), [Char], Either Char Int)
   -> [Char]
 checkGplate = toListOf gplate
+
+checkNoIndexFunctions
+  :: ( TraversableWithIndex i1 f1, TraversableWithIndex i2 f2
+     , TraversableWithIndex i3 f3, TraversableWithIndex i4 f4
+     , TraversableWithIndex i5 f5, TraversableWithIndex i6 f6
+     , TraversableWithIndex i7 f7, TraversableWithIndex i8 f8
+     ) => Optic A_Traversal
+                (WithIx (i1, i2, i3, i4, i5, i6, i7, i8))
+                (f1 (f2 (f3 (f4 (f5 (f6 (f7 (f8 a))))))))
+                (f1 (f2 (f3 (f4 (f5 (f6 (f7 (f8 b))))))))
+                a
+                b
+checkNoIndexFunctions
+  = icomposeN (,,,,,,,) $ (((itraversed % itraversed) % itraversed) % itraversed)
+                        % (itraversed % (itraversed % (itraversed % itraversed)))

--- a/optics/tests/Optics/Tests/Utils.hs
+++ b/optics/tests/Optics/Tests/Utils.hs
@@ -95,3 +95,17 @@ ghcLE84failure = assertFailure'
 #else
 ghcLE84failure = assertSuccess
 #endif
+
+ghc82and90failure :: Result -> IO ()
+#if __GLASGOW_HASKELL__ == 802 || __GLASGOW_HASKELL__ == 900
+ghc82and90failure = assertFailure'
+#else
+ghc82and90failure = assertSuccess
+#endif
+
+ghc90failure :: Result -> IO ()
+#if __GLASGOW_HASKELL__ == 900
+ghc90failure = assertFailure'
+#else
+ghc90failure = assertSuccess
+#endif

--- a/optics/tests/Optics/Tests/Utils.hs
+++ b/optics/tests/Optics/Tests/Utils.hs
@@ -7,6 +7,7 @@ import Test.Tasty.HUnit
 import Test.Inspection
 import qualified GHC.Generics as G
 
+import Optics.Internal.Optic
 import qualified Data.Profunctor.Indexed as P
 
 hasNoProfunctors :: Name -> Obligation
@@ -34,6 +35,14 @@ hasNoProfunctors name = mkObligation name $ NoUseOf
   , 'P.iwander
   , 'P.roam
   , 'P.iroam
+  , 'appendIndices
+  , 'composeN
+  ]
+
+hasNoIndexClasses :: Name -> Obligation
+hasNoIndexClasses name = mkObligation name $ NoUseOf
+  [ 'appendIndices
+  , 'composeN
   ]
 
 -- | 'hasNoGenerics' from 'Test.Inspection' checks for lack of data types, but


### PR DESCRIPTION
Fixes #396.

This doesn't slow compilation, I tested with a big project.