### PR TITLE
Allow transformers-0.6

### DIFF
--- a/metametapost/src/MMP/Optics/Hierarchy.hs
+++ b/metametapost/src/MMP/Optics/Hierarchy.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 module MMP.Optics.Hierarchy where
 
-import           Control.Monad.State
+import           Control.Monad
 import qualified Data.Graph as G
 import           Optics
 

--- a/metametapost/src/MMP/Optics/Indexed.hs
+++ b/metametapost/src/MMP/Optics/Indexed.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 module MMP.Optics.Indexed where
 
+import           Control.Monad
 import           Control.Monad.State
 import           Optics
 

--- a/metametapost/src/MMP/Optics/Re.hs
+++ b/metametapost/src/MMP/Optics/Re.hs
@@ -1,6 +1,6 @@
 module MMP.Optics.Re where
 
-import           Control.Monad.State
+import           Control.Monad
 import           Optics
 
 import           MetaMetaPost

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -75,7 +75,7 @@ library
                , array                  >= 0.5.2.0    && <0.6
                , containers             >= 0.5.10.2   && <0.7
                , indexed-profunctors    >= 0.1        && <0.2
-               , transformers           >= 0.5        && <0.6
+               , transformers           >= 0.5        && <0.7
                , indexed-traversable    >= 0.1        && <0.2
 
   exposed-modules: Optics.Core

--- a/optics-extra/CHANGELOG.md
+++ b/optics-extra/CHANGELOG.md
@@ -1,3 +1,13 @@
+# optics-extra-0.4.2 (????-??-??)
+* Allow transformers-0.6 and mtl-2.3
+
+  Note that optics-extra no longer defines Zoom instances for ErrorT or ListT when
+  building with mtl-2.3 or later. This is because MonadState is a superclass of
+  Zoom, and the MonadState instances for ErrorT and ListT were removed in
+  mtl-2.3. Be watchful of this if you build optics-extra with mtl-2.3 (or
+  later) combined with an older version of transformers (pre-0.6) that defines
+  ErrorT or ListT.  Similarly for Magnify and MagnifyMany.
+
 # optics-extra-0.4.1 (2022-03-22)
 * Add support for GHC-9.2
 

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -67,10 +67,10 @@ library
                , containers             >= 0.5.10.2  && <0.7
                , hashable               >= 1.1.1     && <1.5
                , indexed-profunctors    >= 0.1       && <0.2
-               , mtl                    >= 2.2.2     && <2.3
+               , mtl                    >= 2.2.2     && <2.4
                , optics-core            >= 0.4.1     && <0.4.2
                , text                   >= 1.2       && <1.3 || >=2.0 && <2.1
-               , transformers           >= 0.5       && <0.6
+               , transformers           >= 0.5       && <0.7
                , unordered-containers   >= 0.2.6     && <0.3
                , vector                 >= 0.11      && <0.13
                , indexed-traversable-instances >=0.1 && <0.2

--- a/optics-th/optics-th.cabal
+++ b/optics-th/optics-th.cabal
@@ -62,11 +62,11 @@ library
 
   build-depends: base                   >= 4.10      && <5
                , containers             >= 0.5.10.2  && <0.7
-               , mtl                    >= 2.2.2     && <2.3
+               , mtl                    >= 2.2.2     && <2.4
                , optics-core            >= 0.4.1     && <0.5
                , template-haskell       >= 2.12      && <2.19
                , th-abstraction         >= 0.4       && <0.5
-               , transformers           >= 0.5       && <0.6
+               , transformers           >= 0.5       && <0.7
 
   exposed-modules: Optics.TH
 

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -72,11 +72,11 @@ library
   build-depends: base                   >= 4.10      && <5
                , array                  >= 0.5.2.0   && <0.6
                , containers             >= 0.5.10.2  && <0.7
-               , mtl                    >= 2.2.2     && <2.3
+               , mtl                    >= 2.2.2     && <2.4
                , optics-core            >= 0.4.1     && <0.4.2
                , optics-extra           >= 0.4.1     && <0.4.2
                , optics-th              >= 0.4.1     && <0.4.2
-               , transformers           >= 0.5       && <0.6
+               , transformers           >= 0.5       && <0.7
 
   -- main module to land with repl
   exposed-modules:    Optics


### PR DESCRIPTION
This allow transformers-0.6 (and mtl-2.3) in install plans.

I tested locally that changes upstream don't affect optics. However, we can be 100% sure as e.g. `inspection-testing` depends on `ghc` which depends on `transformers`, so we cannot upgrade that package *and* run tests. Yet, I'm quite sure anyway, and will make revisions.

For reference, ghc to bundle transformers-0.6 issue: https://gitlab.haskell.org/ghc/ghc/-/issues/21587