### PR TITLE
Allow text-2.0

### DIFF
--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -38,7 +38,7 @@ library
                , indexed-profunctors    >= 0.1       && <0.2
                , mtl                    >= 2.2.2     && <2.3
                , optics-core            >= 0.4       && <0.4.1
-               , text                   >= 1.2       && <1.3
+               , text                   >= 1.2       && <1.3 || >=2.0 && <2.1
                , transformers           >= 0.5       && <0.6
                , unordered-containers   >= 0.2.6     && <0.3
                , vector                 >= 0.11      && <0.13


### PR DESCRIPTION
The GHC-8.2 didn't ship `text`, so CI picks up `text-2.0` there.