### PR TITLE
Remove note about missing documentation for reexported modules

### DIFF
--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -19,10 +19,6 @@ description:
   This is the "batteries-included" variant with many dependencies; see the
   @<https://hackage.haskell.org/package/optics-core optics-core>@ package and
   other @optics-*@ dependencies if you need a more limited dependency footprint.
-  .
-  Note: Hackage does not yet display documentation for reexported-modules,
-  but you can start from the "Optics" module documentation or see the module
-  list in @<https://hackage.haskell.org/package/optics-core optics-core>@.
 
 extra-doc-files:
   diagrams/*.png


### PR DESCRIPTION
_As far as I can tell_, this is no longer relevant: Hackage now has documentation for every module.

Although I can't actually find anything recent in the Cabal/Haddock/Hackage trackers/histories indicating when this was fixed.