### PR TITLE
Reexport `Optics.Core.Extras` from `optics` package

### DIFF
--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -108,6 +108,7 @@ library
                     , Optics.At
                     , Optics.Coerce
                     , Optics.Cons
+                    , Optics.Core.Extras
                     , Optics.Each
                     , Optics.Empty
                     , Optics.Generic


### PR DESCRIPTION
Fixes #513.

In the same spirit as #410, this PR does **not** reexport `is` from the `Optics` module. I thought reexporting the `Optics.Core.Extras` module as `Optics.Extras` fit the style of the rest of the modules in the `optics` package better, however I am not opposed to reexporting as `Optics.Core.Extras` either.