### PR TITLE
PoC: Add non-empty folds

### DIFF
--- a/codegen/Subtypes.hs
+++ b/codegen/Subtypes.hs
@@ -40,6 +40,8 @@ data OpticKind
   |  A_Getter
   -- | Tag for an affine fold.
   |  An_AffineFold
+  -- | Tag for a non-empty fold.
+  |  A_NeFold
   -- | Tag for a fold.
   |  A_Fold
   -- | Tag for a reversed lens.
@@ -69,6 +71,8 @@ opticsKind = mkProper $ Map.fromListWith (<>)
     , A_Traversal        ~> A_Fold
 
     , A_Getter           ~> An_AffineFold
+    , A_Getter           ~> A_NeFold
+    , A_NeFold           ~> A_Fold
     , An_AffineFold      ~> A_Fold
     ]
   where

--- a/indexed-profunctors/indexed-profunctors.cabal
+++ b/indexed-profunctors/indexed-profunctors.cabal
@@ -59,6 +59,6 @@ library
   import:           language
   hs-source-dirs:   src
 
-  build-depends: base                   >= 4.10       && <5
+  build-depends: base                   >= 4.10       && <5, foldable1-classes-compat
 
   exposed-modules:    Data.Profunctor.Indexed

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -77,6 +77,7 @@ library
                , indexed-profunctors    >= 0.1        && <0.2
                , transformers           >= 0.5        && <0.7
                , indexed-traversable    >= 0.1        && <0.2
+               , foldable1-classes-compat
 
   exposed-modules: Optics.Core
 
@@ -97,6 +98,7 @@ library
                    Optics.IxSetter
                    Optics.IxTraversal
                    Optics.Lens
+                   Optics.NeFold
                    Optics.Prism
                    Optics.ReversedLens
                    Optics.ReversedPrism

--- a/optics-core/src/Optics/Core.hs
+++ b/optics-core/src/Optics/Core.hs
@@ -41,6 +41,7 @@ import Optics.IxLens                           as O
 import Optics.IxSetter                         as O
 import Optics.IxTraversal                      as O
 import Optics.Lens                             as O
+import Optics.NeFold                           as O
 import Optics.ReversedLens                     as O
 import Optics.Prism                            as O
 import Optics.ReversedPrism                    as O

--- a/optics-core/src/Optics/Internal/Bi.hs
+++ b/optics-core/src/Optics/Internal/Bi.hs
@@ -11,49 +11,12 @@ import Data.Void
 
 import Data.Profunctor.Indexed
 
--- | Class for (covariant) bifunctors.
-class Bifunctor p where
-  bimap  :: (a -> b) -> (c -> d) -> p i a c -> p i b d
-  first  :: (a -> b)             -> p i a c -> p i b c
-  second ::             (c -> d) -> p i a c -> p i a d
-
-instance Bifunctor Tagged where
-  bimap  _f g = Tagged #. g .# unTagged
-  first  _f   = coerce
-  second    g = Tagged #. g .# unTagged
-
--- | Class for contravariant bifunctors.
-class Bicontravariant p where
-  contrabimap  :: (b -> a) -> (d -> c) -> p i a c -> p i b d
-  contrafirst  :: (b -> a)             -> p i a c -> p i b c
-  contrasecond ::             (c -> b) -> p i a b -> p i a c
-
-instance Bicontravariant (Forget r) where
-  contrabimap  f _g (Forget k) = Forget (k . f)
-  contrafirst  f    (Forget k) = Forget (k . f)
-  contrasecond   _g (Forget k) = Forget k
-
-instance Bicontravariant (ForgetM r) where
-  contrabimap  f _g (ForgetM k) = ForgetM (k . f)
-  contrafirst  f    (ForgetM k) = ForgetM (k . f)
-  contrasecond   _g (ForgetM k) = ForgetM k
-
-instance Bicontravariant (IxForget r) where
-  contrabimap  f _g (IxForget k) = IxForget (\i -> k i . f)
-  contrafirst  f    (IxForget k) = IxForget (\i -> k i . f)
-  contrasecond   _g (IxForget k) = IxForget k
-
-instance Bicontravariant (IxForgetM r) where
-  contrabimap  f _g (IxForgetM k) = IxForgetM (\i -> k i . f)
-  contrafirst  f    (IxForgetM k) = IxForgetM (\i -> k i . f)
-  contrasecond   _g (IxForgetM k) = IxForgetM k
-
 ----------------------------------------
 
 -- | If @p@ is a 'Profunctor' and a 'Bifunctor' then its left parameter must be
 -- phantom.
 lphantom :: (Profunctor p, Bifunctor p) => p i a c -> p i b c
-lphantom = first absurd . lmap absurd
+lphantom = first_ absurd . lmap absurd
 
 -- | If @p@ is a 'Profunctor' and 'Bicontravariant' then its right parameter
 -- must be phantom.

--- a/optics-core/src/Optics/Internal/Optic/Subtyping.hs
+++ b/optics-core/src/Optics/Internal/Optic/Subtyping.hs
@@ -102,6 +102,7 @@ instance Is An_Iso             A_Prism            where implies r = r
 instance Is An_Iso             A_Review           where implies r = r
 instance Is An_Iso             A_Lens             where implies r = r
 instance Is An_Iso             A_Getter           where implies r = r
+instance Is An_Iso             A_NeFold           where implies r = r
 instance Is An_Iso             An_AffineTraversal where implies r = r
 instance Is An_Iso             An_AffineFold      where implies r = r
 instance Is An_Iso             A_Traversal        where implies r = r
@@ -111,6 +112,7 @@ instance Is An_Iso             A_Setter           where implies r = r
 instance Is A_ReversedLens     A_Review           where implies r = r
 -- A_ReversedPrism
 instance Is A_ReversedPrism    A_Getter           where implies r = r
+instance Is A_ReversedPrism    A_NeFold           where implies r = r
 instance Is A_ReversedPrism    An_AffineFold      where implies r = r
 instance Is A_ReversedPrism    A_Fold             where implies r = r
 -- A_Prism
@@ -122,14 +124,18 @@ instance Is A_Prism            A_Fold             where implies r = r
 instance Is A_Prism            A_Setter           where implies r = r
 -- A_Lens
 instance Is A_Lens             A_Getter           where implies r = r
+instance Is A_Lens             A_NeFold           where implies r = r
 instance Is A_Lens             An_AffineTraversal where implies r = r
 instance Is A_Lens             An_AffineFold      where implies r = r
 instance Is A_Lens             A_Traversal        where implies r = r
 instance Is A_Lens             A_Fold             where implies r = r
 instance Is A_Lens             A_Setter           where implies r = r
 -- A_Getter
+instance Is A_Getter           A_NeFold           where implies r = r
 instance Is A_Getter           An_AffineFold      where implies r = r
 instance Is A_Getter           A_Fold             where implies r = r
+-- A_NeFold
+instance Is A_NeFold           A_Fold             where implies r = r
 -- An_AffineTraversal
 instance Is An_AffineTraversal An_AffineFold      where implies r = r
 instance Is An_AffineTraversal A_Traversal        where implies r = r
@@ -173,6 +179,8 @@ instance k ~ A_Lens             => JoinKinds An_Iso             A_Lens          
   joinKinds r = r
 instance k ~ A_Getter           => JoinKinds An_Iso             A_Getter           k where
   joinKinds r = r
+instance k ~ A_NeFold           => JoinKinds An_Iso             A_NeFold           k where
+  joinKinds r = r
 instance k ~ An_AffineTraversal => JoinKinds An_Iso             An_AffineTraversal k where
   joinKinds r = r
 instance k ~ An_AffineFold      => JoinKinds An_Iso             An_AffineFold      k where
@@ -196,6 +204,7 @@ instance k ~ A_Review           => JoinKinds A_ReversedLens     A_Review        
   joinKinds r = r
 --                              no JoinKinds A_ReversedLens     A_Lens
 --                              no JoinKinds A_ReversedLens     A_Getter
+--                              no JoinKinds A_ReversedLens     A_NeFold
 --                              no JoinKinds A_ReversedLens     An_AffineTraversal
 --                              no JoinKinds A_ReversedLens     An_AffineFold
 --                              no JoinKinds A_ReversedLens     A_Traversal
@@ -214,6 +223,8 @@ instance k ~ An_AffineFold      => JoinKinds A_ReversedPrism    A_Prism         
 instance k ~ A_Getter           => JoinKinds A_ReversedPrism    A_Lens             k where
   joinKinds r = r
 instance k ~ A_Getter           => JoinKinds A_ReversedPrism    A_Getter           k where
+  joinKinds r = r
+instance k ~ A_NeFold           => JoinKinds A_ReversedPrism    A_NeFold           k where
   joinKinds r = r
 instance k ~ An_AffineFold      => JoinKinds A_ReversedPrism    An_AffineTraversal k where
   joinKinds r = r
@@ -240,6 +251,8 @@ instance k ~ An_AffineTraversal => JoinKinds A_Prism            A_Lens          
   joinKinds r = r
 instance k ~ An_AffineFold      => JoinKinds A_Prism            A_Getter           k where
   joinKinds r = r
+instance k ~ A_Fold             => JoinKinds A_Prism            A_NeFold           k where
+  joinKinds r = r
 instance k ~ An_AffineTraversal => JoinKinds A_Prism            An_AffineTraversal k where
   joinKinds r = r
 instance k ~ An_AffineFold      => JoinKinds A_Prism            An_AffineFold      k where
@@ -263,6 +276,7 @@ instance k ~ A_Review           => JoinKinds A_Review           A_Prism         
   joinKinds r = r
 --                              no JoinKinds A_Review           A_Lens
 --                              no JoinKinds A_Review           A_Getter
+--                              no JoinKinds A_Review           A_NeFold
 --                              no JoinKinds A_Review           An_AffineTraversal
 --                              no JoinKinds A_Review           An_AffineFold
 --                              no JoinKinds A_Review           A_Traversal
@@ -281,6 +295,8 @@ instance k ~ An_AffineTraversal => JoinKinds A_Lens             A_Prism         
   joinKinds r = r
 --                              no JoinKinds A_Lens             A_Review
 instance k ~ A_Getter           => JoinKinds A_Lens             A_Getter           k where
+  joinKinds r = r
+instance k ~ A_NeFold           => JoinKinds A_Lens             A_NeFold           k where
   joinKinds r = r
 instance k ~ An_AffineTraversal => JoinKinds A_Lens             An_AffineTraversal k where
   joinKinds r = r
@@ -306,6 +322,8 @@ instance k ~ An_AffineFold      => JoinKinds A_Getter           A_Prism         
 --                              no JoinKinds A_Getter           A_Review
 instance k ~ A_Getter           => JoinKinds A_Getter           A_Lens             k where
   joinKinds r = r
+instance k ~ A_NeFold           => JoinKinds A_Getter           A_NeFold           k where
+  joinKinds r = r
 instance k ~ An_AffineFold      => JoinKinds A_Getter           An_AffineTraversal k where
   joinKinds r = r
 instance k ~ An_AffineFold      => JoinKinds A_Getter           An_AffineFold      k where
@@ -315,6 +333,31 @@ instance k ~ A_Fold             => JoinKinds A_Getter           A_Traversal     
 instance k ~ A_Fold             => JoinKinds A_Getter           A_Fold             k where
   joinKinds r = r
 --                              no JoinKinds A_Getter           A_Setter
+
+-- A_NeFold -----
+instance k ~ A_NeFold           => JoinKinds A_NeFold           A_NeFold           k where
+  joinKinds r = r
+instance k ~ A_NeFold           => JoinKinds A_NeFold           An_Iso             k where
+  joinKinds r = r
+--                              no JoinKinds A_NeFold           A_ReversedLens
+instance k ~ A_NeFold           => JoinKinds A_NeFold           A_ReversedPrism    k where
+  joinKinds r = r
+instance k ~ A_Fold             => JoinKinds A_NeFold           A_Prism            k where
+  joinKinds r = r
+--                              no JoinKinds A_NeFold           A_Review
+instance k ~ A_NeFold           => JoinKinds A_NeFold           A_Lens             k where
+  joinKinds r = r
+instance k ~ A_NeFold           => JoinKinds A_NeFold           A_Getter           k where
+  joinKinds r = r
+instance k ~ A_Fold             => JoinKinds A_NeFold           An_AffineTraversal k where
+  joinKinds r = r
+instance k ~ A_Fold             => JoinKinds A_NeFold           An_AffineFold      k where
+  joinKinds r = r
+instance k ~ A_Fold             => JoinKinds A_NeFold           A_Traversal        k where
+  joinKinds r = r
+instance k ~ A_Fold             => JoinKinds A_NeFold           A_Fold             k where
+  joinKinds r = r
+--                              no JoinKinds A_NeFold           A_Setter
 
 -- An_AffineTraversal -----
 instance k ~ An_AffineTraversal => JoinKinds An_AffineTraversal An_AffineTraversal k where
@@ -330,6 +373,8 @@ instance k ~ An_AffineTraversal => JoinKinds An_AffineTraversal A_Prism         
 instance k ~ An_AffineTraversal => JoinKinds An_AffineTraversal A_Lens             k where
   joinKinds r = r
 instance k ~ An_AffineFold      => JoinKinds An_AffineTraversal A_Getter           k where
+  joinKinds r = r
+instance k ~ A_Fold             => JoinKinds An_AffineTraversal A_NeFold           k where
   joinKinds r = r
 instance k ~ An_AffineFold      => JoinKinds An_AffineTraversal An_AffineFold      k where
   joinKinds r = r
@@ -355,6 +400,8 @@ instance k ~ An_AffineFold      => JoinKinds An_AffineFold      A_Lens          
   joinKinds r = r
 instance k ~ An_AffineFold      => JoinKinds An_AffineFold      A_Getter           k where
   joinKinds r = r
+instance k ~ A_Fold             => JoinKinds An_AffineFold      A_NeFold           k where
+  joinKinds r = r
 instance k ~ An_AffineFold      => JoinKinds An_AffineFold      An_AffineTraversal k where
   joinKinds r = r
 instance k ~ A_Fold             => JoinKinds An_AffineFold      A_Traversal        k where
@@ -377,6 +424,8 @@ instance k ~ A_Traversal        => JoinKinds A_Traversal        A_Prism         
 instance k ~ A_Traversal        => JoinKinds A_Traversal        A_Lens             k where
   joinKinds r = r
 instance k ~ A_Fold             => JoinKinds A_Traversal        A_Getter           k where
+  joinKinds r = r
+instance k ~ A_Fold             => JoinKinds A_Traversal        A_NeFold           k where
   joinKinds r = r
 instance k ~ A_Traversal        => JoinKinds A_Traversal        An_AffineTraversal k where
   joinKinds r = r
@@ -402,6 +451,8 @@ instance k ~ A_Fold             => JoinKinds A_Fold             A_Lens          
   joinKinds r = r
 instance k ~ A_Fold             => JoinKinds A_Fold             A_Getter           k where
   joinKinds r = r
+instance k ~ A_Fold             => JoinKinds A_Fold             A_NeFold           k where
+  joinKinds r = r
 instance k ~ A_Fold             => JoinKinds A_Fold             An_AffineTraversal k where
   joinKinds r = r
 instance k ~ A_Fold             => JoinKinds A_Fold             An_AffineFold      k where
@@ -423,6 +474,7 @@ instance k ~ A_Setter           => JoinKinds A_Setter           A_Prism         
 instance k ~ A_Setter           => JoinKinds A_Setter           A_Lens             k where
   joinKinds r = r
 --                              no JoinKinds A_Setter           A_Getter
+--                              no JoinKinds A_Setter           A_NeFold
 instance k ~ A_Setter           => JoinKinds A_Setter           An_AffineTraversal k where
   joinKinds r = r
 --                              no JoinKinds A_Setter           An_AffineFold

--- a/optics-core/src/Optics/Internal/Optic/Types.hs
+++ b/optics-core/src/Optics/Internal/Optic/Types.hs
@@ -35,6 +35,8 @@ data A_ReversedPrism :: OpticKind
 data A_Getter :: OpticKind
 -- | Tag for an affine fold.
 data An_AffineFold :: OpticKind
+-- | Tag for a non-empty fold
+data A_NeFold :: OpticKind
 -- | Tag for a fold.
 data A_Fold :: OpticKind
 -- | Tag for a reversed lens.
@@ -58,5 +60,6 @@ type family Constraints (k :: OpticKind) (p :: Type -> Type -> Type -> Type) :: 
   Constraints A_Setter           p = Mapping p
   Constraints A_Getter           p = (Bicontravariant p, Cochoice p, Strong p)
   Constraints An_AffineFold      p = (Bicontravariant p, Cochoice p, Visiting p)
-  Constraints A_Fold             p = (Bicontravariant p, Cochoice p, Traversing p)
+  Constraints A_NeFold           p = Folding1 p
+  Constraints A_Fold             p = Folding p
   Constraints A_Review           p = (Bifunctor p, Choice p, Costrong p)

--- a/optics-core/src/Optics/Iso.hs
+++ b/optics-core/src/Optics/Iso.hs
@@ -345,7 +345,7 @@ involuted a = iso a a
 {-# INLINE involuted #-}
 
 -- | This class provides for symmetric bifunctors.
-class Bifunctor p => Swapped p where
+class Data.Bifunctor.Bifunctor p => Swapped p where
   -- |
   -- @
   -- 'swapped' '.' 'swapped' ≡ 'id'

--- a/optics-core/src/Optics/NeFold.hs
+++ b/optics-core/src/Optics/NeFold.hs
@@ -1,0 +1,185 @@
+-- |
+-- Module: Optics.NeFold
+-- Description: Extracts elements from a container.
+--
+-- A @'NeFold' S A@ has the ability to extract some non-zero number of elements of type @A@
+-- from a container of type @S@.  For example, 'toNonEmptyOf' can be used to obtain
+-- the contained elements as a non-empty list. Unlike a 'Optics.Traversal.Traversal',
+-- there is no way to set or update elements.
+--
+-- This can be seen as a generalisation of 'foldMap1', where the type @S@ does
+-- not need to be a type constructor with @A@ as the last parameter.
+--
+-- A close relative is the 'Optics.AffineFold.AffineFold', which is a 'Fold'
+-- that contains at most one element. 'NeFold' containst at least one element.
+--
+module Optics.NeFold (
+    -- * Formation
+    NeFold
+
+  -- * Introduction
+  , foldrMapping1
+
+  -- * Elimination
+  -- , foldOf
+  , foldMap1Of
+  , foldrMap1Of
+  -- , foldlOf'
+  , toNonEmptyOf
+
+  -- * Computation
+  --
+  -- |
+  --
+  -- @
+  -- 'foldrMap1Of' ('foldrMapping1' f) ≡ f
+  -- @ 
+
+  -- * Additional introduction forms
+  , folded1   
+  , folding1
+  , foldring
+
+  -- * Additional elimination forms
+
+  -- * Semigroup structure #monoids#
+  -- | 'NeFold' admits (at least) one semigroups structures:
+  --
+  -- * 'summingL' (or 'summingR') concatenates results from both folds.
+  --
+  -- TODO: one can concatenate 'Fold' with 'NeFold' and still get 'NeFold'.
+  , summingL
+  , summingR
+
+  -- * Subtyping
+  , A_NeFold
+  -- | <<diagrams/NeFold.png NeFold in the optics hierarchy>>
+) where
+
+
+import Control.Applicative
+import Control.Applicative.Backwards
+import Control.Monad
+import Data.Foldable
+import Data.Foldable1
+import Data.Function
+import Data.Monoid
+import Data.List.NonEmpty (NonEmpty (..))
+
+import qualified Data.List.NonEmpty as NE
+
+import Data.Profunctor.Indexed
+
+import Optics.AffineFold
+import Optics.Fold
+import Optics.Internal.Bi
+import Optics.Internal.Fold
+import Optics.Internal.Optic
+import Optics.Internal.Utils
+
+-- | Type synonym for a non-empty fold.
+type NeFold s a = Optic' A_NeFold NoIx s a
+
+-- | Fold via embedding into a semigroup.
+foldMap1Of :: (Is k A_NeFold, Semigroup m) => Optic' k is s a -> (a -> m) -> s -> m
+foldMap1Of o = runForget #. getOptic (castOptic @A_NeFold o) .# Forget
+{-# INLINE foldMap1Of #-}
+
+-- | Fold right-associatively.
+foldrMap1Of :: Is k A_NeFold => Optic' k is s a -> (a -> r) -> (a -> r -> r)  -> s -> r
+foldrMap1Of o = \one arr s ->
+    let h a Nothing = one a
+        h a (Just b) = arr a b
+
+    in appFromMaybe (foldMap1Of o (FromMaybe #. h) s) Nothing
+
+{-# INLINE foldrMap1Of #-}
+
+-- | Used for foldrMap1 and foldlMap1 definitions
+newtype FromMaybe b = FromMaybe { appFromMaybe :: Maybe b -> b }
+
+instance Semigroup (FromMaybe b) where
+    FromMaybe f <> FromMaybe g = FromMaybe (f . Just . g)
+
+{-
+-- | Used for default toNonEmpty implementation.
+newtype NonEmptyDList a = NEDL { unNEDL :: [a] -> NonEmpty a }
+
+instance Semigroup (NonEmptyDList a) where
+  xs <> ys = NEDL (unNEDL xs . NE.toList . unNEDL ys)
+  {-# INLINE (<>) #-}
+
+-- | Create dlist with a single element
+singleton :: a -> NonEmptyDList a
+singleton = NEDL #. (:|)
+
+-- | Convert a dlist to a non-empty list
+runNonEmptyDList :: NonEmptyDList a -> NonEmpty a
+runNonEmptyDList = ($ []) . unNEDL
+{-# INLINE runNonEmptyDList #-}
+-}
+
+-- | Fold to a non-empty list.
+--
+-- >>> toNonEmptyOf (_1 % folded1) ('h' :| ['i'], "bye")
+-- 'h' :| "i"
+toNonEmptyOf :: Is k A_NeFold => Optic' k is s a -> s -> NonEmpty a
+toNonEmptyOf o = foldrMap1Of o (\a -> a :| []) NE.cons
+{-# INLINE toNonEmptyOf #-}
+
+----------------------------------------
+
+-- | Fold via the 'Foldable1' class.
+folded1 :: Foldable1 f => NeFold (f a) a
+folded1 = Optic folded1__
+{-# INLINE folded1 #-}
+
+-- | Obtain a 'NeFold' by lifting an operation that returns a 'Foldable1' result.
+--
+-- >>> toListOf (folding tail) [1,2,3,4]
+-- [2,3,4]
+folding1 :: Foldable1 f => (s -> f a) -> NeFold s a
+folding1 f = Optic (contrabimap f f . folded1__)
+{-# INLINE folding1 #-}
+
+-- | Obtain a 'NeFold' by lifting 'foldrMap1' like function.
+--
+-- >>> toListOf (foldring foldr) [1,2,3,4]
+-- [1,2,3,4]
+foldrMapping1
+  :: (forall b. (a -> b) -> (a -> b -> b) ->  s -> b)
+  -> NeFold s a
+foldrMapping1 fr = Optic (foldrMapping1__ fr)
+{-# INLINE foldrMapping1 #-}
+
+-- | Return entries of the first 'NeFold', then the second one.
+--
+-- >>> toNonEmptyOf (_1 % folded `summingL` _2 % folded1) ([1,2], 4 :| [7,1])
+-- 1 :| [2,4,7,1]
+--
+summingL
+  :: (Is k A_Fold, Is l A_NeFold)
+  => Optic' k is s a
+  -> Optic' l js s a
+  -> NeFold s a
+summingL a b = foldrMapping1 $ \f g s -> foldrOf a g (foldrMap1Of b f g s) s
+infixr 6 `summingL` -- Same as (<>)
+{-# INLINE summingL #-}
+
+-- | Return entries of the first 'NeFold', then the second one.
+-- 
+-- Use 'summingL' if you can.
+--
+-- >>> toNonEmptyOf (_1 % folded1 `summingR` _2 % folded2) (0 :| [1,2], 4 :| [7,1])
+-- 0 :| [1,2,4,7,1]
+--
+summingR
+  :: (Is k A_NeFold, Is l A_Fold)
+  => Optic' k is s a
+  -> Optic' l js s a
+  -> NeFold s a
+summingR a b = foldrMapping1 $ \f g s ->
+    let tmp = foldrOf b (\x acc -> Just $ maybe (f x) (g x) acc) Nothing s
+    in foldrMap1Of a (\x -> maybe (f x) (g x) tmp) g s 
+infixr 6 `summingR` -- Same as (<>)
+{-# INLINE summingR #-}

--- a/optics-core/src/Optics/Re.hs
+++ b/optics-core/src/Optics/Re.hs
@@ -125,17 +125,17 @@ instance Profunctor p => Profunctor (Re p s t) where
   ixcontramap = error "ixcontramap(Re) shouldn't be reachable"
 
 instance Bicontravariant p => Bifunctor (Re p s t) where
-  bimap  f g (Re p) = Re (p . contrabimap g f)
-  first  f   (Re p) = Re (p . contrasecond f)
-  second   g (Re p) = Re (p . contrafirst g)
-  {-# INLINE bimap #-}
-  {-# INLINE first #-}
-  {-# INLINE second #-}
+  bimap_  f g (Re p) = Re (p . contrabimap g f)
+  first_  f   (Re p) = Re (p . contrasecond f)
+  second_   g (Re p) = Re (p . contrafirst g)
+  {-# INLINE bimap_ #-}
+  {-# INLINE first_ #-}
+  {-# INLINE second_ #-}
 
 instance Bifunctor p => Bicontravariant (Re p s t) where
-  contrabimap  f g (Re p) = Re (p . bimap g f)
-  contrafirst  f   (Re p) = Re (p . second f)
-  contrasecond   g (Re p) = Re (p . first g)
+  contrabimap  f g (Re p) = Re (p . bimap_ g f)
+  contrafirst  f   (Re p) = Re (p . second_ f)
+  contrasecond   g (Re p) = Re (p . first_ g)
   {-# INLINE contrabimap #-}
   {-# INLINE contrafirst #-}
   {-# INLINE contrasecond #-}


### PR DESCRIPTION
As `Foldable1` is in base-4.18 and there is a light compatibility package, we can do this somewhat easily.

This breaks symmetry of hierarchy,as there is no NeTraversal, but it's much less useful than non-empty folds (i.e. to semigroups).

This (softly) needs a `Foldable1WithIndex` to be added to `indexed-traversable`, which I'll do some time in the future (after GHC-9.6 updates are settled).