### PR TITLE
Stop picking the catch-all JoinKinds instance if arguments match

### DIFF
--- a/codegen/Subtypes.hs
+++ b/codegen/Subtypes.hs
@@ -117,7 +117,7 @@ genJoin = either (fail . show) id $ runG opticsKind $ \g -> do
             case mkl of
                 -- alignment is important, thus padding
                 []          -> putStrLn $ unwords
-                  [ "--    no JoinKinds"
+                  [ "--                              no JoinKinds"
                   , leftpad (show k)
                   , leftpad (show l)
                   ]
@@ -126,10 +126,12 @@ genJoin = either (fail . show) id $ runG opticsKind $ \g -> do
                 [kl]        -> putStrLn . joinInstance k l $ gFromVertex kl
   where
     joinInstance k l m = unwords
-      [ "instance JoinKinds"
+      [ "instance k ~"
+      , leftpad $ show m
+      , "=> JoinKinds"
       , leftpad $ show k
       , leftpad $ show l
-      , leftpad $ show m
+      , "k"
       , "where\n  joinKinds r = r"
       ]
 

--- a/optics-core/src/Optics/Internal/Optic/Subtyping.hs
+++ b/optics-core/src/Optics/Internal/Optic/Subtyping.hs
@@ -159,276 +159,276 @@ class JoinKinds k l m | k l -> m where
 -- BEGIN GENERATED CONTENT
 
 -- An_Iso -----
-instance JoinKinds An_Iso             An_Iso             An_Iso             where
+instance k ~ An_Iso             => JoinKinds An_Iso             An_Iso             k where
   joinKinds r = r
-instance JoinKinds An_Iso             A_ReversedLens     A_ReversedLens     where
+instance k ~ A_ReversedLens     => JoinKinds An_Iso             A_ReversedLens     k where
   joinKinds r = r
-instance JoinKinds An_Iso             A_ReversedPrism    A_ReversedPrism    where
+instance k ~ A_ReversedPrism    => JoinKinds An_Iso             A_ReversedPrism    k where
   joinKinds r = r
-instance JoinKinds An_Iso             A_Prism            A_Prism            where
+instance k ~ A_Prism            => JoinKinds An_Iso             A_Prism            k where
   joinKinds r = r
-instance JoinKinds An_Iso             A_Review           A_Review           where
+instance k ~ A_Review           => JoinKinds An_Iso             A_Review           k where
   joinKinds r = r
-instance JoinKinds An_Iso             A_Lens             A_Lens             where
+instance k ~ A_Lens             => JoinKinds An_Iso             A_Lens             k where
   joinKinds r = r
-instance JoinKinds An_Iso             A_Getter           A_Getter           where
+instance k ~ A_Getter           => JoinKinds An_Iso             A_Getter           k where
   joinKinds r = r
-instance JoinKinds An_Iso             An_AffineTraversal An_AffineTraversal where
+instance k ~ An_AffineTraversal => JoinKinds An_Iso             An_AffineTraversal k where
   joinKinds r = r
-instance JoinKinds An_Iso             An_AffineFold      An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds An_Iso             An_AffineFold      k where
   joinKinds r = r
-instance JoinKinds An_Iso             A_Traversal        A_Traversal        where
+instance k ~ A_Traversal        => JoinKinds An_Iso             A_Traversal        k where
   joinKinds r = r
-instance JoinKinds An_Iso             A_Fold             A_Fold             where
+instance k ~ A_Fold             => JoinKinds An_Iso             A_Fold             k where
   joinKinds r = r
-instance JoinKinds An_Iso             A_Setter           A_Setter           where
+instance k ~ A_Setter           => JoinKinds An_Iso             A_Setter           k where
   joinKinds r = r
 
 -- A_ReversedLens -----
-instance JoinKinds A_ReversedLens     A_ReversedLens     A_ReversedLens     where
+instance k ~ A_ReversedLens     => JoinKinds A_ReversedLens     A_ReversedLens     k where
   joinKinds r = r
-instance JoinKinds A_ReversedLens     An_Iso             A_ReversedLens     where
+instance k ~ A_ReversedLens     => JoinKinds A_ReversedLens     An_Iso             k where
   joinKinds r = r
---    no JoinKinds A_ReversedLens     A_ReversedPrism
-instance JoinKinds A_ReversedLens     A_Prism            A_Review           where
+--                              no JoinKinds A_ReversedLens     A_ReversedPrism
+instance k ~ A_Review           => JoinKinds A_ReversedLens     A_Prism            k where
   joinKinds r = r
-instance JoinKinds A_ReversedLens     A_Review           A_Review           where
+instance k ~ A_Review           => JoinKinds A_ReversedLens     A_Review           k where
   joinKinds r = r
---    no JoinKinds A_ReversedLens     A_Lens
---    no JoinKinds A_ReversedLens     A_Getter
---    no JoinKinds A_ReversedLens     An_AffineTraversal
---    no JoinKinds A_ReversedLens     An_AffineFold
---    no JoinKinds A_ReversedLens     A_Traversal
---    no JoinKinds A_ReversedLens     A_Fold
---    no JoinKinds A_ReversedLens     A_Setter
+--                              no JoinKinds A_ReversedLens     A_Lens
+--                              no JoinKinds A_ReversedLens     A_Getter
+--                              no JoinKinds A_ReversedLens     An_AffineTraversal
+--                              no JoinKinds A_ReversedLens     An_AffineFold
+--                              no JoinKinds A_ReversedLens     A_Traversal
+--                              no JoinKinds A_ReversedLens     A_Fold
+--                              no JoinKinds A_ReversedLens     A_Setter
 
 -- A_ReversedPrism -----
-instance JoinKinds A_ReversedPrism    A_ReversedPrism    A_ReversedPrism    where
+instance k ~ A_ReversedPrism    => JoinKinds A_ReversedPrism    A_ReversedPrism    k where
   joinKinds r = r
-instance JoinKinds A_ReversedPrism    An_Iso             A_ReversedPrism    where
+instance k ~ A_ReversedPrism    => JoinKinds A_ReversedPrism    An_Iso             k where
   joinKinds r = r
---    no JoinKinds A_ReversedPrism    A_ReversedLens
-instance JoinKinds A_ReversedPrism    A_Prism            An_AffineFold      where
+--                              no JoinKinds A_ReversedPrism    A_ReversedLens
+instance k ~ An_AffineFold      => JoinKinds A_ReversedPrism    A_Prism            k where
   joinKinds r = r
---    no JoinKinds A_ReversedPrism    A_Review
-instance JoinKinds A_ReversedPrism    A_Lens             A_Getter           where
+--                              no JoinKinds A_ReversedPrism    A_Review
+instance k ~ A_Getter           => JoinKinds A_ReversedPrism    A_Lens             k where
   joinKinds r = r
-instance JoinKinds A_ReversedPrism    A_Getter           A_Getter           where
+instance k ~ A_Getter           => JoinKinds A_ReversedPrism    A_Getter           k where
   joinKinds r = r
-instance JoinKinds A_ReversedPrism    An_AffineTraversal An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds A_ReversedPrism    An_AffineTraversal k where
   joinKinds r = r
-instance JoinKinds A_ReversedPrism    An_AffineFold      An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds A_ReversedPrism    An_AffineFold      k where
   joinKinds r = r
-instance JoinKinds A_ReversedPrism    A_Traversal        A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_ReversedPrism    A_Traversal        k where
   joinKinds r = r
-instance JoinKinds A_ReversedPrism    A_Fold             A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_ReversedPrism    A_Fold             k where
   joinKinds r = r
---    no JoinKinds A_ReversedPrism    A_Setter
+--                              no JoinKinds A_ReversedPrism    A_Setter
 
 -- A_Prism -----
-instance JoinKinds A_Prism            A_Prism            A_Prism            where
+instance k ~ A_Prism            => JoinKinds A_Prism            A_Prism            k where
   joinKinds r = r
-instance JoinKinds A_Prism            An_Iso             A_Prism            where
+instance k ~ A_Prism            => JoinKinds A_Prism            An_Iso             k where
   joinKinds r = r
-instance JoinKinds A_Prism            A_ReversedLens     A_Review           where
+instance k ~ A_Review           => JoinKinds A_Prism            A_ReversedLens     k where
   joinKinds r = r
-instance JoinKinds A_Prism            A_ReversedPrism    An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds A_Prism            A_ReversedPrism    k where
   joinKinds r = r
-instance JoinKinds A_Prism            A_Review           A_Review           where
+instance k ~ A_Review           => JoinKinds A_Prism            A_Review           k where
   joinKinds r = r
-instance JoinKinds A_Prism            A_Lens             An_AffineTraversal where
+instance k ~ An_AffineTraversal => JoinKinds A_Prism            A_Lens             k where
   joinKinds r = r
-instance JoinKinds A_Prism            A_Getter           An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds A_Prism            A_Getter           k where
   joinKinds r = r
-instance JoinKinds A_Prism            An_AffineTraversal An_AffineTraversal where
+instance k ~ An_AffineTraversal => JoinKinds A_Prism            An_AffineTraversal k where
   joinKinds r = r
-instance JoinKinds A_Prism            An_AffineFold      An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds A_Prism            An_AffineFold      k where
   joinKinds r = r
-instance JoinKinds A_Prism            A_Traversal        A_Traversal        where
+instance k ~ A_Traversal        => JoinKinds A_Prism            A_Traversal        k where
   joinKinds r = r
-instance JoinKinds A_Prism            A_Fold             A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_Prism            A_Fold             k where
   joinKinds r = r
-instance JoinKinds A_Prism            A_Setter           A_Setter           where
+instance k ~ A_Setter           => JoinKinds A_Prism            A_Setter           k where
   joinKinds r = r
 
 -- A_Review -----
-instance JoinKinds A_Review           A_Review           A_Review           where
+instance k ~ A_Review           => JoinKinds A_Review           A_Review           k where
   joinKinds r = r
-instance JoinKinds A_Review           An_Iso             A_Review           where
+instance k ~ A_Review           => JoinKinds A_Review           An_Iso             k where
   joinKinds r = r
-instance JoinKinds A_Review           A_ReversedLens     A_Review           where
+instance k ~ A_Review           => JoinKinds A_Review           A_ReversedLens     k where
   joinKinds r = r
---    no JoinKinds A_Review           A_ReversedPrism
-instance JoinKinds A_Review           A_Prism            A_Review           where
+--                              no JoinKinds A_Review           A_ReversedPrism
+instance k ~ A_Review           => JoinKinds A_Review           A_Prism            k where
   joinKinds r = r
---    no JoinKinds A_Review           A_Lens
---    no JoinKinds A_Review           A_Getter
---    no JoinKinds A_Review           An_AffineTraversal
---    no JoinKinds A_Review           An_AffineFold
---    no JoinKinds A_Review           A_Traversal
---    no JoinKinds A_Review           A_Fold
---    no JoinKinds A_Review           A_Setter
+--                              no JoinKinds A_Review           A_Lens
+--                              no JoinKinds A_Review           A_Getter
+--                              no JoinKinds A_Review           An_AffineTraversal
+--                              no JoinKinds A_Review           An_AffineFold
+--                              no JoinKinds A_Review           A_Traversal
+--                              no JoinKinds A_Review           A_Fold
+--                              no JoinKinds A_Review           A_Setter
 
 -- A_Lens -----
-instance JoinKinds A_Lens             A_Lens             A_Lens             where
+instance k ~ A_Lens             => JoinKinds A_Lens             A_Lens             k where
   joinKinds r = r
-instance JoinKinds A_Lens             An_Iso             A_Lens             where
+instance k ~ A_Lens             => JoinKinds A_Lens             An_Iso             k where
   joinKinds r = r
---    no JoinKinds A_Lens             A_ReversedLens
-instance JoinKinds A_Lens             A_ReversedPrism    A_Getter           where
+--                              no JoinKinds A_Lens             A_ReversedLens
+instance k ~ A_Getter           => JoinKinds A_Lens             A_ReversedPrism    k where
   joinKinds r = r
-instance JoinKinds A_Lens             A_Prism            An_AffineTraversal where
+instance k ~ An_AffineTraversal => JoinKinds A_Lens             A_Prism            k where
   joinKinds r = r
---    no JoinKinds A_Lens             A_Review
-instance JoinKinds A_Lens             A_Getter           A_Getter           where
+--                              no JoinKinds A_Lens             A_Review
+instance k ~ A_Getter           => JoinKinds A_Lens             A_Getter           k where
   joinKinds r = r
-instance JoinKinds A_Lens             An_AffineTraversal An_AffineTraversal where
+instance k ~ An_AffineTraversal => JoinKinds A_Lens             An_AffineTraversal k where
   joinKinds r = r
-instance JoinKinds A_Lens             An_AffineFold      An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds A_Lens             An_AffineFold      k where
   joinKinds r = r
-instance JoinKinds A_Lens             A_Traversal        A_Traversal        where
+instance k ~ A_Traversal        => JoinKinds A_Lens             A_Traversal        k where
   joinKinds r = r
-instance JoinKinds A_Lens             A_Fold             A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_Lens             A_Fold             k where
   joinKinds r = r
-instance JoinKinds A_Lens             A_Setter           A_Setter           where
+instance k ~ A_Setter           => JoinKinds A_Lens             A_Setter           k where
   joinKinds r = r
 
 -- A_Getter -----
-instance JoinKinds A_Getter           A_Getter           A_Getter           where
+instance k ~ A_Getter           => JoinKinds A_Getter           A_Getter           k where
   joinKinds r = r
-instance JoinKinds A_Getter           An_Iso             A_Getter           where
+instance k ~ A_Getter           => JoinKinds A_Getter           An_Iso             k where
   joinKinds r = r
---    no JoinKinds A_Getter           A_ReversedLens
-instance JoinKinds A_Getter           A_ReversedPrism    A_Getter           where
+--                              no JoinKinds A_Getter           A_ReversedLens
+instance k ~ A_Getter           => JoinKinds A_Getter           A_ReversedPrism    k where
   joinKinds r = r
-instance JoinKinds A_Getter           A_Prism            An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds A_Getter           A_Prism            k where
   joinKinds r = r
---    no JoinKinds A_Getter           A_Review
-instance JoinKinds A_Getter           A_Lens             A_Getter           where
+--                              no JoinKinds A_Getter           A_Review
+instance k ~ A_Getter           => JoinKinds A_Getter           A_Lens             k where
   joinKinds r = r
-instance JoinKinds A_Getter           An_AffineTraversal An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds A_Getter           An_AffineTraversal k where
   joinKinds r = r
-instance JoinKinds A_Getter           An_AffineFold      An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds A_Getter           An_AffineFold      k where
   joinKinds r = r
-instance JoinKinds A_Getter           A_Traversal        A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_Getter           A_Traversal        k where
   joinKinds r = r
-instance JoinKinds A_Getter           A_Fold             A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_Getter           A_Fold             k where
   joinKinds r = r
---    no JoinKinds A_Getter           A_Setter
+--                              no JoinKinds A_Getter           A_Setter
 
 -- An_AffineTraversal -----
-instance JoinKinds An_AffineTraversal An_AffineTraversal An_AffineTraversal where
+instance k ~ An_AffineTraversal => JoinKinds An_AffineTraversal An_AffineTraversal k where
   joinKinds r = r
-instance JoinKinds An_AffineTraversal An_Iso             An_AffineTraversal where
+instance k ~ An_AffineTraversal => JoinKinds An_AffineTraversal An_Iso             k where
   joinKinds r = r
---    no JoinKinds An_AffineTraversal A_ReversedLens
-instance JoinKinds An_AffineTraversal A_ReversedPrism    An_AffineFold      where
+--                              no JoinKinds An_AffineTraversal A_ReversedLens
+instance k ~ An_AffineFold      => JoinKinds An_AffineTraversal A_ReversedPrism    k where
   joinKinds r = r
-instance JoinKinds An_AffineTraversal A_Prism            An_AffineTraversal where
+instance k ~ An_AffineTraversal => JoinKinds An_AffineTraversal A_Prism            k where
   joinKinds r = r
---    no JoinKinds An_AffineTraversal A_Review
-instance JoinKinds An_AffineTraversal A_Lens             An_AffineTraversal where
+--                              no JoinKinds An_AffineTraversal A_Review
+instance k ~ An_AffineTraversal => JoinKinds An_AffineTraversal A_Lens             k where
   joinKinds r = r
-instance JoinKinds An_AffineTraversal A_Getter           An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds An_AffineTraversal A_Getter           k where
   joinKinds r = r
-instance JoinKinds An_AffineTraversal An_AffineFold      An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds An_AffineTraversal An_AffineFold      k where
   joinKinds r = r
-instance JoinKinds An_AffineTraversal A_Traversal        A_Traversal        where
+instance k ~ A_Traversal        => JoinKinds An_AffineTraversal A_Traversal        k where
   joinKinds r = r
-instance JoinKinds An_AffineTraversal A_Fold             A_Fold             where
+instance k ~ A_Fold             => JoinKinds An_AffineTraversal A_Fold             k where
   joinKinds r = r
-instance JoinKinds An_AffineTraversal A_Setter           A_Setter           where
+instance k ~ A_Setter           => JoinKinds An_AffineTraversal A_Setter           k where
   joinKinds r = r
 
 -- An_AffineFold -----
-instance JoinKinds An_AffineFold      An_AffineFold      An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds An_AffineFold      An_AffineFold      k where
   joinKinds r = r
-instance JoinKinds An_AffineFold      An_Iso             An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds An_AffineFold      An_Iso             k where
   joinKinds r = r
---    no JoinKinds An_AffineFold      A_ReversedLens
-instance JoinKinds An_AffineFold      A_ReversedPrism    An_AffineFold      where
+--                              no JoinKinds An_AffineFold      A_ReversedLens
+instance k ~ An_AffineFold      => JoinKinds An_AffineFold      A_ReversedPrism    k where
   joinKinds r = r
-instance JoinKinds An_AffineFold      A_Prism            An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds An_AffineFold      A_Prism            k where
   joinKinds r = r
---    no JoinKinds An_AffineFold      A_Review
-instance JoinKinds An_AffineFold      A_Lens             An_AffineFold      where
+--                              no JoinKinds An_AffineFold      A_Review
+instance k ~ An_AffineFold      => JoinKinds An_AffineFold      A_Lens             k where
   joinKinds r = r
-instance JoinKinds An_AffineFold      A_Getter           An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds An_AffineFold      A_Getter           k where
   joinKinds r = r
-instance JoinKinds An_AffineFold      An_AffineTraversal An_AffineFold      where
+instance k ~ An_AffineFold      => JoinKinds An_AffineFold      An_AffineTraversal k where
   joinKinds r = r
-instance JoinKinds An_AffineFold      A_Traversal        A_Fold             where
+instance k ~ A_Fold             => JoinKinds An_AffineFold      A_Traversal        k where
   joinKinds r = r
-instance JoinKinds An_AffineFold      A_Fold             A_Fold             where
+instance k ~ A_Fold             => JoinKinds An_AffineFold      A_Fold             k where
   joinKinds r = r
---    no JoinKinds An_AffineFold      A_Setter
+--                              no JoinKinds An_AffineFold      A_Setter
 
 -- A_Traversal -----
-instance JoinKinds A_Traversal        A_Traversal        A_Traversal        where
+instance k ~ A_Traversal        => JoinKinds A_Traversal        A_Traversal        k where
   joinKinds r = r
-instance JoinKinds A_Traversal        An_Iso             A_Traversal        where
+instance k ~ A_Traversal        => JoinKinds A_Traversal        An_Iso             k where
   joinKinds r = r
---    no JoinKinds A_Traversal        A_ReversedLens
-instance JoinKinds A_Traversal        A_ReversedPrism    A_Fold             where
+--                              no JoinKinds A_Traversal        A_ReversedLens
+instance k ~ A_Fold             => JoinKinds A_Traversal        A_ReversedPrism    k where
   joinKinds r = r
-instance JoinKinds A_Traversal        A_Prism            A_Traversal        where
+instance k ~ A_Traversal        => JoinKinds A_Traversal        A_Prism            k where
   joinKinds r = r
---    no JoinKinds A_Traversal        A_Review
-instance JoinKinds A_Traversal        A_Lens             A_Traversal        where
+--                              no JoinKinds A_Traversal        A_Review
+instance k ~ A_Traversal        => JoinKinds A_Traversal        A_Lens             k where
   joinKinds r = r
-instance JoinKinds A_Traversal        A_Getter           A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_Traversal        A_Getter           k where
   joinKinds r = r
-instance JoinKinds A_Traversal        An_AffineTraversal A_Traversal        where
+instance k ~ A_Traversal        => JoinKinds A_Traversal        An_AffineTraversal k where
   joinKinds r = r
-instance JoinKinds A_Traversal        An_AffineFold      A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_Traversal        An_AffineFold      k where
   joinKinds r = r
-instance JoinKinds A_Traversal        A_Fold             A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_Traversal        A_Fold             k where
   joinKinds r = r
-instance JoinKinds A_Traversal        A_Setter           A_Setter           where
+instance k ~ A_Setter           => JoinKinds A_Traversal        A_Setter           k where
   joinKinds r = r
 
 -- A_Fold -----
-instance JoinKinds A_Fold             A_Fold             A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_Fold             A_Fold             k where
   joinKinds r = r
-instance JoinKinds A_Fold             An_Iso             A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_Fold             An_Iso             k where
   joinKinds r = r
---    no JoinKinds A_Fold             A_ReversedLens
-instance JoinKinds A_Fold             A_ReversedPrism    A_Fold             where
+--                              no JoinKinds A_Fold             A_ReversedLens
+instance k ~ A_Fold             => JoinKinds A_Fold             A_ReversedPrism    k where
   joinKinds r = r
-instance JoinKinds A_Fold             A_Prism            A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_Fold             A_Prism            k where
   joinKinds r = r
---    no JoinKinds A_Fold             A_Review
-instance JoinKinds A_Fold             A_Lens             A_Fold             where
+--                              no JoinKinds A_Fold             A_Review
+instance k ~ A_Fold             => JoinKinds A_Fold             A_Lens             k where
   joinKinds r = r
-instance JoinKinds A_Fold             A_Getter           A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_Fold             A_Getter           k where
   joinKinds r = r
-instance JoinKinds A_Fold             An_AffineTraversal A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_Fold             An_AffineTraversal k where
   joinKinds r = r
-instance JoinKinds A_Fold             An_AffineFold      A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_Fold             An_AffineFold      k where
   joinKinds r = r
-instance JoinKinds A_Fold             A_Traversal        A_Fold             where
+instance k ~ A_Fold             => JoinKinds A_Fold             A_Traversal        k where
   joinKinds r = r
---    no JoinKinds A_Fold             A_Setter
+--                              no JoinKinds A_Fold             A_Setter
 
 -- A_Setter -----
-instance JoinKinds A_Setter           A_Setter           A_Setter           where
+instance k ~ A_Setter           => JoinKinds A_Setter           A_Setter           k where
   joinKinds r = r
-instance JoinKinds A_Setter           An_Iso             A_Setter           where
+instance k ~ A_Setter           => JoinKinds A_Setter           An_Iso             k where
   joinKinds r = r
---    no JoinKinds A_Setter           A_ReversedLens
---    no JoinKinds A_Setter           A_ReversedPrism
-instance JoinKinds A_Setter           A_Prism            A_Setter           where
+--                              no JoinKinds A_Setter           A_ReversedLens
+--                              no JoinKinds A_Setter           A_ReversedPrism
+instance k ~ A_Setter           => JoinKinds A_Setter           A_Prism            k where
   joinKinds r = r
---    no JoinKinds A_Setter           A_Review
-instance JoinKinds A_Setter           A_Lens             A_Setter           where
+--                              no JoinKinds A_Setter           A_Review
+instance k ~ A_Setter           => JoinKinds A_Setter           A_Lens             k where
   joinKinds r = r
---    no JoinKinds A_Setter           A_Getter
-instance JoinKinds A_Setter           An_AffineTraversal A_Setter           where
+--                              no JoinKinds A_Setter           A_Getter
+instance k ~ A_Setter           => JoinKinds A_Setter           An_AffineTraversal k where
   joinKinds r = r
---    no JoinKinds A_Setter           An_AffineFold
-instance JoinKinds A_Setter           A_Traversal        A_Setter           where
+--                              no JoinKinds A_Setter           An_AffineFold
+instance k ~ A_Setter           => JoinKinds A_Setter           A_Traversal        k where
   joinKinds r = r
---    no JoinKinds A_Setter           A_Fold
+--                              no JoinKinds A_Setter           A_Fold
 
 -- END GENERATED CONTENT
 

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -533,10 +533,6 @@ import Data.Either.Optics                    as P
 -- constraint 'JoinKinds A_Lens A_Prism k' makes GHC infer that @k@ must be
 -- 'An_AffineTraversal'.
 --
--- >>> let res :: JoinKinds A_Lens A_Prism k => Proxy k; res = Proxy
--- >>> :t res
--- res :: Proxy An_AffineTraversal
---
 -- The join does not exist for some pairs of optic kinds, which means that they
 -- cannot be composed.  For example there is no optic kind above both 'Setter'
 -- and 'Fold':
@@ -996,11 +992,9 @@ import Data.Either.Optics                    as P
 -- +--------------+-----------------+-------------------------------------------+------------------------------+-------------------------------+-------------------------------------------+
 
 -- $setup
--- >>> :set -XFlexibleContexts
 -- >>> import Control.Monad.Reader
 -- >>> import Control.Monad.State
 -- >>> import Data.Functor.Identity
--- >>> import Data.Proxy
 -- >>> import qualified Data.IntSet as IntSet
 -- >>> import qualified Data.Map as Map
 -- >>> import Optics.State.Operators

--- a/optics/tests/Optics/Tests/Core.hs
+++ b/optics/tests/Optics/Tests/Core.hs
@@ -40,7 +40,7 @@ coreTests = testGroup "Core"
   , testCase "optimized rhs05" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs05)
   , testCase "traverseOf_ (_Left % itraversed % _1 % ifolded) = traverseOf_ ..." $
-    -- GHC >= 8.6 gives different order of let bindings
+    -- GHC >= 8.6 gives different structure of let bindings.
     ghcGE86failure $(inspectTest $ 'lhs06 === 'rhs06)
   , testCase "optimized lhs06" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs06)
@@ -60,15 +60,15 @@ coreTests = testGroup "Core"
   , testCase "optimized rhs08a" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs08a)
   , testCase "iover (imapped <% imapped) = iover (imapped % mapped)" $
-    -- GHC 9.* applies a worker-wrapper transformation to the RHS
+    -- GHC 9.* applies a worker-wrapper transformation to the RHS.
     ghcGE90failure $(inspectTest $ 'lhs09 === 'rhs09)
   , testCase "optimized lhs09" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs09)
   , testCase "optimized rhs09" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs09)
   , testCase "itraverseOf_ itraversed = itraverseOf_ ifolded" $
-    -- GHC 8.2 and 9.2 give a different order of let bindings
-    ghc82and92failure $(inspectTest $ 'lhs10 === 'rhs10)
+    -- GHC 8.2, 8.6 to 8.10 and 9.2 give a different structure of let bindings.
+    ghc82and86to810and92failure $(inspectTest $ 'lhs10 === 'rhs10)
   , testCase "optimized lhs10a" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs10a)
   , testCase "optimized rhs10a" $
@@ -80,7 +80,8 @@ coreTests = testGroup "Core"
   , testCase "optimized rhs11" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs11)
   , testCase "traverseOf_ traversed = traverseOf_ folded" $
-    assertSuccess $(inspectTest $ 'lhs12 === 'rhs12)
+    -- GHC 8.6 to 8.10 give a different structure of let bindings.
+    ghc86to810failure $(inspectTest $ 'lhs12 === 'rhs12)
   , testCase "optimized lhs12a" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs12a)
   , testCase "optimized rhs12a" $
@@ -92,8 +93,8 @@ coreTests = testGroup "Core"
   , testCase "optimized rhs13" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs13)
   , testCase "traverseOf_ itraversed = traverseOf_ folded" $
-    -- GHC 9.2 gives a different structure of let bindings.
-    ghc92failure $(inspectTest $ 'lhs14 ==- 'rhs14)
+    -- GHC 8.6 to 8.10 and GHC 9.2 give a different structure of let bindings.
+    ghc86to810and92failure $(inspectTest $ 'lhs14 ==- 'rhs14)
   , testCase "optimized lhs14a" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs14a)
   , testCase "optimized rhs14a" $
@@ -105,13 +106,15 @@ coreTests = testGroup "Core"
   , testCase "optimized rhs15" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs15)
   , testCase "iset (itraversed..) = iset (imapped..)" $
-    assertSuccess $(inspectTest $ 'lhs16 === 'rhs16)
+    -- GHC 8.10 has an intermediate let in the RHS.
+    ghc810failure $(inspectTest $ 'lhs16 === 'rhs16)
   , testCase "optimized lhs16" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs16)
   , testCase "optimized rhs16" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs16)
   , testCase "iset (_1 % itraversed) = iset (_1 % imapped)" $
-    assertSuccess $(inspectTest $ 'lhs17 === 'rhs17)
+    -- GHC 8.10 has an intermediate let in the LHS.
+    ghc810failure $(inspectTest $ 'lhs17 === 'rhs17)
   , testCase "optimized lhs17" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs17)
   , testCase "optimized rhs17" $

--- a/optics/tests/Optics/Tests/Utils.hs
+++ b/optics/tests/Optics/Tests/Utils.hs
@@ -75,11 +75,25 @@ ghc82to86failure = assertFailure'
 ghc82to86failure = assertSuccess
 #endif
 
+ghc86to810failure :: Result -> IO ()
+#if __GLASGOW_HASKELL__ >= 806 && __GLASGOW_HASKELL__ <= 810
+ghc86to810failure = assertFailure'
+#else
+ghc86to810failure = assertSuccess
+#endif
+
 ghc82failure :: Result -> IO ()
 #if __GLASGOW_HASKELL__ == 802
 ghc82failure = assertFailure'
 #else
 ghc82failure = assertSuccess
+#endif
+
+ghc810failure :: Result -> IO ()
+#if __GLASGOW_HASKELL__ == 810
+ghc810failure = assertFailure'
+#else
+ghc810failure = assertSuccess
 #endif
 
 ghcGE86failure :: Result -> IO ()
@@ -97,17 +111,20 @@ ghcLE84failure = assertSuccess
 #endif
 
 ghc82andGE90failure :: Result -> IO ()
-#if __GLASGOW_HASKELL__ == 802 || __GLASGOW_HASKELL__ >= 900
+#if __GLASGOW_HASKELL__ == 802 \
+ || __GLASGOW_HASKELL__ >= 900
 ghc82andGE90failure = assertFailure'
 #else
 ghc82andGE90failure = assertSuccess
 #endif
 
-ghc82and92failure :: Result -> IO ()
-#if __GLASGOW_HASKELL__ == 802 || __GLASGOW_HASKELL__ == 902
-ghc82and92failure = assertFailure'
+ghc82and86to810and92failure :: Result -> IO ()
+#if __GLASGOW_HASKELL__ == 802 \
+ || __GLASGOW_HASKELL__ >= 806 && __GLASGOW_HASKELL__ <= 810 \
+ || __GLASGOW_HASKELL__ == 902
+ghc82and86to810and92failure = assertFailure'
 #else
-ghc82and92failure = assertSuccess
+ghc82and86to810and92failure = assertSuccess
 #endif
 
 ghcGE90failure :: Result -> IO ()
@@ -117,9 +134,10 @@ ghcGE90failure = assertFailure'
 ghcGE90failure = assertSuccess
 #endif
 
-ghc92failure :: Result -> IO ()
-#if __GLASGOW_HASKELL__ == 902
-ghc92failure = assertFailure'
+ghc86to810and92failure :: Result -> IO ()
+#if __GLASGOW_HASKELL__ >= 806 && __GLASGOW_HASKELL__ <= 810 \
+ || __GLASGOW_HASKELL__ == 902
+ghc86to810and92failure = assertFailure'
 #else
-ghc92failure = assertSuccess
+ghc86to810and92failure = assertSuccess
 #endif


### PR DESCRIPTION
Fixes #423 (to an extent).

Simpler than #424, but should make the situation strictly better.