### PR TITLE
Add is

### DIFF
--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -88,6 +88,7 @@ library
                    Optics.Operators.Unsafe
                    Optics.Re
                    Optics.ReadOnly
+                   Optics.Core.Extras
 
                    -- optics for data types
                    Data.Either.Optics

--- a/optics-core/src/Optics/AffineFold.hs
+++ b/optics-core/src/Optics/AffineFold.hs
@@ -150,7 +150,7 @@ infixl 3 `afailing` -- Same as (<|>)
 -- The negation of this operator is 'Optics.Core.Extras.is' from
 -- "Optics.Core.Extras".
 isn't :: Is k An_AffineFold => Optic' k is s a -> s -> Bool
-isn't k s = not (isJust (preview k s))
+isn't k s = isNothing (preview k s)
 {-# INLINE isn't #-}
 
 -- $setup

--- a/optics-core/src/Optics/AffineFold.hs
+++ b/optics-core/src/Optics/AffineFold.hs
@@ -147,6 +147,8 @@ infixl 3 `afailing` -- Same as (<|>)
 -- >>> isn't _Just Nothing
 -- True
 --
+-- The negation of this operator is 'Optics.Core.Extras.is' from
+-- "Optics.Core.Extras".
 isn't :: Is k An_AffineFold => Optic' k is s a -> s -> Bool
 isn't k s = not (isJust (preview k s))
 {-# INLINE isn't #-}

--- a/optics-core/src/Optics/Core/Extras.hs
+++ b/optics-core/src/Optics/Core/Extras.hs
@@ -1,0 +1,22 @@
+module Optics.Core.Extras
+  (
+    is
+  )
+  where
+
+import Data.Maybe
+
+import Optics.Optic
+import Optics.AffineFold
+
+-- | Check to see if this 'AffineFold' matches.
+--
+-- >>> is _Just Nothing
+-- False
+--
+is :: Is k An_AffineFold => Optic' k is s a -> s -> Bool
+is k s = isJust (preview k s)
+{-# INLINE is #-}
+
+-- $setup
+-- >>> import Optics.Core


### PR DESCRIPTION
(the opposite of isn't)

I found it rather strange that `isn't` exists but `is` doesn't. [`lens` has `is`](https://hackage.haskell.org/package/lens-5.0.1/docs/Control-Lens-Extras.html#v:is). Could we add it to `optics`?