### PR TITLE
Add 'matching' example

### DIFF
--- a/optics-core/src/Optics/Prism.hs
+++ b/optics-core/src/Optics/Prism.hs
@@ -15,18 +15,20 @@ module Optics.Prism
   , prism
 
   -- * Elimination
-  -- | A 'Prism' is in particular an 'Optics.AffineFold.AffineFold', a
+  -- | A 'Prism' is in particular an 'Optics.AffineFold.AffineFold',
+  -- an 'Optics.AffineTraversal.AffineTraversal', a
   -- 'Optics.Review.Review' and a 'Optics.Setter.Setter', therefore you can
   -- specialise types to obtain:
   --
   -- @
-  -- 'Optics.AffineFold.preview' :: 'Prism'' s a -> s -> Maybe a
-  -- 'Optics.Review.review'  :: 'Prism'' s a -> a -> s
+  -- 'Optics.AffineFold.preview'  :: 'Prism'' s a -> s -> Maybe a
+  -- 'Optics.Review.review'   :: 'Prism'' s a -> a -> s
   -- @
   --
   -- @
-  -- 'Optics.Setter.over'    :: 'Prism' s t a b -> (a -> b) -> s -> t
-  -- 'Optics.Setter.set'     :: 'Prism' s t a b ->       b  -> s -> t
+  -- 'Optics.Setter.over'     :: 'Prism' s t a b -> (a -> b) -> s -> t
+  -- 'Optics.Setter.set'      :: 'Prism' s t a b ->       b  -> s -> t
+  -- 'Optics.AffineTraversal.matching' :: 'Prism' s t a b             -> s -> Either t a
   -- @
   --
   -- If you want to 'Optics.AffineFold.preview' a type-modifying 'Prism' that is


### PR DESCRIPTION
and reformat surrounding examples to match

I was really surprised not to find `matching` called out more prominently in the `Prism` Haddock. Could we please add it? Now looks like:

![screenshot](https://user-images.githubusercontent.com/1951567/110012488-79bc4200-7d18-11eb-9b85-5f17b1083fd7.png)
