### PR TITLE
Better inference for AppendIndices

### DIFF
--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -111,12 +111,12 @@ data IxEq i is js where
 class AppendIndices xs ys ks | xs ys -> ks where
   appendIndices :: IxEq i (Curry xs (Curry ys i)) (Curry ks i)
 
--- | If the second list is empty, we can shortcircuit and pick the first list
--- immediately.
+-- | If the second list is empty, we can pick the first list
+-- even if nothing is known about it.
 instance {-# INCOHERENT #-} AppendIndices xs '[] xs where
   appendIndices = IxEq
 
-instance AppendIndices '[] ys ys where
+instance ys ~ zs => AppendIndices '[] ys zs where
   appendIndices = IxEq
 
 instance AppendIndices xs ys ks => AppendIndices (x ': xs) ys (x ': ks) where

--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -113,7 +113,7 @@ class AppendIndices xs ys ks | xs ys -> ks where
 
 -- | If the second list is empty, we can pick the first list
 -- even if nothing is known about it.
-instance {-# INCOHERENT #-} AppendIndices xs '[] xs where
+instance {-# INCOHERENT #-} xs ~ zs => AppendIndices xs '[] zs where
   appendIndices = IxEq
 
 instance ys ~ zs => AppendIndices '[] ys zs where


### PR DESCRIPTION
* Allow the second argument of `AppendIndices` to be determined by the first and third arguments.
* Refine the documentation for `AppendIndices`. Due to the way incoherent instances work, the "short-circuit" path is actually treated as a fall-back; it will *only* be taken if nothing is known about the shape of the first list.