### PR TITLE
Allow tamplate-haskell-2.18 in optics-th

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.11.20210222
+# version: 0.13.20211113
 #
-# REGENDATA ("0.11.20210222",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.13.20211113",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -22,57 +22,129 @@ on:
       - master
 jobs:
   linux:
-    name: Haskell-CI - Linux - GHC ${{ matrix.ghc }}
+    name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
+    timeout-minutes:
+      60
     container:
       image: buildpack-deps:bionic
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - ghc: 9.0.1
+          - compiler: ghcjs-8.4
+            compilerKind: ghcjs
+            compilerVersion: "8.4"
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.10.4
+          - compiler: ghc-9.2.1
+            compilerKind: ghc
+            compilerVersion: 9.2.1
+            setup-method: ghcup
             allow-failure: false
-          - ghc: 8.8.4
+          - compiler: ghc-9.0.1
+            compilerKind: ghc
+            compilerVersion: 9.0.1
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.6.5
+          - compiler: ghc-8.10.7
+            compilerKind: ghc
+            compilerVersion: 8.10.7
+            setup-method: ghcup
             allow-failure: false
-          - ghc: 8.4.4
+          - compiler: ghc-8.8.4
+            compilerKind: ghc
+            compilerVersion: 8.8.4
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.2.2
+          - compiler: ghc-8.6.5
+            compilerKind: ghc
+            compilerVersion: 8.6.5
+            setup-method: hvr-ppa
+            allow-failure: false
+          - compiler: ghc-8.4.4
+            compilerKind: ghc
+            compilerVersion: 8.4.4
+            setup-method: hvr-ppa
+            allow-failure: false
+          - compiler: ghc-8.2.2
+            compilerKind: ghc
+            compilerVersion: 8.2.2
+            setup-method: hvr-ppa
             allow-failure: false
       fail-fast: false
     steps:
+      - name: Set GHCJS environment variables
+        run: |
+          if [ $HCKIND = ghcjs ]; then
+          echo "GHCJS=true" >> "$GITHUB_ENV"
+          echo "GHCJSARITH=1" >> "$GITHUB_ENV"
+          else
+          echo "GHCJS=false" >> "$GITHUB_ENV"
+          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
+          fi
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
-          apt-add-repository -y 'ppa:hvr/ghc'
-          apt-get update
-          apt-get install -y ghc-$GHC_VERSION cabal-install-3.4
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+          else
+            apt-add-repository -y 'ppa:hvr/ghc'
+            if [ $((GHCJSARITH)) -ne 0 ] ; then apt-add-repository -y 'ppa:hvr/ghcjs' ; fi
+            if [ $((GHCJSARITH)) -ne 0 ] ; then curl -sSL "https://deb.nodesource.com/gpgkey/nodesource.gpg.key" | apt-key add - ; fi
+            if [ $((GHCJSARITH)) -ne 0 ] ; then apt-add-repository -y 'deb https://deb.nodesource.com/node_10.x bionic main' ; fi
+            apt-get update
+            if [ $((GHCJSARITH)) -ne 0 ] ; then apt-get install -y "$HCNAME" ghc-8.4.4 nodejs ; else apt-get install -y "$HCNAME" ; fi
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+          fi
         env:
-          GHC_VERSION: ${{ matrix.ghc }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "LANG=C.UTF-8" >> $GITHUB_ENV
-          echo "CABAL_DIR=$HOME/.cabal" >> $GITHUB_ENV
-          echo "CABAL_CONFIG=$HOME/.cabal/config" >> $GITHUB_ENV
-          HC=/opt/ghc/$GHC_VERSION/bin/ghc
-          echo "HC=$HC" >> $GITHUB_ENV
-          echo "HCPKG=/opt/ghc/$GHC_VERSION/bin/ghc-pkg" >> $GITHUB_ENV
-          echo "HADDOCK=/opt/ghc/$GHC_VERSION/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          if [ $((GHCJSARITH)) -ne 0 ] ; then echo "/opt/ghc/8.4.4/bin" >> $GITHUB_PATH ; fi
+          echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
+          echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
+          echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
+          HCDIR=/opt/$HCKIND/$HCVER
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          else
+            HC=$HCDIR/bin/$HCKIND
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          fi
+
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
-          echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
-          echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
-          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90000)) -ne 0 ] ; then echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV ; else echo "ARG_BENCH=--disable-benchmarks" >> $GITHUB_ENV ; fi
-          echo "HEADHACKAGE=false" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--ghc --with-compiler=$HC" >> $GITHUB_ENV
-          echo "GHCJSARITH=0" >> $GITHUB_ENV
+          echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
+          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90000)) -ne 0 ] ; then echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV" ; else echo "ARG_BENCH=--disable-benchmarks" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
-          GHC_VERSION: ${{ matrix.ghc }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: env
         run: |
           env
@@ -95,19 +167,25 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          cat >> $CABAL_CONFIG <<EOF
+          program-default-options
+            ghc-options: $GHCJOBS +RTS -M3G -RTS
+          EOF
           cat $CABAL_CONFIG
       - name: versions
         run: |
           $HC --version || true
           $HC --print-project-git-commit-id || true
           $CABAL --version || true
+          if [ $((GHCJSARITH)) -ne 0 ] ; then node --version ; fi
+          if [ $((GHCJSARITH)) -ne 0 ] ; then echo $GHCJS ; fi
       - name: update cabal index
         run: |
           $CABAL v2-update -v
       - name: cache (tools)
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.ghc }}-tools-68b98ccd
+          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-60139de7
           path: ~/.haskell-ci-tools
       - name: install cabal-plan
         run: |
@@ -132,12 +210,12 @@ jobs:
           echo "packages: $GITHUB_WORKSPACE/source/optics" >> cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/optics-core" >> cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/optics-extra" >> cabal.project
-          echo "packages: $GITHUB_WORKSPACE/source/optics-sop" >> cabal.project
+          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90200)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/optics-sop" >> cabal.project ; fi
           echo "packages: $GITHUB_WORKSPACE/source/optics-th" >> cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/optics-vl" >> cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/indexed-profunctors" >> cabal.project
           if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90000)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/template-haskell-optics" >> cabal.project ; fi
-          echo "packages: $GITHUB_WORKSPACE/source/metametapost" >> cabal.project
+          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90200)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/metametapost" >> cabal.project ; fi
           cat cabal.project
       - name: sdist
         run: |
@@ -150,42 +228,43 @@ jobs:
       - name: generate cabal.project
         run: |
           PKGDIR_optics="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/optics-[0-9.]*')"
-          echo "PKGDIR_optics=${PKGDIR_optics}" >> $GITHUB_ENV
+          echo "PKGDIR_optics=${PKGDIR_optics}" >> "$GITHUB_ENV"
           PKGDIR_optics_core="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/optics-core-[0-9.]*')"
-          echo "PKGDIR_optics_core=${PKGDIR_optics_core}" >> $GITHUB_ENV
+          echo "PKGDIR_optics_core=${PKGDIR_optics_core}" >> "$GITHUB_ENV"
           PKGDIR_optics_extra="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/optics-extra-[0-9.]*')"
-          echo "PKGDIR_optics_extra=${PKGDIR_optics_extra}" >> $GITHUB_ENV
+          echo "PKGDIR_optics_extra=${PKGDIR_optics_extra}" >> "$GITHUB_ENV"
           PKGDIR_optics_sop="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/optics-sop-[0-9.]*')"
-          echo "PKGDIR_optics_sop=${PKGDIR_optics_sop}" >> $GITHUB_ENV
+          echo "PKGDIR_optics_sop=${PKGDIR_optics_sop}" >> "$GITHUB_ENV"
           PKGDIR_optics_th="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/optics-th-[0-9.]*')"
-          echo "PKGDIR_optics_th=${PKGDIR_optics_th}" >> $GITHUB_ENV
+          echo "PKGDIR_optics_th=${PKGDIR_optics_th}" >> "$GITHUB_ENV"
           PKGDIR_optics_vl="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/optics-vl-[0-9.]*')"
-          echo "PKGDIR_optics_vl=${PKGDIR_optics_vl}" >> $GITHUB_ENV
+          echo "PKGDIR_optics_vl=${PKGDIR_optics_vl}" >> "$GITHUB_ENV"
           PKGDIR_indexed_profunctors="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/indexed-profunctors-[0-9.]*')"
-          echo "PKGDIR_indexed_profunctors=${PKGDIR_indexed_profunctors}" >> $GITHUB_ENV
+          echo "PKGDIR_indexed_profunctors=${PKGDIR_indexed_profunctors}" >> "$GITHUB_ENV"
           PKGDIR_template_haskell_optics="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/template-haskell-optics-[0-9.]*')"
-          echo "PKGDIR_template_haskell_optics=${PKGDIR_template_haskell_optics}" >> $GITHUB_ENV
+          echo "PKGDIR_template_haskell_optics=${PKGDIR_template_haskell_optics}" >> "$GITHUB_ENV"
           PKGDIR_metametapost="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/metametapost-[0-9.]*')"
-          echo "PKGDIR_metametapost=${PKGDIR_metametapost}" >> $GITHUB_ENV
+          echo "PKGDIR_metametapost=${PKGDIR_metametapost}" >> "$GITHUB_ENV"
+          rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_optics}" >> cabal.project
           echo "packages: ${PKGDIR_optics_core}" >> cabal.project
           echo "packages: ${PKGDIR_optics_extra}" >> cabal.project
-          echo "packages: ${PKGDIR_optics_sop}" >> cabal.project
+          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90200)) -ne 0 ] ; then echo "packages: ${PKGDIR_optics_sop}" >> cabal.project ; fi
           echo "packages: ${PKGDIR_optics_th}" >> cabal.project
           echo "packages: ${PKGDIR_optics_vl}" >> cabal.project
           echo "packages: ${PKGDIR_indexed_profunctors}" >> cabal.project
           if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90000)) -ne 0 ] ; then echo "packages: ${PKGDIR_template_haskell_optics}" >> cabal.project ; fi
-          echo "packages: ${PKGDIR_metametapost}" >> cabal.project
+          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90200)) -ne 0 ] ; then echo "packages: ${PKGDIR_metametapost}" >> cabal.project ; fi
           echo "package optics" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           echo "package optics-core" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           echo "package optics-extra" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
-          echo "package optics-sop" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90200)) -ne 0 ] ; then echo "package optics-sop" >> cabal.project ; fi
+          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           echo "package optics-th" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           echo "package optics-vl" >> cabal.project
@@ -194,8 +273,8 @@ jobs:
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90000)) -ne 0 ] ; then echo "package template-haskell-optics" >> cabal.project ; fi
           if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          echo "package metametapost" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90200)) -ne 0 ] ; then echo "package metametapost" >> cabal.project ; fi
+          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(indexed-profunctors|metametapost|optics|optics-core|optics-extra|optics-sop|optics-th|optics-vl|template-haskell-optics)$/; }' >> cabal.project.local
@@ -208,9 +287,9 @@ jobs:
       - name: cache
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
-          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+          restore-keys: ${{ runner.os }}-${{ matrix.compiler }}-
       - name: install dependencies
         run: |
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only -j2 all
@@ -250,8 +329,8 @@ jobs:
           ${CABAL} -vnormal check
           cd ${PKGDIR_optics_extra} || false
           ${CABAL} -vnormal check
-          cd ${PKGDIR_optics_sop} || false
-          ${CABAL} -vnormal check
+          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90200)) -ne 0 ] ; then cd ${PKGDIR_optics_sop} || false ; fi
+          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90200)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
           cd ${PKGDIR_optics_th} || false
           ${CABAL} -vnormal check
           cd ${PKGDIR_optics_vl} || false
@@ -260,8 +339,8 @@ jobs:
           ${CABAL} -vnormal check
           if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90000)) -ne 0 ] ; then cd ${PKGDIR_template_haskell_optics} || false ; fi
           if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90000)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
-          cd ${PKGDIR_metametapost} || false
-          ${CABAL} -vnormal check
+          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90200)) -ne 0 ] ; then cd ${PKGDIR_metametapost} || false ; fi
+          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER < 90200)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
       - name: haddock
         run: |
           if [ $((! GHCJSARITH)) -ne 0 ] ; then $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi

--- a/indexed-profunctors/indexed-profunctors.cabal
+++ b/indexed-profunctors/indexed-profunctors.cabal
@@ -6,7 +6,7 @@ build-type:    Simple
 cabal-version: 1.24
 maintainer:    optics@well-typed.com
 author:        Adam Gundry, Andres Löh, Andrzej Rybczak, Oleg Grenrus
-tested-with:   GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1, GHCJS ==8.4
+tested-with:   GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.1 || ==9.2.1, GHCJS ==8.4
 synopsis:      Utilities for indexed profunctors
 category:      Data, Optics, Lenses, Profunctors
 description:

--- a/metametapost/metametapost.cabal
+++ b/metametapost/metametapost.cabal
@@ -4,7 +4,7 @@ version:       0.1
 license:       BSD3
 license-file:  LICENSE
 build-type:    Simple
-tested-with:   ghc ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1, GHCJS ==8.4
+tested-with:   ghc ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.1, GHCJS ==8.4
 maintainer:    oleg@well-typed.com
 synopsis:      Generate optics documentation diagrams
 category:      Optics, Examples

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -6,7 +6,7 @@ build-type:    Simple
 cabal-version: 1.24
 maintainer:    optics@well-typed.com
 author:        Adam Gundry, Andres Löh, Andrzej Rybczak, Oleg Grenrus
-tested-with:   GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1, GHCJS ==8.4
+tested-with:   GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.1 || ==9.2.1, GHCJS ==8.4
 synopsis:      Optics as an abstract interface: core definitions
 category:      Data, Optics, Lenses
 description:

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -6,7 +6,7 @@ build-type:    Simple
 cabal-version: 1.24
 maintainer:    optics@well-typed.com
 author:        Andrzej Rybczak
-tested-with:   ghc ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1, GHCJS ==8.4
+tested-with:   ghc ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.1 || ==9.2.1, GHCJS ==8.4
 synopsis:      Extra utilities and instances for optics-core
 category:      Data, Optics, Lenses
 description:

--- a/optics-sop/optics-sop.cabal
+++ b/optics-sop/optics-sop.cabal
@@ -6,7 +6,7 @@ build-type:    Simple
 maintainer:    optics@well-typed.com
 author:        Adam Gundry, Andres Löh, Andrzej Rybczak
 cabal-version: >=1.10
-tested-with:   ghc ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1, GHCJS ==8.4
+tested-with:   ghc ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.1, GHCJS ==8.4
 synopsis:      Optics for generics-sop, and using generics-sop
 category:      Data, Optics, Lenses, Generics
 description:

--- a/optics-th/optics-th.cabal
+++ b/optics-th/optics-th.cabal
@@ -6,7 +6,7 @@ build-type:    Simple
 maintainer:    optics@well-typed.com
 author:        Andrzej Rybczak
 cabal-version: 1.24
-tested-with:   ghc ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1, GHCJS ==8.4
+tested-with:   ghc ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.1 || ==9.2.1, GHCJS ==8.4
 synopsis:      Optics construction using TemplateHaskell
 category:      Data, Optics, Lenses
 description:
@@ -33,7 +33,7 @@ library
                , containers             >= 0.5.10.2  && <0.7
                , mtl                    >= 2.2.2     && <2.3
                , optics-core            >= 0.4       && <0.5
-               , template-haskell       >= 2.12      && <2.18
+               , template-haskell       >= 2.12      && <2.19
                , th-abstraction         >= 0.4       && <0.5
                , transformers           >= 0.5       && <0.6
 

--- a/optics-vl/optics-vl.cabal
+++ b/optics-vl/optics-vl.cabal
@@ -6,7 +6,7 @@ build-type:    Simple
 maintainer:    optics@well-typed.com
 author:        Andrzej Rybczak
 cabal-version: 1.24
-tested-with:   ghc ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1, GHCJS ==8.4
+tested-with:   ghc ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.1 || ==9.2.1, GHCJS ==8.4
 synopsis:      Utilities for compatibility with van Laarhoven optics
 category:      Data, Optics, Lenses
 description:

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -6,7 +6,7 @@ build-type:      Simple
 maintainer:      optics@well-typed.com
 author:          Adam Gundry, Andres Löh, Andrzej Rybczak, Oleg Grenrus
 cabal-version:   1.24
-tested-with:     ghc ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1, GHCJS ==8.4
+tested-with:     ghc ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.1 || ==9.2.1, GHCJS ==8.4
 synopsis:        Optics as an abstract interface
 category:        Data, Optics, Lenses
 description:

--- a/optics/tests/Optics/Tests/Core.hs
+++ b/optics/tests/Optics/Tests/Core.hs
@@ -60,15 +60,15 @@ coreTests = testGroup "Core"
   , testCase "optimized rhs08a" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs08a)
   , testCase "iover (imapped <% imapped) = iover (imapped % mapped)" $
-    -- GHC 9.0.1 splits the rhs into two bindings
-    ghc90failure $(inspectTest $ 'lhs09 === 'rhs09)
+    -- GHC 9.* applies a worker-wrapper transformation to the RHS
+    ghcGE90failure $(inspectTest $ 'lhs09 === 'rhs09)
   , testCase "optimized lhs09" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs09)
   , testCase "optimized rhs09" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs09)
   , testCase "itraverseOf_ itraversed = itraverseOf_ ifolded" $
-    -- GHC 8.2 gives a different order of let bindings
-    ghc82failure $(inspectTest $ 'lhs10 === 'rhs10)
+    -- GHC 8.2 and 9.2 give a different order of let bindings
+    ghc82and92failure $(inspectTest $ 'lhs10 === 'rhs10)
   , testCase "optimized lhs10a" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs10a)
   , testCase "optimized rhs10a" $
@@ -92,7 +92,7 @@ coreTests = testGroup "Core"
   , testCase "optimized rhs13" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs13)
   , testCase "traverseOf_ itraversed = traverseOf_ folded" $
-    assertSuccess $(inspectTest $ 'lhs14 ==- 'rhs14)
+    ghc92failure $(inspectTest $ 'lhs14 ==- 'rhs14)
   , testCase "optimized lhs14a" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs14a)
   , testCase "optimized rhs14a" $

--- a/optics/tests/Optics/Tests/Core.hs
+++ b/optics/tests/Optics/Tests/Core.hs
@@ -92,6 +92,7 @@ coreTests = testGroup "Core"
   , testCase "optimized rhs13" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs13)
   , testCase "traverseOf_ itraversed = traverseOf_ folded" $
+    -- GHC 9.2 gives a different structure of let bindings.
     ghc92failure $(inspectTest $ 'lhs14 ==- 'rhs14)
   , testCase "optimized lhs14a" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs14a)

--- a/optics/tests/Optics/Tests/Eta.hs
+++ b/optics/tests/Optics/Tests/Eta.hs
@@ -33,7 +33,7 @@ etaTests = testGroup "Eta expansion"
     assertSuccess $(inspectTest $ hasNoProfunctors 'eta5lhs)
   , testCase "itraverseOf_ ifolded = \\f -> itraverseOf_ ifolded f" $
     -- The lhs has more lets which the rhs inlines.
-    ghc82and90failure $(inspectTest $ 'eta6lhs === 'eta6rhs)
+    ghc82andGE90failure $(inspectTest $ 'eta6lhs === 'eta6rhs)
   , testCase "optimized eta6lhs" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'eta6lhs)
   , testCase "over mapped = \\f -> over mapped f" $

--- a/optics/tests/Optics/Tests/Utils.hs
+++ b/optics/tests/Optics/Tests/Utils.hs
@@ -96,16 +96,30 @@ ghcLE84failure = assertFailure'
 ghcLE84failure = assertSuccess
 #endif
 
-ghc82and90failure :: Result -> IO ()
-#if __GLASGOW_HASKELL__ == 802 || __GLASGOW_HASKELL__ == 900
-ghc82and90failure = assertFailure'
+ghc82andGE90failure :: Result -> IO ()
+#if __GLASGOW_HASKELL__ == 802 || __GLASGOW_HASKELL__ >= 900
+ghc82andGE90failure = assertFailure'
 #else
-ghc82and90failure = assertSuccess
+ghc82andGE90failure = assertSuccess
 #endif
 
-ghc90failure :: Result -> IO ()
-#if __GLASGOW_HASKELL__ == 900
-ghc90failure = assertFailure'
+ghc82and92failure :: Result -> IO ()
+#if __GLASGOW_HASKELL__ == 802 || __GLASGOW_HASKELL__ == 902
+ghc82and92failure = assertFailure'
 #else
-ghc90failure = assertSuccess
+ghc82and92failure = assertSuccess
+#endif
+
+ghcGE90failure :: Result -> IO ()
+#if __GLASGOW_HASKELL__ >= 900
+ghcGE90failure = assertFailure'
+#else
+ghcGE90failure = assertSuccess
+#endif
+
+ghc92failure :: Result -> IO ()
+#if __GLASGOW_HASKELL__ == 902
+ghc92failure = assertFailure'
+#else
+ghc92failure = assertSuccess
 #endif

--- a/template-haskell-optics/template-haskell-optics.cabal
+++ b/template-haskell-optics/template-haskell-optics.cabal
@@ -6,7 +6,7 @@ build-type:    Simple
 maintainer:    optics@well-typed.com
 author:        Andrzej Rybczak
 cabal-version: 1.18
-tested-with:   ghc ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4, GHCJS ==8.4
+tested-with:   ghc ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7, GHCJS ==8.4
 synopsis:      Optics for template-haskell types
 category:      Data, Optics, Lenses
 description:


### PR DESCRIPTION
Add GHC-9.2 job too, except for optics-sop, metametapost (blocked on `generics-sop`) and `template-haskell-optics`

Resolves #436 