### PR TITLE
Remove references to Join from the documentation

### DIFF
--- a/optics-core/src/Optics/Optic.hs
+++ b/optics-core/src/Optics/Optic.hs
@@ -13,7 +13,7 @@
 -- * the subtyping relation 'Is' with an accompanying 'castOptic' function to
 --   convert an optic kind;
 --
--- * the 'Join' operation used to find the optic kind resulting from a
+-- * the 'JoinKinds' class used to find the optic kind resulting from a
 --   composition.
 --
 -- Each optic kind is identified by a "tag type" (such as 'A_Lens'), which is an
@@ -36,7 +36,7 @@ module Optics.Optic
   -- * Composition
   -- | The usual operator for composing optics is ('%'), which allows different
   -- optic kinds to be composed, automatically calculating the resulting optic
-  -- kind using 'Join'.
+  -- kind using 'JoinKinds'.
   --
   -- The ('.') function composition operator cannot be used to compose optics,
   -- because /optics are not functions/.  The ('Control.Category..') operator

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -528,9 +528,10 @@ import Data.Either.Optics                    as P
 -- generates a type error if the composition does not make sense.
 --
 -- The optic kind resulting from a composition is the least upper bound (join)
--- of the optic kinds being composed, if it exists.  The 'Join' type family
+-- of the optic kinds being composed, if it exists.  The 'JoinKinds' class
 -- computes the least upper bound given two optic kind tags.  For example the
--- 'Join' of a 'Lens' and a 'Prism' is an 'AffineTraversal'.
+-- constraint 'JoinKinds A_Lens A_Prism k' makes GHC unify @k@ with
+-- 'An_AffineTraversal'.
 --
 -- >>> let res :: JoinKinds A_Lens A_Prism k => Proxy k; res = Proxy
 -- >>> :t res

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -530,7 +530,7 @@ import Data.Either.Optics                    as P
 -- The optic kind resulting from a composition is the least upper bound (join)
 -- of the optic kinds being composed, if it exists.  The 'JoinKinds' class
 -- computes the least upper bound given two optic kind tags.  For example the
--- constraint 'JoinKinds A_Lens A_Prism k' makes GHC unify @k@ with
+-- constraint 'JoinKinds A_Lens A_Prism k' makes GHC infer that @k@ must be
 -- 'An_AffineTraversal'.
 --
 -- >>> let res :: JoinKinds A_Lens A_Prism k => Proxy k; res = Proxy


### PR DESCRIPTION
Tiny doc improvements that remove references to `Join` in favor of `JoinKinds`.

@adamgundry do these look good to you?