### PR TITLE
Use explicit imports

### DIFF
--- a/optics/tests/Optics/Tests/Labels/TH.hs
+++ b/optics/tests/Optics/Tests/Labels/TH.hs
@@ -6,8 +6,10 @@ module Optics.Tests.Labels.TH where
 
 import Data.Ord
 import Data.Word
-import Control.Monad.Reader
-import Control.Monad.State
+import Data.Function (fix)
+import Control.Monad (replicateM)
+import Control.Monad.Reader (MonadReader (..), runReaderT, asks)
+import Control.Monad.State (MonadState (..), gets, evalStateT, modify')
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Inspection


### PR DESCRIPTION
Don't import Control.Monad combinators through mtl modules, as mtl-2.3 removed the re-exports.