### PR TITLE
Use cabal-docspec

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250710
+# version: 0.19.20250722
 #
-# REGENDATA ("0.19.20250710",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.19.20250722",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -172,11 +172,6 @@ jobs:
       - name: update cabal index
         run: |
           $CABAL v2-update -v
-      - name: cache (tools)
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-55831830
-          path: ~/.haskell-ci-tools
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
@@ -186,16 +181,15 @@ jobs:
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
-      - name: install doctest
+      - name: install cabal-docspec
         run: |
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then $CABAL --store-dir=$HOME/.haskell-ci-tools/store v2-install $ARG_COMPILER --ignore-project -j2 doctest --constraint='doctest ^>=0.22.0' ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest --version ; fi
-      - name: save cache (tools)
-        if: always()
-        uses: actions/cache/save@v4
-        with:
-          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-55831830
-          path: ~/.haskell-ci-tools
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20250606/cabal-docspec-0.0.0.20250606-x86_64-linux.xz > cabal-docspec.xz
+          echo 'cc20bb5c19501b42bde77556bc419c7c0a5c8d1eb65663024d8a4e4c868bef25  cabal-docspec.xz' | sha256sum -c -
+          xz -d < cabal-docspec.xz > $HOME/.cabal/bin/cabal-docspec
+          rm -f cabal-docspec.xz
+          chmod a+x $HOME/.cabal/bin/cabal-docspec
+          cabal-docspec --version
       - name: checkout
         uses: actions/checkout@v4
         with:
@@ -335,24 +329,10 @@ jobs:
       - name: tests
         run: |
           if [ $((! GHCJSARITH)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
-      - name: doctest
+      - name: docspec
         run: |
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_optics} || false ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_optics_core} || false ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_optics_extra} || false ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_optics_sop} || false ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_optics_th} || false ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_optics_vl} || false ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_indexed_profunctors} || false ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 -XBangPatterns -XConstraintKinds -XDefaultSignatures -XDeriveFoldable -XDeriveFunctor -XDeriveGeneric -XDeriveTraversable -XEmptyCase -XFlexibleContexts -XFlexibleInstances -XFunctionalDependencies -XGADTs -XGeneralizedNewtypeDeriving -XInstanceSigs -XKindSignatures -XLambdaCase -XOverloadedLabels -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XTupleSections -XTypeApplications -XTypeFamilies -XTypeOperators -XViewPatterns src ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then cd ${PKGDIR_template_haskell_optics} || false ; fi
-          if [ $((! GHCJSARITH && HCNUMVER < 90400)) -ne 0 ] ; then doctest  -XHaskell2010 src ; fi
+          if [ $((! GHCJSARITH && (HCNUMVER < 90400 || HCNUMVER >= 90800))) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all ; fi
+          if [ $((! GHCJSARITH && (HCNUMVER < 90400 || HCNUMVER >= 90800))) -ne 0 ] ; then cabal-docspec $ARG_COMPILER ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_optics} || false

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,9 +1,10 @@
 distribution:   focal
 branches:       master
-doctest:        <9.3
+-- GHC-9.4 and 9.6 have some issue with overlapping instances for optic labels
+docspec:        <9.4 || >=9.8
 tests:          True
 benchmarks:     <9.5
 jobs-selection: any
 
 -- turn head hackage off
-head-hackage: <0
+head-hackage: False

--- a/optics-core/optics-core.cabal
+++ b/optics-core/optics-core.cabal
@@ -156,3 +156,5 @@ library
                    Optics.Internal.Setter
                    Optics.Internal.Traversal
                    Optics.Internal.Utils
+
+  x-docspec-options: -XTypeApplications -XTypeOperators -XFlexibleContexts -XStandaloneDeriving -XDeriveGeneric -XDataKinds -XOverloadedLabels -XTupleSections

--- a/optics-core/src/Data/IntMap/Optics.hs
+++ b/optics-core/src/Data/IntMap/Optics.hs
@@ -50,6 +50,11 @@ import Optics.IxAffineTraversal
 import Optics.IxFold
 import Optics.Optic
 
+-- $setup
+-- >>> import qualified Data.IntMap as IntMap
+-- >>> import Data.Monoid (Sum (..))
+-- >>> import Optics.Core
+
 -- | Construct a map from an 'IxFold'.
 --
 -- The construction is left-biased (see 'IntMap.union'), i.e. the first occurrences of
@@ -132,7 +137,3 @@ ge k = iatraversalVL $ \point f s ->
     Nothing      -> point s
     Just (k', v) -> f k' v <&> \v' -> IntMap.insert k' v' s
 {-# INLINE ge #-}
-
--- $setup
--- >>> import Data.Monoid
--- >>> import Optics.Core

--- a/optics-core/src/Data/IntSet/Optics.hs
+++ b/optics-core/src/Data/IntSet/Optics.hs
@@ -17,6 +17,10 @@ import Optics.Fold
 import Optics.Optic
 import Optics.Setter
 
+-- $setup
+-- >>> import qualified Data.IntSet as IntSet
+-- >>> import Optics.Core
+
 -- | IntSet isn't Foldable, but this 'Fold' can be used to access the members of
 -- an 'IntSet'.
 --
@@ -49,6 +53,3 @@ setmapped = sets IntSet.map
 setOf :: Is k A_Fold => Optic' k is s Int -> s -> IntSet
 setOf l = foldMapOf l IntSet.singleton
 {-# INLINE setOf #-}
-
--- $setup
--- >>> import Optics.Core

--- a/optics-core/src/Data/Map/Optics.hs
+++ b/optics-core/src/Data/Map/Optics.hs
@@ -57,6 +57,11 @@ import Optics.IxAffineTraversal
 import Optics.IxFold
 import Optics.Optic
 
+-- $setup
+-- >>> import qualified Data.Map as Map
+-- >>> import Data.Monoid (Sum (..))
+-- >>> import Optics.Core
+
 -- | Construct a map from an 'IxFold'.
 --
 -- The construction is left-biased (see 'Map.union'), i.e. the first
@@ -139,7 +144,3 @@ ge k = iatraversalVL $ \point f s ->
     Nothing      -> point s
     Just (k', v) -> f k' v <&> \v' -> Map.insert k' v' s
 {-# INLINE ge #-}
-
--- $setup
--- >>> import Data.Monoid
--- >>> import Optics.Core

--- a/optics-core/src/Data/Sequence/Optics.hs
+++ b/optics-core/src/Data/Sequence/Optics.hs
@@ -20,6 +20,11 @@ import Optics.IxTraversal
 import Optics.Optic
 import Optics.Traversal
 
+-- $setup
+-- >>> import Data.Sequence (ViewL (..), ViewR (..))
+-- >>> import qualified Data.Sequence as Seq
+-- >>> import Optics.Core
+
 -- * Sequence isomorphisms
 
 -- | A 'Seq' is isomorphic to a 'ViewL'
@@ -136,6 +141,3 @@ sliced i j = conjoined noix ix
 seqOf :: Is k A_Fold => Optic' k is s a -> s -> Seq a
 seqOf l = foldMapOf l Seq.singleton
 {-# INLINE seqOf #-}
-
--- $setup
--- >>> import Optics.Core

--- a/optics-core/src/Data/Set/Optics.hs
+++ b/optics-core/src/Data/Set/Optics.hs
@@ -16,6 +16,10 @@ import Optics.Fold
 import Optics.Optic
 import Optics.Setter
 
+-- $setup
+-- >>> import qualified Data.Set as Set
+-- >>> import Optics.Core
+
 -- | This 'Setter' can be used to change the type of a 'Set' by mapping the
 -- elements to new values.
 --
@@ -39,6 +43,3 @@ setmapped = sets Set.map
 setOf :: (Is k A_Fold, Ord a) => Optic' k is s a -> s -> Set a
 setOf l = foldMapOf l Set.singleton
 {-# INLINE setOf #-}
-
--- $setup
--- >>> import Optics.Core

--- a/optics-core/src/Data/Tree/Optics.hs
+++ b/optics-core/src/Data/Tree/Optics.hs
@@ -13,6 +13,10 @@ import Data.Tree (Tree (..))
 
 import Optics.Lens
 
+-- $setup
+-- >>> import Data.Tree (Tree (..))
+-- >>> import Optics.Core
+
 -- | A 'Lens' that focuses on the root of a 'Tree'.
 --
 -- >>> view root $ Node 42 []
@@ -27,6 +31,3 @@ root = lensVL $ \f (Node a as) -> (`Node` as) <$> f a
 branches :: Lens' (Tree a) [Tree a]
 branches = lensVL $ \f (Node a as) -> Node a <$> f as
 {-# INLINE branches #-}
-
--- $setup
--- >>> import Optics.Core

--- a/optics-core/src/Optics/AffineFold.hs
+++ b/optics-core/src/Optics/AffineFold.hs
@@ -60,6 +60,10 @@ import Data.Profunctor.Indexed
 import Optics.Internal.Bi
 import Optics.Internal.Optic
 
+-- $setup
+-- >>> import Data.Maybe (listToMaybe)
+-- >>> import Optics.Core
+
 -- | Type synonym for an affine fold.
 type AffineFold s a = Optic' An_AffineFold NoIx s a
 
@@ -152,6 +156,3 @@ infixl 3 `afailing` -- Same as (<|>)
 isn't :: Is k An_AffineFold => Optic' k is s a -> s -> Bool
 isn't k s = isNothing (preview k s)
 {-# INLINE isn't #-}
-
--- $setup
--- >>> import Optics.Core

--- a/optics-core/src/Optics/AffineTraversal.hs
+++ b/optics-core/src/Optics/AffineTraversal.hs
@@ -64,6 +64,9 @@ import Data.Profunctor.Indexed
 
 import Optics.Internal.Optic
 
+-- $setup
+-- >>> import Optics.Core
+
 -- | Type synonym for a type-modifying affine traversal.
 type AffineTraversal s t a b = Optic An_AffineTraversal NoIx s t a b
 
@@ -186,6 +189,3 @@ matching o = withAffineTraversal o $ \match _ -> match
 unsafeFiltered :: (a -> Bool) -> AffineTraversal' a a
 unsafeFiltered p = atraversalVL (\point f a -> if p a then f a else point a)
 {-# INLINE unsafeFiltered #-}
-
--- $setup
--- >>> import Optics.Core

--- a/optics-core/src/Optics/At/Core.hs
+++ b/optics-core/src/Optics/At/Core.hs
@@ -69,6 +69,11 @@ import Optics.Lens
 import Optics.Optic
 import Optics.Setter
 
+-- $setup
+-- >>> import Optics.Core
+-- >>> import qualified Data.Map as Map
+-- >>> import qualified Data.IntSet as IntSet
+
 -- | Type family that takes a key-value container type and returns the type of
 -- keys (indices) into the container, for example @'Index' ('Map' k a) ~ k@.
 -- This is shared by 'Ixed', 'At' and 'Contains'.
@@ -483,6 +488,3 @@ ixListVL k point f xs0 =
            go (a:as) i = (a:) <$> (go as $! i - 1)
        in go xs0 k
 {-# INLINE ixListVL #-}
-
--- $setup
--- >>> import Optics.Core

--- a/optics-core/src/Optics/Fold.hs
+++ b/optics-core/src/Optics/Fold.hs
@@ -106,7 +106,7 @@ import Control.Applicative
 import Control.Applicative.Backwards
 import Control.Monad
 import Data.Foldable
-import Data.Function
+import Data.Function (fix)
 import Data.Monoid
 
 import Data.Profunctor.Indexed
@@ -116,6 +116,10 @@ import Optics.Internal.Bi
 import Optics.Internal.Fold
 import Optics.Internal.Optic
 import Optics.Internal.Utils
+
+-- $setup
+-- >>> import Optics.Core
+-- >>> import Data.Function (on)
 
 -- | Type synonym for a fold.
 type Fold s a = Optic' A_Fold NoIx s a
@@ -218,7 +222,7 @@ folded = Optic folded__
 -- This can be useful to lift operations from @Data.List@ and elsewhere into a
 -- 'Fold'.
 --
--- >>> toListOf (folding tail) [1,2,3,4]
+-- >>> toListOf (folding (drop 1)) [1,2,3,4]
 -- [2,3,4]
 folding :: Foldable f => (s -> f a) -> Fold s a
 folding f = Optic (contrafirst f . foldVL__ traverse_)
@@ -707,6 +711,3 @@ paraOf o f = go
   where
     go a = f a (go <$> toListOf o a)
 {-# INLINE paraOf #-}
-
--- $setup
--- >>> import Optics.Core

--- a/optics-core/src/Optics/Generic.hs
+++ b/optics-core/src/Optics/Generic.hs
@@ -53,6 +53,11 @@ import Optics.Lens
 import Optics.Prism
 import Optics.Traversal
 
+-- $setup
+-- >>> import GHC.Generics (Generic)
+-- >>> import Optics.Core
+-- >>> newtype NoG = NoG { fromNoG :: Char }
+
 -- | Hidden type for preventing GHC from solving constraints too early.
 data Void0
 
@@ -385,7 +390,3 @@ instance GPlate a Void0 where
 instance GPlate Void0 a where
   gplate = error "unreachable"
 
--- $setup
--- >>> :set -XDataKinds -XDeriveGeneric -XStandaloneDeriving -XOverloadedLabels
--- >>> import Optics.Core
--- >>> newtype NoG = NoG { fromNoG :: Char }

--- a/optics-extra/src/Data/ByteString/Lazy/Optics.hs
+++ b/optics-extra/src/Data/ByteString/Lazy/Optics.hs
@@ -15,6 +15,12 @@ import Data.Word (Word8)
 import Optics.Core
 import Optics.Extra.Internal.ByteString
 
+-- $setup
+-- >>> import Numeric
+-- >>> import qualified Data.ByteString.Lazy.Char8 as Char8
+-- >>> import Optics.Each
+-- >>> import Optics.Core
+
 -- | 'Data.ByteString.Lazy.pack' (or 'Data.ByteString.Lazy.unpack') a list of
 -- bytes into a 'ByteString'.
 --
@@ -127,7 +133,3 @@ pattern Bytes b <- (view unpackedBytes -> b) where
 pattern Chars :: [Char] -> ByteString
 pattern Chars b <- (view unpackedChars -> b) where
   Chars b = review unpackedChars b
-
--- $setup
--- >>> import Numeric
--- >>> import Optics.Each

--- a/optics-extra/src/Data/ByteString/Strict/Optics.hs
+++ b/optics-extra/src/Data/ByteString/Strict/Optics.hs
@@ -14,6 +14,12 @@ import Data.Word (Word8)
 import Optics.Core
 import Optics.Extra.Internal.ByteString
 
+-- $setup
+-- >>> import Numeric
+-- >>> import qualified Data.ByteString.Char8 as Char8
+-- >>> import Optics.Each
+-- >>> import Optics.Core
+
 -- | 'Data.ByteString.pack' (or 'Data.ByteString.unpack') a list of bytes into a 'ByteString'
 --
 -- @
@@ -126,7 +132,3 @@ pattern Bytes b <- (view unpackedBytes -> b) where
 pattern Chars :: [Char] -> ByteString
 pattern Chars b <- (view unpackedChars -> b) where
   Chars b = review unpackedChars b
-
--- $setup
--- >>> import Numeric
--- >>> import Optics.Each

--- a/optics-extra/src/Data/HashMap/Optics.hs
+++ b/optics-extra/src/Data/HashMap/Optics.hs
@@ -53,6 +53,13 @@ import qualified Data.HashMap.Lazy as HashMap
 
 import Optics.Core
 
+-- $setup
+-- >>> import qualified Data.HashMap.Lazy as HashMap
+-- >>> import Data.Monoid
+-- >>> import Optics.At ()
+-- >>> import Optics.Indexed ()
+-- >>> import Optics.Core
+
 -- | Construct a hash map from an 'IxFold'.
 --
 -- The construction is left-biased (see 'HashMap.union'), i.e. the first
@@ -72,8 +79,3 @@ toMapOf
   => Optic' k is s a -> s -> HashMap i a
 toMapOf o = ifoldMapOf o HashMap.singleton
 {-# INLINE toMapOf #-}
-
--- $setup
--- >>> import Data.Monoid
--- >>> import Optics.At ()
--- >>> import Optics.Indexed ()

--- a/optics-extra/src/Data/HashSet/Optics.hs
+++ b/optics-extra/src/Data/HashSet/Optics.hs
@@ -18,6 +18,11 @@ import Optics.Fold
 import Optics.Optic
 import Optics.Setter
 
+-- $setup
+-- >>> import qualified Data.HashSet as HashSet
+-- >>> import Optics.Core
+
+
 -- | This 'Setter' can be used to change the type of a 'HashSet' by mapping the
 -- elements to new values.
 --
@@ -41,6 +46,3 @@ setmapped = sets HashSet.map
 setOf :: (Is k A_Fold, Eq a, Hashable a) => Optic' k is s a -> s -> HashSet a
 setOf l = foldMapOf l HashSet.singleton
 {-# INLINE setOf #-}
-
--- $setup
--- >>> import Optics.Core

--- a/optics-extra/src/Data/Text/Lazy/Optics.hs
+++ b/optics-extra/src/Data/Text/Lazy/Optics.hs
@@ -35,6 +35,8 @@ import Optics.Internal.Optic
 
 -- $setup
 -- >>> import Data.ByteString.Lazy as LBS
+-- >>> import qualified Data.Text.Lazy as Text
+-- >>> import Optics.Core
 
 -- | This isomorphism can be used to 'pack' (or 'unpack') lazy 'Text.Text'.
 --

--- a/optics-extra/src/Data/Text/Optics.hs
+++ b/optics-extra/src/Data/Text/Optics.hs
@@ -25,6 +25,10 @@ import Optics.Core
 import qualified Data.Text.Lazy.Optics as Lazy
 import qualified Data.Text.Strict.Optics as Strict
 
+-- $setup
+-- >>> import qualified Data.Text as Strict
+-- >>> import Optics.Core
+
 -- | Traversals for strict or lazy 'Text'
 class IsText t where
   -- | This isomorphism can be used to 'pack' (or 'unpack') strict or lazy

--- a/optics-extra/src/Data/Text/Strict/Optics.hs
+++ b/optics-extra/src/Data/Text/Strict/Optics.hs
@@ -34,6 +34,10 @@ import Optics.Internal.IxFold
 import Optics.Internal.IxTraversal
 import Optics.Internal.Optic
 
+-- $setup
+-- >>> import qualified Data.Text as Strict
+-- >>> import Optics.Core
+
 -- | This isomorphism can be used to 'pack' (or 'unpack') strict 'Strict.Text'.
 --
 --

--- a/optics-extra/src/Data/Vector/Generic/Optics.hs
+++ b/optics-extra/src/Data/Vector/Generic/Optics.hs
@@ -32,6 +32,7 @@ import Optics.Internal.Optic
 
 -- $setup
 -- >>> import qualified Data.Vector as Vector
+-- >>> import Optics.Core
 
 -- | @sliced i n@ provides a 'Lens' that edits the @n@ elements starting at
 -- index @i@ from a 'Lens'.

--- a/optics-extra/src/Data/Vector/Optics.hs
+++ b/optics-extra/src/Data/Vector/Optics.hs
@@ -16,6 +16,7 @@ import qualified Data.Vector.Generic.Optics as G
 
 -- $setup
 -- >>> import Data.Vector as Vector
+-- >>> import Optics.Core
 
 -- | @sliced i n@ provides a 'Lens' that edits the @n@ elements starting at
 -- index @i@ from a 'Lens'.

--- a/optics-extra/src/Optics/At.hs
+++ b/optics-extra/src/Optics/At.hs
@@ -61,6 +61,11 @@ import Data.Word (Word8)
 
 import Optics.Core
 
+-- $setup
+-- >>> import qualified Data.IntSet as IntSet
+-- >>> import qualified Data.Map as Map
+-- >>> import Optics.Core
+
 type instance Index (HashSet a) = a
 type instance Index (HashMap k a) = k
 type instance Index (Vector.Vector a) = Int
@@ -185,7 +190,3 @@ instance (Eq k, Hashable k) => At (HashSet k) where
       Nothing -> maybe m (const (HashSet.delete k m)) mv
       Just () -> HashSet.insert k m
   {-# INLINE at #-}
-
--- $setup
--- >>> import qualified Data.IntSet as IntSet
--- >>> import qualified Data.Map as Map

--- a/optics-extra/src/Optics/Empty.hs
+++ b/optics-extra/src/Optics/Empty.hs
@@ -31,6 +31,9 @@ import qualified Data.Vector.Unboxed as Unboxed
 
 import Optics.Core
 
+-- $setup
+-- >>> import Optics.Core
+
 -- Extra instances
 
 instance AsEmpty (HashMap k a) where

--- a/optics-extra/src/Optics/State.hs
+++ b/optics-extra/src/Optics/State.hs
@@ -15,9 +15,14 @@ module Optics.State
   , preuse
   ) where
 
-import Control.Monad.State
+import Control.Monad.State (MonadState, gets, modify, modify') 
 
 import Optics.Core
+
+-- $setup
+-- >>> import Control.Monad.State (execState, evalState)
+-- >>> import Data.Semigroup
+-- >>> import Optics.Core
 
 -- | Map over the target(s) of an 'Optic' in our monadic state.
 --
@@ -109,6 +114,3 @@ preuse
   -> m (Maybe a)
 preuse o = gets (preview o)
 {-# INLINE preuse #-}
-
--- $setup
--- >>> import Data.Semigroup

--- a/optics-extra/src/Optics/View.hs
+++ b/optics-extra/src/Optics/View.hs
@@ -1,12 +1,16 @@
 -- | EXPERIMENTAL
 module Optics.View where
 
-import Control.Monad.Reader.Class
-import Control.Monad.State
-import Control.Monad.Writer
-import Data.Kind
+import Control.Monad.Reader.Class (MonadReader, asks)
+import Control.Monad.State (MonadState, gets)
+import Control.Monad.Writer (MonadWriter, listen)
+import Data.Kind (Type)
 
 import Optics.Core
+
+-- $setup
+-- >>> import Control.Monad.State (evalState)
+-- >>> import Optics.Core
 
 -- | Generalized view (even more powerful than @view@ from the lens library).
 --

--- a/optics-extra/src/Optics/Zoom.hs
+++ b/optics-extra/src/Optics/Zoom.hs
@@ -34,9 +34,12 @@ import Optics.Extra.Internal.Zoom
 -- $setup
 -- >>> import Data.Monoid
 -- >>> import Control.Monad.Reader (runReader, ask)
+-- >>> import qualified Control.Monad.Trans.State.Lazy as L
+-- >>> import qualified Control.Monad.Trans.State.Strict as S
 -- >>> import Optics.State
 -- >>> import Optics.State.Operators
 -- >>> import Optics.View
+-- >>> import Optics.Core
 
 -- Chosen so that they have lower fixity than ('%=').
 infixr 2 `zoom`, `zoomMaybe`, `zoomMany`

--- a/optics-sop/src/Optics/SOP.hs
+++ b/optics-sop/src/Optics/SOP.hs
@@ -44,6 +44,9 @@ import Optics.Core
 import Generics.SOP.Optics
 import Optics.SOP.ToTuple
 
+-- $setup
+-- >>> import Optics.Core
+
 -- | Wrapped form of a simple lens, to enable partial application.
 newtype WrappedLens    s a  = WrappedLens    { unWrapLens :: Lens' s a }
 -- | Wrapped form of a prism to an 'NP', to enable partial application.

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -148,6 +148,8 @@ library
                     , Data.Vector.Optics
                     , GHC.Generics.Optics
                     , Numeric.Optics
+  
+  x-docspec-extra-packages: containers mtl
 
 test-suite optics-tests
   import:           language


### PR DESCRIPTION
I was making extensions cleanup, and that broke previous `doctest` based setup. That's just wrong. (Non-breaking) implementation changes should not break examples.

For a concrete example: having explicit import lists for external modules *is a good thing*, but GHC would report about unused imports which are there just for `doctest`.