### PR TITLE
Turn Join into a class for neater type signatures

### DIFF
--- a/codegen/Subtypes.hs
+++ b/codegen/Subtypes.hs
@@ -97,7 +97,9 @@ genJoin = either (fail . show) id $ runG opticsKind $ \g -> do
     for_ gVertices $ \a -> do
         let k = gFromVertex a
         putStrLn   ""
-        putStrLn $ "  -- " ++ show k ++ "-----"
+        putStrLn $ "-- " ++ show k ++ " -----"
+
+        putStrLn $ joinInstance k k k
 
         for_ gVertices $ \b -> unless (a == b) $ do
             let l = gFromVertex b
@@ -114,16 +116,23 @@ genJoin = either (fail . show) id $ runG opticsKind $ \g -> do
 
             case mkl of
                 -- alignment is important, thus padding
-                []          -> putStrLn $ "  -- no Join with         " ++ show l
-                kls@(_:_:_) -> putStrLn $ "  -- error: multiple joins: " ++ show (map gFromVertex kls)
-                [kl]        -> do
-                  putStrLn $ unwords
-                    [ "  Join"
-                    , leftpad (show k)
-                    , leftpad (show l)
-                    , "="
-                    , show (gFromVertex kl)
-                    ]
+                []          -> putStrLn $ unwords
+                  [ "--    no JoinKinds"
+                  , leftpad (show k)
+                  , leftpad (show l)
+                  ]
+                kls@(_:_:_) -> putStrLn $ "-- error: multiple joins: "
+                                       ++ show (map gFromVertex kls)
+                [kl]        -> putStrLn . joinInstance k l $ gFromVertex kl
+  where
+    joinInstance k l m = unwords
+      [ "instance JoinKinds"
+      , leftpad $ show k
+      , leftpad $ show l
+      , leftpad $ show m
+      , "where\n  joinKinds r = r"
+      ]
+
 
 -------------------------------------------------------------------------------
 -- subtypes

--- a/optics-core/src/Optics/Indexed/Core.hs
+++ b/optics-core/src/Optics/Indexed/Core.hs
@@ -75,8 +75,7 @@ import Optics.Traversal
 --
 infixl 9 <%>
 (<%>)
-  :: (m ~ Join k l, Is k m, Is l m, IxOptic m s t a b,
-      is `HasSingleIndex` i, js `HasSingleIndex` j)
+  :: (JoinKinds k l m, IxOptic m s t a b, is `HasSingleIndex` i, js `HasSingleIndex` j)
   => Optic k is              s t u v
   -> Optic l js              u v a b
   -> Optic m (WithIx (i, j)) s t a b
@@ -91,7 +90,7 @@ o <%> o' = icompose (,) (o % o')
 --
 infixl 9 %>
 (%>)
-  :: (m ~ Join k l, Is k m, Is l m, IxOptic k s t u v, NonEmptyIndices is)
+  :: (JoinKinds k l m, IxOptic k s t u v, NonEmptyIndices is)
   => Optic k is s t u v
   -> Optic l js u v a b
   -> Optic m js s t a b
@@ -106,7 +105,7 @@ o %> o' = noIx o % o'
 --
 infixl 9 <%
 (<%)
-  :: (m ~ Join k l, Is l m, Is k m, IxOptic l u v a b, NonEmptyIndices js)
+  :: (JoinKinds k l m, IxOptic l u v a b, NonEmptyIndices js)
   => Optic k is s t u v
   -> Optic l js u v a b
   -> Optic m is s t a b

--- a/optics-core/src/Optics/Internal/Optic/Subtyping.hs
+++ b/optics-core/src/Optics/Internal/Optic/Subtyping.hs
@@ -147,174 +147,291 @@ instance Is A_Traversal        A_Setter           where implies r = r
 
 -- | Computes the least upper bound of two optics kinds.
 --
--- @Join k l@ represents the least upper bound of an @Optic k@ and an @Optic
--- l@. This means in particular that composition of an @Optic k@ and an @Optic
--- k@ will yield an @Optic (Join k l)@.
+-- In presence of a @JoinKinds k l m@ constraint @Optic m@ represents the least
+-- upper bound of an @Optic k@ and an @Optic l@. This means in particular that
+-- composition of an @Optic k@ and an @Optic k@ will yield an @Optic m@.
 --
-type family Join (k :: OpticKind) (l :: OpticKind) where
-  -- BEGIN GENERATED CONTENT
-  -- An_Iso-----
-  Join An_Iso             A_ReversedLens     = A_ReversedLens
-  Join An_Iso             A_ReversedPrism    = A_ReversedPrism
-  Join An_Iso             A_Prism            = A_Prism
-  Join An_Iso             A_Review           = A_Review
-  Join An_Iso             A_Lens             = A_Lens
-  Join An_Iso             A_Getter           = A_Getter
-  Join An_Iso             An_AffineTraversal = An_AffineTraversal
-  Join An_Iso             An_AffineFold      = An_AffineFold
-  Join An_Iso             A_Traversal        = A_Traversal
-  Join An_Iso             A_Fold             = A_Fold
-  Join An_Iso             A_Setter           = A_Setter
+class JoinKinds k l m | k l -> m where
+  joinKinds :: ((Constraints k p, Constraints l p) => r) -> (Constraints m p => r)
 
-  -- A_ReversedLens-----
-  Join A_ReversedLens     An_Iso             = A_ReversedLens
-  -- no Join with         A_ReversedPrism
-  Join A_ReversedLens     A_Prism            = A_Review
-  Join A_ReversedLens     A_Review           = A_Review
-  -- no Join with         A_Lens
-  -- no Join with         A_Getter
-  -- no Join with         An_AffineTraversal
-  -- no Join with         An_AffineFold
-  -- no Join with         A_Traversal
-  -- no Join with         A_Fold
-  -- no Join with         A_Setter
+-- BEGIN GENERATED CONTENT
 
-  -- A_ReversedPrism-----
-  Join A_ReversedPrism    An_Iso             = A_ReversedPrism
-  -- no Join with         A_ReversedLens
-  Join A_ReversedPrism    A_Prism            = An_AffineFold
-  -- no Join with         A_Review
-  Join A_ReversedPrism    A_Lens             = A_Getter
-  Join A_ReversedPrism    A_Getter           = A_Getter
-  Join A_ReversedPrism    An_AffineTraversal = An_AffineFold
-  Join A_ReversedPrism    An_AffineFold      = An_AffineFold
-  Join A_ReversedPrism    A_Traversal        = A_Fold
-  Join A_ReversedPrism    A_Fold             = A_Fold
-  -- no Join with         A_Setter
+-- An_Iso -----
+instance JoinKinds An_Iso             An_Iso             An_Iso             where
+  joinKinds r = r
+instance JoinKinds An_Iso             A_ReversedLens     A_ReversedLens     where
+  joinKinds r = r
+instance JoinKinds An_Iso             A_ReversedPrism    A_ReversedPrism    where
+  joinKinds r = r
+instance JoinKinds An_Iso             A_Prism            A_Prism            where
+  joinKinds r = r
+instance JoinKinds An_Iso             A_Review           A_Review           where
+  joinKinds r = r
+instance JoinKinds An_Iso             A_Lens             A_Lens             where
+  joinKinds r = r
+instance JoinKinds An_Iso             A_Getter           A_Getter           where
+  joinKinds r = r
+instance JoinKinds An_Iso             An_AffineTraversal An_AffineTraversal where
+  joinKinds r = r
+instance JoinKinds An_Iso             An_AffineFold      An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds An_Iso             A_Traversal        A_Traversal        where
+  joinKinds r = r
+instance JoinKinds An_Iso             A_Fold             A_Fold             where
+  joinKinds r = r
+instance JoinKinds An_Iso             A_Setter           A_Setter           where
+  joinKinds r = r
 
-  -- A_Prism-----
-  Join A_Prism            An_Iso             = A_Prism
-  Join A_Prism            A_ReversedLens     = A_Review
-  Join A_Prism            A_ReversedPrism    = An_AffineFold
-  Join A_Prism            A_Review           = A_Review
-  Join A_Prism            A_Lens             = An_AffineTraversal
-  Join A_Prism            A_Getter           = An_AffineFold
-  Join A_Prism            An_AffineTraversal = An_AffineTraversal
-  Join A_Prism            An_AffineFold      = An_AffineFold
-  Join A_Prism            A_Traversal        = A_Traversal
-  Join A_Prism            A_Fold             = A_Fold
-  Join A_Prism            A_Setter           = A_Setter
+-- A_ReversedLens -----
+instance JoinKinds A_ReversedLens     A_ReversedLens     A_ReversedLens     where
+  joinKinds r = r
+instance JoinKinds A_ReversedLens     An_Iso             A_ReversedLens     where
+  joinKinds r = r
+--    no JoinKinds A_ReversedLens     A_ReversedPrism
+instance JoinKinds A_ReversedLens     A_Prism            A_Review           where
+  joinKinds r = r
+instance JoinKinds A_ReversedLens     A_Review           A_Review           where
+  joinKinds r = r
+--    no JoinKinds A_ReversedLens     A_Lens
+--    no JoinKinds A_ReversedLens     A_Getter
+--    no JoinKinds A_ReversedLens     An_AffineTraversal
+--    no JoinKinds A_ReversedLens     An_AffineFold
+--    no JoinKinds A_ReversedLens     A_Traversal
+--    no JoinKinds A_ReversedLens     A_Fold
+--    no JoinKinds A_ReversedLens     A_Setter
 
-  -- A_Review-----
-  Join A_Review           An_Iso             = A_Review
-  Join A_Review           A_ReversedLens     = A_Review
-  -- no Join with         A_ReversedPrism
-  Join A_Review           A_Prism            = A_Review
-  -- no Join with         A_Lens
-  -- no Join with         A_Getter
-  -- no Join with         An_AffineTraversal
-  -- no Join with         An_AffineFold
-  -- no Join with         A_Traversal
-  -- no Join with         A_Fold
-  -- no Join with         A_Setter
+-- A_ReversedPrism -----
+instance JoinKinds A_ReversedPrism    A_ReversedPrism    A_ReversedPrism    where
+  joinKinds r = r
+instance JoinKinds A_ReversedPrism    An_Iso             A_ReversedPrism    where
+  joinKinds r = r
+--    no JoinKinds A_ReversedPrism    A_ReversedLens
+instance JoinKinds A_ReversedPrism    A_Prism            An_AffineFold      where
+  joinKinds r = r
+--    no JoinKinds A_ReversedPrism    A_Review
+instance JoinKinds A_ReversedPrism    A_Lens             A_Getter           where
+  joinKinds r = r
+instance JoinKinds A_ReversedPrism    A_Getter           A_Getter           where
+  joinKinds r = r
+instance JoinKinds A_ReversedPrism    An_AffineTraversal An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds A_ReversedPrism    An_AffineFold      An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds A_ReversedPrism    A_Traversal        A_Fold             where
+  joinKinds r = r
+instance JoinKinds A_ReversedPrism    A_Fold             A_Fold             where
+  joinKinds r = r
+--    no JoinKinds A_ReversedPrism    A_Setter
 
-  -- A_Lens-----
-  Join A_Lens             An_Iso             = A_Lens
-  -- no Join with         A_ReversedLens
-  Join A_Lens             A_ReversedPrism    = A_Getter
-  Join A_Lens             A_Prism            = An_AffineTraversal
-  -- no Join with         A_Review
-  Join A_Lens             A_Getter           = A_Getter
-  Join A_Lens             An_AffineTraversal = An_AffineTraversal
-  Join A_Lens             An_AffineFold      = An_AffineFold
-  Join A_Lens             A_Traversal        = A_Traversal
-  Join A_Lens             A_Fold             = A_Fold
-  Join A_Lens             A_Setter           = A_Setter
+-- A_Prism -----
+instance JoinKinds A_Prism            A_Prism            A_Prism            where
+  joinKinds r = r
+instance JoinKinds A_Prism            An_Iso             A_Prism            where
+  joinKinds r = r
+instance JoinKinds A_Prism            A_ReversedLens     A_Review           where
+  joinKinds r = r
+instance JoinKinds A_Prism            A_ReversedPrism    An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds A_Prism            A_Review           A_Review           where
+  joinKinds r = r
+instance JoinKinds A_Prism            A_Lens             An_AffineTraversal where
+  joinKinds r = r
+instance JoinKinds A_Prism            A_Getter           An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds A_Prism            An_AffineTraversal An_AffineTraversal where
+  joinKinds r = r
+instance JoinKinds A_Prism            An_AffineFold      An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds A_Prism            A_Traversal        A_Traversal        where
+  joinKinds r = r
+instance JoinKinds A_Prism            A_Fold             A_Fold             where
+  joinKinds r = r
+instance JoinKinds A_Prism            A_Setter           A_Setter           where
+  joinKinds r = r
 
-  -- A_Getter-----
-  Join A_Getter           An_Iso             = A_Getter
-  -- no Join with         A_ReversedLens
-  Join A_Getter           A_ReversedPrism    = A_Getter
-  Join A_Getter           A_Prism            = An_AffineFold
-  -- no Join with         A_Review
-  Join A_Getter           A_Lens             = A_Getter
-  Join A_Getter           An_AffineTraversal = An_AffineFold
-  Join A_Getter           An_AffineFold      = An_AffineFold
-  Join A_Getter           A_Traversal        = A_Fold
-  Join A_Getter           A_Fold             = A_Fold
-  -- no Join with         A_Setter
+-- A_Review -----
+instance JoinKinds A_Review           A_Review           A_Review           where
+  joinKinds r = r
+instance JoinKinds A_Review           An_Iso             A_Review           where
+  joinKinds r = r
+instance JoinKinds A_Review           A_ReversedLens     A_Review           where
+  joinKinds r = r
+--    no JoinKinds A_Review           A_ReversedPrism
+instance JoinKinds A_Review           A_Prism            A_Review           where
+  joinKinds r = r
+--    no JoinKinds A_Review           A_Lens
+--    no JoinKinds A_Review           A_Getter
+--    no JoinKinds A_Review           An_AffineTraversal
+--    no JoinKinds A_Review           An_AffineFold
+--    no JoinKinds A_Review           A_Traversal
+--    no JoinKinds A_Review           A_Fold
+--    no JoinKinds A_Review           A_Setter
 
-  -- An_AffineTraversal-----
-  Join An_AffineTraversal An_Iso             = An_AffineTraversal
-  -- no Join with         A_ReversedLens
-  Join An_AffineTraversal A_ReversedPrism    = An_AffineFold
-  Join An_AffineTraversal A_Prism            = An_AffineTraversal
-  -- no Join with         A_Review
-  Join An_AffineTraversal A_Lens             = An_AffineTraversal
-  Join An_AffineTraversal A_Getter           = An_AffineFold
-  Join An_AffineTraversal An_AffineFold      = An_AffineFold
-  Join An_AffineTraversal A_Traversal        = A_Traversal
-  Join An_AffineTraversal A_Fold             = A_Fold
-  Join An_AffineTraversal A_Setter           = A_Setter
+-- A_Lens -----
+instance JoinKinds A_Lens             A_Lens             A_Lens             where
+  joinKinds r = r
+instance JoinKinds A_Lens             An_Iso             A_Lens             where
+  joinKinds r = r
+--    no JoinKinds A_Lens             A_ReversedLens
+instance JoinKinds A_Lens             A_ReversedPrism    A_Getter           where
+  joinKinds r = r
+instance JoinKinds A_Lens             A_Prism            An_AffineTraversal where
+  joinKinds r = r
+--    no JoinKinds A_Lens             A_Review
+instance JoinKinds A_Lens             A_Getter           A_Getter           where
+  joinKinds r = r
+instance JoinKinds A_Lens             An_AffineTraversal An_AffineTraversal where
+  joinKinds r = r
+instance JoinKinds A_Lens             An_AffineFold      An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds A_Lens             A_Traversal        A_Traversal        where
+  joinKinds r = r
+instance JoinKinds A_Lens             A_Fold             A_Fold             where
+  joinKinds r = r
+instance JoinKinds A_Lens             A_Setter           A_Setter           where
+  joinKinds r = r
 
-  -- An_AffineFold-----
-  Join An_AffineFold      An_Iso             = An_AffineFold
-  -- no Join with         A_ReversedLens
-  Join An_AffineFold      A_ReversedPrism    = An_AffineFold
-  Join An_AffineFold      A_Prism            = An_AffineFold
-  -- no Join with         A_Review
-  Join An_AffineFold      A_Lens             = An_AffineFold
-  Join An_AffineFold      A_Getter           = An_AffineFold
-  Join An_AffineFold      An_AffineTraversal = An_AffineFold
-  Join An_AffineFold      A_Traversal        = A_Fold
-  Join An_AffineFold      A_Fold             = A_Fold
-  -- no Join with         A_Setter
+-- A_Getter -----
+instance JoinKinds A_Getter           A_Getter           A_Getter           where
+  joinKinds r = r
+instance JoinKinds A_Getter           An_Iso             A_Getter           where
+  joinKinds r = r
+--    no JoinKinds A_Getter           A_ReversedLens
+instance JoinKinds A_Getter           A_ReversedPrism    A_Getter           where
+  joinKinds r = r
+instance JoinKinds A_Getter           A_Prism            An_AffineFold      where
+  joinKinds r = r
+--    no JoinKinds A_Getter           A_Review
+instance JoinKinds A_Getter           A_Lens             A_Getter           where
+  joinKinds r = r
+instance JoinKinds A_Getter           An_AffineTraversal An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds A_Getter           An_AffineFold      An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds A_Getter           A_Traversal        A_Fold             where
+  joinKinds r = r
+instance JoinKinds A_Getter           A_Fold             A_Fold             where
+  joinKinds r = r
+--    no JoinKinds A_Getter           A_Setter
 
-  -- A_Traversal-----
-  Join A_Traversal        An_Iso             = A_Traversal
-  -- no Join with         A_ReversedLens
-  Join A_Traversal        A_ReversedPrism    = A_Fold
-  Join A_Traversal        A_Prism            = A_Traversal
-  -- no Join with         A_Review
-  Join A_Traversal        A_Lens             = A_Traversal
-  Join A_Traversal        A_Getter           = A_Fold
-  Join A_Traversal        An_AffineTraversal = A_Traversal
-  Join A_Traversal        An_AffineFold      = A_Fold
-  Join A_Traversal        A_Fold             = A_Fold
-  Join A_Traversal        A_Setter           = A_Setter
+-- An_AffineTraversal -----
+instance JoinKinds An_AffineTraversal An_AffineTraversal An_AffineTraversal where
+  joinKinds r = r
+instance JoinKinds An_AffineTraversal An_Iso             An_AffineTraversal where
+  joinKinds r = r
+--    no JoinKinds An_AffineTraversal A_ReversedLens
+instance JoinKinds An_AffineTraversal A_ReversedPrism    An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds An_AffineTraversal A_Prism            An_AffineTraversal where
+  joinKinds r = r
+--    no JoinKinds An_AffineTraversal A_Review
+instance JoinKinds An_AffineTraversal A_Lens             An_AffineTraversal where
+  joinKinds r = r
+instance JoinKinds An_AffineTraversal A_Getter           An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds An_AffineTraversal An_AffineFold      An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds An_AffineTraversal A_Traversal        A_Traversal        where
+  joinKinds r = r
+instance JoinKinds An_AffineTraversal A_Fold             A_Fold             where
+  joinKinds r = r
+instance JoinKinds An_AffineTraversal A_Setter           A_Setter           where
+  joinKinds r = r
 
-  -- A_Fold-----
-  Join A_Fold             An_Iso             = A_Fold
-  -- no Join with         A_ReversedLens
-  Join A_Fold             A_ReversedPrism    = A_Fold
-  Join A_Fold             A_Prism            = A_Fold
-  -- no Join with         A_Review
-  Join A_Fold             A_Lens             = A_Fold
-  Join A_Fold             A_Getter           = A_Fold
-  Join A_Fold             An_AffineTraversal = A_Fold
-  Join A_Fold             An_AffineFold      = A_Fold
-  Join A_Fold             A_Traversal        = A_Fold
-  -- no Join with         A_Setter
+-- An_AffineFold -----
+instance JoinKinds An_AffineFold      An_AffineFold      An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds An_AffineFold      An_Iso             An_AffineFold      where
+  joinKinds r = r
+--    no JoinKinds An_AffineFold      A_ReversedLens
+instance JoinKinds An_AffineFold      A_ReversedPrism    An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds An_AffineFold      A_Prism            An_AffineFold      where
+  joinKinds r = r
+--    no JoinKinds An_AffineFold      A_Review
+instance JoinKinds An_AffineFold      A_Lens             An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds An_AffineFold      A_Getter           An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds An_AffineFold      An_AffineTraversal An_AffineFold      where
+  joinKinds r = r
+instance JoinKinds An_AffineFold      A_Traversal        A_Fold             where
+  joinKinds r = r
+instance JoinKinds An_AffineFold      A_Fold             A_Fold             where
+  joinKinds r = r
+--    no JoinKinds An_AffineFold      A_Setter
 
-  -- A_Setter-----
-  Join A_Setter           An_Iso             = A_Setter
-  -- no Join with         A_ReversedLens
-  -- no Join with         A_ReversedPrism
-  Join A_Setter           A_Prism            = A_Setter
-  -- no Join with         A_Review
-  Join A_Setter           A_Lens             = A_Setter
-  -- no Join with         A_Getter
-  Join A_Setter           An_AffineTraversal = A_Setter
-  -- no Join with         An_AffineFold
-  Join A_Setter           A_Traversal        = A_Setter
-  -- no Join with         A_Fold
+-- A_Traversal -----
+instance JoinKinds A_Traversal        A_Traversal        A_Traversal        where
+  joinKinds r = r
+instance JoinKinds A_Traversal        An_Iso             A_Traversal        where
+  joinKinds r = r
+--    no JoinKinds A_Traversal        A_ReversedLens
+instance JoinKinds A_Traversal        A_ReversedPrism    A_Fold             where
+  joinKinds r = r
+instance JoinKinds A_Traversal        A_Prism            A_Traversal        where
+  joinKinds r = r
+--    no JoinKinds A_Traversal        A_Review
+instance JoinKinds A_Traversal        A_Lens             A_Traversal        where
+  joinKinds r = r
+instance JoinKinds A_Traversal        A_Getter           A_Fold             where
+  joinKinds r = r
+instance JoinKinds A_Traversal        An_AffineTraversal A_Traversal        where
+  joinKinds r = r
+instance JoinKinds A_Traversal        An_AffineFold      A_Fold             where
+  joinKinds r = r
+instance JoinKinds A_Traversal        A_Fold             A_Fold             where
+  joinKinds r = r
+instance JoinKinds A_Traversal        A_Setter           A_Setter           where
+  joinKinds r = r
 
-  -- END GENERATED CONTENT
+-- A_Fold -----
+instance JoinKinds A_Fold             A_Fold             A_Fold             where
+  joinKinds r = r
+instance JoinKinds A_Fold             An_Iso             A_Fold             where
+  joinKinds r = r
+--    no JoinKinds A_Fold             A_ReversedLens
+instance JoinKinds A_Fold             A_ReversedPrism    A_Fold             where
+  joinKinds r = r
+instance JoinKinds A_Fold             A_Prism            A_Fold             where
+  joinKinds r = r
+--    no JoinKinds A_Fold             A_Review
+instance JoinKinds A_Fold             A_Lens             A_Fold             where
+  joinKinds r = r
+instance JoinKinds A_Fold             A_Getter           A_Fold             where
+  joinKinds r = r
+instance JoinKinds A_Fold             An_AffineTraversal A_Fold             where
+  joinKinds r = r
+instance JoinKinds A_Fold             An_AffineFold      A_Fold             where
+  joinKinds r = r
+instance JoinKinds A_Fold             A_Traversal        A_Fold             where
+  joinKinds r = r
+--    no JoinKinds A_Fold             A_Setter
 
-  -- Every optic kinds can be joined with itself.
-  Join k k = k
+-- A_Setter -----
+instance JoinKinds A_Setter           A_Setter           A_Setter           where
+  joinKinds r = r
+instance JoinKinds A_Setter           An_Iso             A_Setter           where
+  joinKinds r = r
+--    no JoinKinds A_Setter           A_ReversedLens
+--    no JoinKinds A_Setter           A_ReversedPrism
+instance JoinKinds A_Setter           A_Prism            A_Setter           where
+  joinKinds r = r
+--    no JoinKinds A_Setter           A_Review
+instance JoinKinds A_Setter           A_Lens             A_Setter           where
+  joinKinds r = r
+--    no JoinKinds A_Setter           A_Getter
+instance JoinKinds A_Setter           An_AffineTraversal A_Setter           where
+  joinKinds r = r
+--    no JoinKinds A_Setter           An_AffineFold
+instance JoinKinds A_Setter           A_Traversal        A_Setter           where
+  joinKinds r = r
+--    no JoinKinds A_Setter           A_Fold
 
-  -- Everything else is a type error.
-  Join k l = TypeError ('ShowType k
-                        ':<>: 'Text " cannot be composed with "
-                        ':<>: 'ShowType l)
+-- END GENERATED CONTENT
+
+instance {-# OVERLAPPABLE #-}
+  ( JoinKinds k l m
+  , TypeError ('ShowType k ':<>: 'Text " cannot be composed with " ':<>: 'ShowType l)
+  ) => JoinKinds k l m where
+  joinKinds _ = error "unreachable"

--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -31,7 +31,7 @@ module Optics.Optic
   -- * Subtyping
   , castOptic
   , Is
-  , Join
+  , JoinKinds
 
   -- * Composition
   -- | The usual operator for composing optics is ('%'), which allows different

--- a/optics-core/src/Optics/ReadOnly.hs
+++ b/optics-core/src/Optics/ReadOnly.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeInType #-}
 -- |
 -- Module: Optics.ReadOnly
 -- Description: Converting read-write optics into their read-only counterparts.
@@ -16,6 +18,7 @@ import Optics.Internal.Optic
 
 -- | Class for read-write optics that have their read-only counterparts.
 class ToReadOnly k s t a b where
+  type ReadOnlyOptic k :: OpticKind
   -- | Turn read-write optic into its read-only counterpart (or leave read-only
   -- optics as-is).
   --
@@ -35,41 +38,50 @@ class ToReadOnly k s t a b where
   --
   -- >>> :t view (getting fstIntToChar)
   -- view (getting fstIntToChar) :: (Int, r) -> Int
-  getting :: Optic k is s t a b -> Optic' (Join A_Getter k) is s a
+  getting :: Optic k is s t a b -> Optic' (ReadOnlyOptic k) is s a
 
 instance ToReadOnly An_Iso s t a b where
+  type ReadOnlyOptic An_Iso = A_Getter
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 
 instance ToReadOnly A_Lens s t a b where
+  type ReadOnlyOptic A_Lens = A_Getter
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 
 instance ToReadOnly A_Prism s t a b where
+  type ReadOnlyOptic A_Prism = An_AffineFold
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 
 instance ToReadOnly An_AffineTraversal s t a b where
+  type ReadOnlyOptic An_AffineTraversal = An_AffineFold
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 
 instance ToReadOnly A_Traversal s t a b where
+  type ReadOnlyOptic A_Traversal = A_Fold
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 
 instance ToReadOnly A_ReversedPrism s t a b where
+  type ReadOnlyOptic A_ReversedPrism = A_Getter
   getting o = Optic (getting__ o)
   {-# INLINE getting #-}
 
 instance (s ~ t, a ~ b) => ToReadOnly A_Getter s t a b where
+  type ReadOnlyOptic A_Getter = A_Getter
   getting = id
   {-# INLINE getting #-}
 
 instance (s ~ t, a ~ b) => ToReadOnly An_AffineFold s t a b where
+  type ReadOnlyOptic An_AffineFold = An_AffineFold
   getting = id
   {-# INLINE getting #-}
 
 instance (s ~ t, a ~ b) => ToReadOnly A_Fold s t a b where
+  type ReadOnlyOptic A_Fold = A_Fold
   getting = id
   {-# INLINE getting #-}
 

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -532,17 +532,13 @@ import Data.Either.Optics                    as P
 -- computes the least upper bound given two optic kind tags.  For example the
 -- 'Join' of a 'Lens' and a 'Prism' is an 'AffineTraversal'.
 --
--- >>> :kind! Join A_Lens A_Prism
--- Join A_Lens A_Prism :: OpticKind
--- = An_AffineTraversal
+-- >>> let res :: JoinKinds A_Lens A_Prism k => Proxy k; res = Proxy
+-- >>> :t res
+-- res :: Proxy An_AffineTraversal
 --
 -- The join does not exist for some pairs of optic kinds, which means that they
 -- cannot be composed.  For example there is no optic kind above both 'Setter'
 -- and 'Fold':
---
--- >>> :kind! Join A_Setter A_Fold
--- Join A_Setter A_Fold :: OpticKind
--- = (TypeError ...)
 --
 -- >>> :t mapped % folded
 -- ...
@@ -999,9 +995,11 @@ import Data.Either.Optics                    as P
 -- +--------------+-----------------+-------------------------------------------+------------------------------+-------------------------------+-------------------------------------------+
 
 -- $setup
+-- >>> :set -XFlexibleContexts
 -- >>> import Control.Monad.Reader
 -- >>> import Control.Monad.State
 -- >>> import Data.Functor.Identity
+-- >>> import Data.Proxy
 -- >>> import qualified Data.IntSet as IntSet
 -- >>> import qualified Data.Map as Map
 -- >>> import Optics.State.Operators

--- a/optics/tests/Optics/Tests/Labels/Generic.hs
+++ b/optics/tests/Optics/Tests/Labels/Generic.hs
@@ -113,14 +113,13 @@ label6rhs s name_ age_ fishName_ pets_ = s
 -- | Check that the setter compiles in full generality.
 label6setter
   :: ( Is k1 A_Setter
+     , Is k2 A_Setter
      , Is k3 A_Setter
      , Is k4 A_Setter
-     , Is l (Join k2 l)
-     , Is k2 (Join k2 l)
-     , Is (Join k2 l) A_Setter
+     , JoinKinds k5 l k4
      , LabelOptic "_GoldFish" l u v a1 b1
-     , LabelOptic "age" k4 s1 s2 a2 b2
-     , LabelOptic "fish" k2 s2 s3 u v
+     , LabelOptic "age" k2 s1 s2 a2 b2
+     , LabelOptic "fish" k5 s2 s3 u v
      , LabelOptic "name" k3 s4 s1 a3 b3
      , LabelOptic "pets" k1 s3 b4 a4 b5
      ) => s4 -> b3 -> b2 -> b1 -> b5 -> b4


### PR DESCRIPTION
Somewhat related to https://gitlab.haskell.org/ghc/ghc/-/issues/19336 (it's a GHC bug, but it pushed me to find a solution for using a class for `Join` that works).

I wanted to do that for some time now, considering that the type signature of `%` was a bit messy, not to mention type signatures of generic optic functions (see e.g. #368). Now looks like a good time to do that since `Append` was also changed.

Now the signature of `%` is quite neat:

```haskell
>>> :t (%)
(%)
  :: (JoinKinds k l m, AppendIndices is js ks) =>
     Optic k is s t u v -> Optic l js u v a b -> Optic m ks s t a b
```

Also, now label compositions are somewhat readable:

```haskell
>>> :t #pets % traversed % #_GoldFish % #name
#pets % traversed % #_GoldFish % #name
  :: (Traversable t1, JoinKinds k1 l1 m, JoinKinds k2 l2 k1,
      JoinKinds k3 A_Traversal k2, LabelOptic "_GoldFish" l2 u1 v1 u2 v2,
      LabelOptic "name" l1 u2 v2 a b,
      LabelOptic "pets" k3 s t2 (t1 u1) (t1 v1)) =>
     Optic m NoIx s t2 a b
```

instead of this monstrosity

```haskell
>>> :t #pets % traversed % #_GoldFish % #name
#pets % traversed % #_GoldFish % #name
  :: (Traversable t1,
      Is
        (Join (Join k A_Traversal) l1)
        (Join (Join (Join k A_Traversal) l1) l2),
      Is l2 (Join (Join (Join k A_Traversal) l1) l2),
      Is (Join k A_Traversal) (Join (Join k A_Traversal) l1),
      Is l1 (Join (Join k A_Traversal) l1), Is k (Join k A_Traversal),
      Is A_Traversal (Join k A_Traversal),
      LabelOptic "_GoldFish" l1 u1 v1 u2 v2,
      LabelOptic "name" l2 u2 v2 a b,
      LabelOptic "pets" k s t2 (t1 u1) (t1 v1)) =>
     Optic (Join (Join (Join k A_Traversal) l1) l2) NoIx s t2 a b
```

See also change to `label6setter` in code, no more weird `Is` constraints.

If no one protests, I'll adjust codegen.