### PR TITLE
Allow vector 0.13 series

### DIFF
--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -72,7 +72,7 @@ library
                , text                   >= 1.2       && <1.3 || >=2.0 && <2.1
                , transformers           >= 0.5       && <0.7
                , unordered-containers   >= 0.2.6     && <0.3
-               , vector                 >= 0.11      && <0.13
+               , vector                 >= 0.11      && <0.14
                , indexed-traversable-instances >=0.1 && <0.2
 
   exposed-modules: Optics.Extra


### PR DESCRIPTION
Tested using

    cabal build --constraint='vector>=0.13' -w ghc-9.2.4


The `optics-extra` package has no tests.
