### PR TITLE
Adapt optics for GHC 9.4

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.3
+# version: 0.15.20220525
 #
-# REGENDATA ("0.14.3",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.15.20220525",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -23,7 +23,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -36,6 +36,11 @@ jobs:
             compilerKind: ghcjs
             compilerVersion: "8.4"
             setup-method: hvr-ppa
+            allow-failure: false
+          - compiler: ghc-9.4.0.20220501
+            compilerKind: ghc
+            compilerVersion: 9.4.0.20220501
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.2
             compilerKind: ghc
@@ -93,8 +98,9 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            if $HEADHACKAGE; then "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml; fi
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           else
@@ -105,7 +111,7 @@ jobs:
             apt-get update
             if [ $((GHCJSARITH)) -ne 0 ] ; then apt-get install -y "$HCNAME" ghc-8.4.4 nodejs ; else apt-get install -y "$HCNAME" ; fi
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           fi
@@ -139,7 +145,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((! GHCJSARITH && HCNUMVER >= 90400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -167,6 +173,17 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -185,7 +202,7 @@ jobs:
       - name: cache (tools)
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-16fe7d6d
+          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-c2e577c5
           path: ~/.haskell-ci-tools
       - name: install cabal-plan
         run: |
@@ -198,8 +215,8 @@ jobs:
           cabal-plan --version
       - name: install doctest
         run: |
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then $CABAL --store-dir=$HOME/.haskell-ci-tools/store v2-install $ARG_COMPILER --ignore-project -j2 doctest --constraint='doctest ^>=0.20' ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then doctest --version ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then $CABAL --store-dir=$HOME/.haskell-ci-tools/store v2-install $ARG_COMPILER --ignore-project -j2 doctest --constraint='doctest ^>=0.20' ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest --version ; fi
       - name: checkout
         uses: actions/checkout@v2
         with:
@@ -277,6 +294,9 @@ jobs:
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(indexed-profunctors|metametapost|optics|optics-core|optics-extra|optics-sop|optics-th|optics-vl|template-haskell-optics)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -305,22 +325,22 @@ jobs:
           if [ $((! GHCJSARITH)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
       - name: doctest
         run: |
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then cd ${PKGDIR_optics} || false ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then cd ${PKGDIR_optics_core} || false ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then cd ${PKGDIR_optics_extra} || false ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then cd ${PKGDIR_optics_sop} || false ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then cd ${PKGDIR_optics_th} || false ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then cd ${PKGDIR_optics_vl} || false ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then cd ${PKGDIR_indexed_profunctors} || false ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then cd ${PKGDIR_template_haskell_optics} || false ; fi
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then doctest  -XHaskell2010 src ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_optics} || false ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_optics_core} || false ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_optics_extra} || false ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_optics_sop} || false ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_optics_th} || false ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_optics_vl} || false ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_indexed_profunctors} || false ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_template_haskell_optics} || false ; fi
+          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 src ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_optics} || false
@@ -343,7 +363,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          if [ $((! GHCJSARITH)) -ne 0 ] ; then $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi
+          if [ $((! GHCJSARITH)) -ne 0 ] ; then $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,5 +1,5 @@
 branches:       master
 doctest:        <9.3
 tests:          True
-benchmarks:     <9.3
+benchmarks:     <9.5
 jobs-selection: any

--- a/indexed-profunctors/indexed-profunctors.cabal
+++ b/indexed-profunctors/indexed-profunctors.cabal
@@ -7,7 +7,7 @@ build-type:    Simple
 maintainer:    optics@well-typed.com
 author:        Adam Gundry, Andres Löh, Andrzej Rybczak, Oleg Grenrus
 tested-with:   GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7
-                || ==9.0.2 || ==9.2.2, GHCJS ==8.4
+                || ==9.0.2 || ==9.2.2 || ==9.4.1, GHCJS ==8.4
 synopsis:      Utilities for indexed profunctors
 category:      Data, Optics, Lenses, Profunctors
 description:

--- a/metametapost/metametapost.cabal
+++ b/metametapost/metametapost.cabal
@@ -5,7 +5,7 @@ license:       BSD-3-Clause
 license-file:  LICENSE
 build-type:    Simple
 tested-with:   GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7
-                || ==9.0.2 || ==9.2.2, GHCJS ==8.4
+                || ==9.0.2 || ==9.2.2 || ==9.4.1, GHCJS ==8.4
 maintainer:    oleg@well-typed.com
 synopsis:      Generate optics documentation diagrams
 category:      Optics, Examples

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -7,7 +7,7 @@ build-type:    Simple
 maintainer:    optics@well-typed.com
 author:        Adam Gundry, Andres Löh, Andrzej Rybczak, Oleg Grenrus
 tested-with:   GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7
-                || ==9.0.2 || ==9.2.2, GHCJS ==8.4
+                || ==9.0.2 || ==9.2.2 || ==9.4.1, GHCJS ==8.4
 synopsis:      Optics as an abstract interface: core definitions
 category:      Data, Optics, Lenses
 description:

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -7,7 +7,7 @@ build-type:    Simple
 maintainer:    optics@well-typed.com
 author:        Andrzej Rybczak
 tested-with:   GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7
-                || ==9.0.2 || ==9.2.2, GHCJS ==8.4
+                || ==9.0.2 || ==9.2.2 || ==9.4.1, GHCJS ==8.4
 synopsis:      Extra utilities and instances for optics-core
 category:      Data, Optics, Lenses
 description:

--- a/optics-sop/optics-sop.cabal
+++ b/optics-sop/optics-sop.cabal
@@ -7,7 +7,7 @@ build-type:    Simple
 maintainer:    optics@well-typed.com
 author:        Adam Gundry, Andres Löh, Andrzej Rybczak
 tested-with:   GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7
-                || ==9.0.2 || ==9.2.2, GHCJS ==8.4
+                || ==9.0.2 || ==9.2.2 || ==9.4.1, GHCJS ==8.4
 synopsis:      Optics for generics-sop, and using generics-sop
 category:      Data, Optics, Lenses, Generics
 description:

--- a/optics-th/optics-th.cabal
+++ b/optics-th/optics-th.cabal
@@ -7,7 +7,7 @@ build-type:    Simple
 maintainer:    optics@well-typed.com
 author:        Andrzej Rybczak
 tested-with:   GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7
-                || ==9.0.2 || ==9.2.2, GHCJS ==8.4
+                || ==9.0.2 || ==9.2.2 || ==9.4.1, GHCJS ==8.4
 synopsis:      Optics construction using TemplateHaskell
 category:      Data, Optics, Lenses
 description:

--- a/optics-th/optics-th.cabal
+++ b/optics-th/optics-th.cabal
@@ -64,7 +64,7 @@ library
                , containers             >= 0.5.10.2  && <0.7
                , mtl                    >= 2.2.2     && <2.4
                , optics-core            >= 0.4.1     && <0.5
-               , template-haskell       >= 2.12      && <2.19
+               , template-haskell       >= 2.12      && <2.20
                , th-abstraction         >= 0.4       && <0.5
                , transformers           >= 0.5       && <0.7
 

--- a/optics-th/tests/Optics/TH/Tests.hs
+++ b/optics-th/tests/Optics/TH/Tests.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-} -- GHC 8.2.2 hangs on this module otherwise
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/optics-vl/optics-vl.cabal
+++ b/optics-vl/optics-vl.cabal
@@ -7,7 +7,7 @@ build-type:    Simple
 maintainer:    optics@well-typed.com
 author:        Andrzej Rybczak
 tested-with:   GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7
-                || ==9.0.2 || ==9.2.2, GHCJS ==8.4
+                || ==9.0.2 || ==9.2.2 || ==9.4.1, GHCJS ==8.4
 synopsis:      Utilities for compatibility with van Laarhoven optics
 category:      Data, Optics, Lenses
 description:

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -7,7 +7,7 @@ build-type:      Simple
 maintainer:      optics@well-typed.com
 author:          Adam Gundry, Andres Löh, Andrzej Rybczak, Oleg Grenrus
 tested-with:     GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7
-                  || ==9.0.2 || ==9.2.2, GHCJS ==8.4
+                  || ==9.0.2 || ==9.2.2 || ==9.4.1, GHCJS ==8.4
 synopsis:        Optics as an abstract interface
 category:        Data, Optics, Lenses
 description:

--- a/optics/tests/Optics/Tests/Core.hs
+++ b/optics/tests/Optics/Tests/Core.hs
@@ -67,8 +67,9 @@ coreTests = testGroup "Core"
   , testCase "optimized rhs09" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs09)
   , testCase "itraverseOf_ itraversed = itraverseOf_ ifolded" $
-    -- GHC 8.2, 8.6 to 8.10 and 9.2 give a different structure of let bindings.
-    ghc82and86to810and92failure $(inspectTest $ 'lhs10 === 'rhs10)
+    -- GHC 8.2, 8.6 to 8.10 and 9.2 to 9.4 give a different structure of let
+    -- bindings.
+    ghc82and86to810and92to94failure $(inspectTest $ 'lhs10 === 'rhs10)
   , testCase "optimized lhs10a" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs10a)
   , testCase "optimized rhs10a" $
@@ -93,8 +94,9 @@ coreTests = testGroup "Core"
   , testCase "optimized rhs13" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'rhs13)
   , testCase "traverseOf_ itraversed = traverseOf_ folded" $
-    -- GHC 8.6 to 8.10 and GHC 9.2 give a different structure of let bindings.
-    ghc86to810and92failure $(inspectTest $ 'lhs14 ==- 'rhs14)
+    -- GHC 8.6 to 8.10 and GHC 9.2 to 9.4 give a different structure of let
+    -- bindings.
+    ghc86to810and92to94failure $(inspectTest $ 'lhs14 ==- 'rhs14)
   , testCase "optimized lhs14a" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'lhs14a)
   , testCase "optimized rhs14a" $

--- a/optics/tests/Optics/Tests/Labels/Generic.hs
+++ b/optics/tests/Optics/Tests/Labels/Generic.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fplugin=Test.Inspection.Plugin -dsuppress-all #-}
 module Optics.Tests.Labels.Generic where
@@ -69,7 +70,7 @@ genericLabelsTests = testGroup "Labels via Generic"
 
 label1lhs, label1rhs :: forall a. Human a -> String
 label1lhs s = view #name s
-label1rhs s = name (s :: Human a)
+label1rhs Human{name} = name
 
 label2lhs, label2rhs :: Human a -> [b] -> Human b
 label2lhs s b = set #pets b s
@@ -77,7 +78,9 @@ label2rhs s b = s { pets = b }
 
 label3lhs, label3rhs :: Human a -> String
 label3lhs s = view (#fish % #name) s
-label3rhs s = name (fish s :: Fish)
+label3rhs Human{fish} = case fish of
+  GoldFish{name} -> name
+  Herring{name}  -> name
 
 label4lhs, label4rhs :: Human a -> String -> Human a
 label4lhs s b = set (#fish % #name) b s

--- a/optics/tests/Optics/Tests/Utils.hs
+++ b/optics/tests/Optics/Tests/Utils.hs
@@ -118,13 +118,13 @@ ghc82andGE90failure = assertFailure'
 ghc82andGE90failure = assertSuccess
 #endif
 
-ghc82and86to810and92failure :: Result -> IO ()
+ghc82and86to810and92to94failure :: Result -> IO ()
 #if __GLASGOW_HASKELL__ == 802 \
  || __GLASGOW_HASKELL__ >= 806 && __GLASGOW_HASKELL__ <= 810 \
- || __GLASGOW_HASKELL__ == 902
-ghc82and86to810and92failure = assertFailure'
+ || __GLASGOW_HASKELL__ >= 902 && __GLASGOW_HASKELL__ <= 904
+ghc82and86to810and92to94failure = assertFailure'
 #else
-ghc82and86to810and92failure = assertSuccess
+ghc82and86to810and92to94failure = assertSuccess
 #endif
 
 ghcGE90failure :: Result -> IO ()
@@ -134,10 +134,10 @@ ghcGE90failure = assertFailure'
 ghcGE90failure = assertSuccess
 #endif
 
-ghc86to810and92failure :: Result -> IO ()
+ghc86to810and92to94failure :: Result -> IO ()
 #if __GLASGOW_HASKELL__ >= 806 && __GLASGOW_HASKELL__ <= 810 \
- || __GLASGOW_HASKELL__ == 902
-ghc86to810and92failure = assertFailure'
+ || __GLASGOW_HASKELL__ >= 902 && __GLASGOW_HASKELL__ <= 904
+ghc86to810and92to94failure = assertFailure'
 #else
-ghc86to810and92failure = assertSuccess
+ghc86to810and92to94failure = assertSuccess
 #endif

--- a/template-haskell-optics/CHANGELOG.md
+++ b/template-haskell-optics/CHANGELOG.md
@@ -1,3 +1,6 @@
+# template-haskell-optics-0.3 (2022-??-??)
+* Add support for GHC 9.4
+
 # template-haskell-optics-0.2 (2022-03-22)
 * Add support for GHC 9.0 and 9.2
 * Drop the `DataPrim` type synonym

--- a/template-haskell-optics/template-haskell-optics.cabal
+++ b/template-haskell-optics/template-haskell-optics.cabal
@@ -1,5 +1,5 @@
 name:          template-haskell-optics
-version:       0.2
+version:       0.3
 license:       BSD3
 license-file:  LICENSE
 build-type:    Simple
@@ -7,7 +7,7 @@ maintainer:    optics@well-typed.com
 author:        Andrzej Rybczak
 cabal-version: 1.18
 tested-with:   GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7
-                || ==9.0.2 || ==9.2.2, GHCJS ==8.4
+                || ==9.0.2 || ==9.2.2 || ==9.4.1, GHCJS ==8.4
 synopsis:      Optics for template-haskell types
 category:      Data, Optics, Lenses
 description:
@@ -32,7 +32,7 @@ library
   build-depends: base                   >= 4.10      && <5
                , optics-core            >= 0.4       && <0.5
                , containers             >= 0.5.10.2  && <0.7
-               , template-haskell       >= 2.12      && <2.19
+               , template-haskell       >= 2.12      && <2.20
                , th-abstraction         >= 0.4       && <0.5
 
   exposed-modules: Language.Haskell.TH.Optics


### PR DESCRIPTION
~~`template-haskell-optics` excluded for now.~~