### PR TITLE
Fix CPP around Magnify ListT and ErrorT instances

### DIFF
--- a/optics-extra/CHANGELOG.md
+++ b/optics-extra/CHANGELOG.md
@@ -1,3 +1,6 @@
+# optics-extra-0.4.2.1 (2022-05-20)
+* Fix for previous release when used with `mtl-2.3` and `transformers-0.5`.
+
 # optics-extra-0.4.2 (2022-05-19)
 * Allow `transformers-0.6` and `mtl-2.3`
 

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          optics-extra
-version:       0.4.2
+version:       0.4.2.1
 license:       BSD-3-Clause
 license-file:  LICENSE
 build-type:    Simple

--- a/optics-extra/src/Optics/Zoom.hs
+++ b/optics-extra/src/Optics/Zoom.hs
@@ -22,7 +22,7 @@ import qualified Control.Monad.Trans.State.Strict as S
 import qualified Control.Monad.Trans.Writer.Lazy as L
 import qualified Control.Monad.Trans.Writer.Strict as S
 
-#if !MIN_VERSION_transformers(0,6,0)
+#if !MIN_VERSION_transformers(0,6,0) && !MIN_VERSION_mtl(2,3,0)
 import Control.Monad.Trans.Error (Error, ErrorT (..))
 import Control.Monad.Trans.List (ListT (..))
 #endif
@@ -395,7 +395,7 @@ instance MagnifyMany m n b a => MagnifyMany (ExceptT e m) (ExceptT e n) b a wher
   magnifyMany o = ExceptT #. fmap getErr . magnifyMany o . fmap Err .# runExceptT
   {-# INLINE magnifyMany #-}
 
-#if !MIN_VERSION_transformers(0,6,0)
+#if !MIN_VERSION_transformers(0,6,0) && !MIN_VERSION_mtl(2,3,0)
 instance (Error e, Magnify m n b a) => Magnify (ErrorT e m) (ErrorT e n) b a where
   magnify o = ErrorT #. magnify o .# runErrorT
   magnifyMaybe o =


### PR DESCRIPTION
Tested by building

```
cabal build --constraint 'mtl >= 2.3' --constraint 'transformers < 0.6' all --disable-tests
cabal build --constraint 'mtl >= 2.3' --constraint 'transformers >= 0.6' all --disable-tests
cabal build --constraint 'mtl < 2.3' all --disable-tests
```

Fixes #458 