### PR TITLE
Rename remaining traverse_-like constructors from fooVL to mkFoo

### DIFF
--- a/optics-core/CHANGELOG.md
+++ b/optics-core/CHANGELOG.md
@@ -10,6 +10,12 @@
 * **Breaking changes**:
   - Rename the `traverse_`-like `Fold` constructor `foldVL` to `mkFold`. The new
     `foldVL` now builds a `Fold` from its van Laarhoven representation `FoldVL`.
+  - Rename the remaining `traverse_`-like constructors to match: `afoldVL` to
+    `mkAffineFold` (`Optics.AffineFold`), `ifoldVL` to `mkIxFold`
+    (`Optics.IxFold`) and `iafoldVL` to `mkIxAffineFold`
+    (`Optics.IxAffineFold`). A `fooVL` function now consistently builds an optic
+    from its van Laarhoven representation `FooVL`, while `mkFoo` lifts a
+    `traverse_`-like function.
 
 # optics-core-0.4.2 (2025-02-10)
 * Rename `PathTree` data constructor to `PathNode`, to avoid pun with type

--- a/optics-core/src/Optics/AffineFold.hs
+++ b/optics-core/src/Optics/AffineFold.hs
@@ -26,7 +26,7 @@ module Optics.AffineFold
   -- @
 
   -- * Additional introduction forms
-  , afoldVL
+  , mkAffineFold
   , filtered
 
   -- * Additional elimination forms
@@ -70,16 +70,16 @@ type AffineFold s a = Optic' An_AffineFold NoIx s a
 -- | Obtain an 'AffineFold' by lifting 'traverse_' like function.
 --
 -- @
--- 'afoldVL' '.' 'atraverseOf_' ≡ 'id'
--- 'atraverseOf_' '.' 'afoldVL' ≡ 'id'
+-- 'mkAffineFold' '.' 'atraverseOf_' ≡ 'id'
+-- 'atraverseOf_' '.' 'mkAffineFold' ≡ 'id'
 -- @
 --
--- @since 0.3
-afoldVL
+-- @since 0.5
+mkAffineFold
   :: (forall f. Functor f => (forall r. r -> f r) -> (a -> f u) -> s -> f v)
   -> AffineFold s a
-afoldVL f = Optic (rphantom . visit f . rphantom)
-{-# INLINE afoldVL #-}
+mkAffineFold f = Optic (rphantom . visit f . rphantom)
+{-# INLINE mkAffineFold #-}
 
 -- | Retrieve the value targeted by an 'AffineFold'.
 --
@@ -126,7 +126,7 @@ afolding f = Optic (contrabimap (\s -> maybe (Left s) Right (f s)) Left . right'
 
 -- | Filter result(s) of a fold that don't satisfy a predicate.
 filtered :: (a -> Bool) -> AffineFold a a
-filtered p = afoldVL (\point f a -> if p a then f a else point a)
+filtered p = mkAffineFold (\point f a -> if p a then f a else point a)
 {-# INLINE filtered #-}
 
 -- | Try the first 'AffineFold'. If it returns no entry, try the second one.

--- a/optics-core/src/Optics/Internal/Fold.hs
+++ b/optics-core/src/Optics/Internal/Fold.hs
@@ -16,7 +16,7 @@ import Data.Profunctor.Indexed
 import Optics.Internal.Bi
 import Optics.Internal.Optic
 
--- | Internal implementation of 'Optics.Fold.foldVL'.
+-- | Internal implementation of 'Optics.Fold.mkFold'.
 foldVL__
   :: (Bicontravariant p, Traversing p)
   => (forall f. Applicative f => (a -> f u) -> s -> f v)

--- a/optics-core/src/Optics/Internal/IxFold.hs
+++ b/optics-core/src/Optics/Internal/IxFold.hs
@@ -16,7 +16,7 @@ import Optics.Internal.Indexed.Classes
 import Optics.Internal.Optic
 import Optics.Internal.Fold
 
--- | Internal implementation of 'Optics.IxFold.ifoldVL'.
+-- | Internal implementation of 'Optics.IxFold.mkIxFold'.
 ifoldVL__
   :: (Bicontravariant p, Traversing p)
   => (forall f. Applicative f => (i -> a -> f u) -> s -> f v)

--- a/optics-core/src/Optics/IxAffineFold.hs
+++ b/optics-core/src/Optics/IxAffineFold.hs
@@ -27,7 +27,7 @@ module Optics.IxAffineFold
   -- @
 
   -- * Additional introduction forms
-  , iafoldVL
+  , mkIxAffineFold
 
   -- * Additional elimination forms
   , iatraverseOf_
@@ -68,16 +68,16 @@ type IxAffineFold i s a = Optic' An_AffineFold (WithIx i) s a
 -- | Obtain an 'IxAffineFold' by lifting 'itraverse_' like function.
 --
 -- @
--- 'iafoldVL' '.' 'iatraverseOf_' ≡ 'id'
--- 'iatraverseOf_' '.' 'iafoldVL' ≡ 'id'
+-- 'mkIxAffineFold' '.' 'iatraverseOf_' ≡ 'id'
+-- 'iatraverseOf_' '.' 'mkIxAffineFold' ≡ 'id'
 -- @
 --
--- @since 0.3
-iafoldVL
+-- @since 0.5
+mkIxAffineFold
   :: (forall f. Functor f => (forall r. r -> f r) -> (i -> a -> f u) -> s -> f v)
   -> IxAffineFold i s a
-iafoldVL f = Optic (rphantom . ivisit f . rphantom)
-{-# INLINE iafoldVL #-}
+mkIxAffineFold f = Optic (rphantom . ivisit f . rphantom)
+{-# INLINE mkIxAffineFold #-}
 
 -- | Retrieve the value along with its index targeted by an 'IxAffineFold'.
 ipreview
@@ -114,7 +114,7 @@ iatraverseOf_ o point f s = case ipreview o s of
 
 -- | Create an 'IxAffineFold' from a partial function.
 iafolding :: (s -> Maybe (i, a)) -> IxAffineFold i s a
-iafolding g = iafoldVL (\point f s -> maybe (point s) (uncurry' f) $ g s)
+iafolding g = mkIxAffineFold (\point f s -> maybe (point s) (uncurry' f) $ g s)
 {-# INLINE iafolding #-}
 
 -- | Obtain a potentially empty 'IxAffineFold' by taking the element from
@@ -122,7 +122,7 @@ iafolding g = iafoldVL (\point f s -> maybe (point s) (uncurry' f) $ g s)
 --
 -- @since 0.3
 filteredBy :: Is k An_AffineFold  => Optic' k is a i -> IxAffineFold i a a
-filteredBy p = iafoldVL $ \point f s -> case preview p s of
+filteredBy p = mkIxAffineFold $ \point f s -> case preview p s of
   Just i  -> f i s
   Nothing -> point s
 {-# INLINE filteredBy #-}

--- a/optics-core/src/Optics/IxFold.hs
+++ b/optics-core/src/Optics/IxFold.hs
@@ -12,7 +12,7 @@ module Optics.IxFold
     IxFold
 
   -- * Introduction
-  , ifoldVL
+  , mkIxFold
 
   -- * Elimination
   , ifoldMapOf
@@ -91,14 +91,16 @@ type IxFold i s a = Optic' A_Fold (WithIx i) s a
 -- | Obtain an indexed fold by lifting 'itraverse_' like function.
 --
 -- @
--- 'ifoldVL' '.' 'itraverseOf_' ≡ 'id'
--- 'itraverseOf_' '.' 'ifoldVL' ≡ 'id'
+-- 'mkIxFold' '.' 'itraverseOf_' ≡ 'id'
+-- 'itraverseOf_' '.' 'mkIxFold' ≡ 'id'
 -- @
-ifoldVL
+--
+-- @since 0.5
+mkIxFold
   :: (forall f. Applicative f => (i -> a -> f u) -> s -> f v)
   -> IxFold i s a
-ifoldVL f = Optic (ifoldVL__ f)
-{-# INLINE ifoldVL #-}
+mkIxFold f = Optic (ifoldVL__ f)
+{-# INLINE mkIxFold #-}
 
 -- | Fold with index via embedding into a monoid.
 ifoldMapOf
@@ -217,7 +219,7 @@ ifiltered
   => (i -> a -> Bool)
   -> Optic' k is s a
   -> IxFold i s a
-ifiltered p o = ifoldVL $ \f ->
+ifiltered p o = mkIxFold $ \f ->
   itraverseOf_ o (\i a -> if p i a then f i a else pure ())
 {-# INLINE ifiltered #-}
 -- Note: technically this should be defined per optic kind:
@@ -234,7 +236,7 @@ ibackwards_
   :: (Is k A_Fold, is `HasSingleIndex` i)
   => Optic' k is s a
   -> IxFold i s a
-ibackwards_ o = conjoined (backwards_ o) $ ifoldVL $ \f ->
+ibackwards_ o = conjoined (backwards_ o) $ mkIxFold $ \f ->
   forwards #. itraverseOf_ o (\i -> Backwards #. f i)
 {-# INLINE ibackwards_ #-}
 
@@ -250,7 +252,7 @@ isumming
   => Optic' k is1 s a
   -> Optic' l is2 s a
   -> IxFold i s a
-isumming a b = conjoined (summing a b) $ ifoldVL $ \f s ->
+isumming a b = conjoined (summing a b) $ mkIxFold $ \f s ->
   itraverseOf_ a f s *> itraverseOf_ b f s
 infixr 6 `isumming` -- Same as (<>)
 {-# INLINE isumming #-}
@@ -267,7 +269,7 @@ ifailing
   => Optic' k is1 s a
   -> Optic' l is2 s a
   -> IxFold i s a
-ifailing a b = conjoined (failing a b) $ ifoldVL $ \f s ->
+ifailing a b = conjoined (failing a b) $ mkIxFold $ \f s ->
   let OrT visited fu = itraverseOf_ a (\i -> wrapOrT . f i) s
   in if visited
      then fu

--- a/optics/CHANGELOG.md
+++ b/optics/CHANGELOG.md
@@ -10,6 +10,12 @@
 * **Breaking changes**:
   - Rename the `traverse_`-like `Fold` constructor `foldVL` to `mkFold`. The new
     `foldVL` now builds a `Fold` from its van Laarhoven representation `FoldVL`.
+  - Rename the remaining `traverse_`-like constructors to match: `afoldVL` to
+    `mkAffineFold` (`Optics.AffineFold`), `ifoldVL` to `mkIxFold`
+    (`Optics.IxFold`) and `iafoldVL` to `mkIxAffineFold`
+    (`Optics.IxAffineFold`). A `fooVL` function now consistently builds an optic
+    from its van Laarhoven representation `FooVL`, while `mkFoo` lifts a
+    `traverse_`-like function.
 
 # optics-0.4.2.1 (2023-06-22)
 * Fix compilation of tests with GHC 9.4 and 9.6


### PR DESCRIPTION
Since #430 renamed foldVL to mkFold, the naming has become inconsistent. This bridges the gap.