### PR TITLE
Restrict strict modifications to traversals

### DIFF
--- a/optics-core/CHANGELOG.md
+++ b/optics-core/CHANGELOG.md
@@ -7,6 +7,14 @@
   `Optics.IxFold`.
 * Mention the resulting optic kind in the error message about optics that cannot
   be composed.
+* Fix `failover'` and `ifailover'` being lazier than expected: they wrapped the
+  result of the strict traversal in `Just` without forcing it, so the new values
+  were not forced until the contents of the `Just` were demanded, unlike with
+  `over'` and `iover'`.
+* Fix `(?!~)` being stricter than expected: it forced the new value eagerly,
+  even if the traversal had no targets, unlike `(!~)` and the other strict
+  modifications. Now the value is forced if and only if the traversal has at
+  least one target.
 * **Breaking changes**:
   - Rename the `traverse_`-like `Fold` constructor `foldVL` to `mkFold`. The new
     `foldVL` now builds a `Fold` from its van Laarhoven representation `FoldVL`.
@@ -16,6 +24,12 @@
     (`Optics.IxAffineFold`). A `fooVL` function now consistently builds an optic
     from its van Laarhoven representation `FooVL`, while `mkFoo` lifts a
     `traverse_`-like function.
+  - Restrict `over'`, `set'`, `iover'`, `iset'` and the associated operators
+    `(%!~)`, `(!~)` and `(?!~)` to require traversals rather than just setters.
+    Setters are not capable of actually making strict modifications, so these
+    operations were just silently lazier than expected when passed setters.
+  - Move `over'` and `set'` from `Optics.Setter` to `Optics.Traversal`, and
+    `iover'` and `iset'` from `Optics.IxSetter` to `Optics.IxTraversal`.
 
 # optics-core-0.4.2 (2025-02-10)
 * Rename `PathTree` data constructor to `PathNode`, to avoid pun with type

--- a/optics-core/src/Optics/Internal/Utils.hs
+++ b/optics-core/src/Optics/Internal/Utils.hs
@@ -3,9 +3,9 @@
 -- | This module is intended for internal use only, and may change without warning
 -- in subsequent releases.
 module Optics.Internal.Utils
-  ( Identity'(..)
-  , wrapIdentity'
-  , unwrapIdentity'
+  ( Box
+  , wrapBox
+  , unwrapBox
 
   , Traversed(..)
   , runTraversed
@@ -22,39 +22,38 @@ import qualified Data.Semigroup as SG
 
 import Data.Profunctor.Indexed
 
--- Needed for strict application of (indexed) setters.
+-- Needed for strict application of (indexed) traversals.
 --
 -- Credit for this goes to Eric Mertens, see
 -- <https://github.com/glguy/irc-core/commit/2d5fc45b05f1>.
-data Identity' a = Identity' {-# UNPACK #-} !() a
+--
+-- Both the data type and the laziness of its field are necessary:
+--
+-- - It must not be a newtype, as then matching on the constructor in '<*>' and
+--   'unwrapBox' would no longer force the value put in by 'wrapBox'.
+--
+-- - The field must stay lazy, with only 'wrapBox' forcing what it puts in it.
+--   A strict field would make 'pure' and 'fmap' force the reconstructed
+--   structure as well, not only the new values.
+data Box a = Box a
   deriving Functor
 
-instance Applicative Identity' where
-  pure a = Identity' () a
-  Identity' () f <*> Identity' () x = Identity' () (f x)
+instance Applicative Box where
+  pure = Box
+  Box f <*> Box x = Box (f x)
 
-instance Mapping (Star Identity') where
-  roam  f (Star k) = Star $ wrapIdentity' . f (unwrapIdentity' . k)
-  iroam f (Star k) = Star $ wrapIdentity' . f (\_ -> unwrapIdentity' . k)
-
-instance Mapping (IxStar Identity') where
-  roam  f (IxStar k) =
-    IxStar $ \i -> wrapIdentity' . f (unwrapIdentity' . k i)
-  iroam f (IxStar k) =
-    IxStar $ \ij -> wrapIdentity' . f (\i -> unwrapIdentity' . k (ij i))
-
--- | Mark a value for evaluation to whnf.
+-- | Mark a value for evaluation to WHNF.
 --
--- This allows us to, when applying a setter to a structure, evaluate only the
--- parts that we modify. If an optic focuses on multiple targets, Applicative
--- instance of Identity' makes sure that we force evaluation of all of them, but
--- we leave anything else alone.
+-- This allows us to, when applying a traversal to a structure, evaluate only
+-- the parts that we modify. If an optic focuses on multiple targets,
+-- Applicative instance of Box makes sure that we force evaluation of all of
+-- them, but we leave anything else alone.
 --
-wrapIdentity' :: a -> Identity' a
-wrapIdentity' a = Identity' (a `seq` ()) a
+wrapBox :: a -> Box a
+wrapBox a = Box $! a
 
-unwrapIdentity' :: Identity' a -> a
-unwrapIdentity' (Identity' () a) = a
+unwrapBox :: Box a -> a
+unwrapBox (Box a) = a
 
 ----------------------------------------
 

--- a/optics-core/src/Optics/IxSetter.hs
+++ b/optics-core/src/Optics/IxSetter.hs
@@ -47,8 +47,6 @@ module Optics.IxSetter
 
   -- * Additional elimination forms
   , iset
-  , iset'
-  , iover'
 
   -- * Subtyping
   , A_Setter
@@ -63,7 +61,6 @@ import Optics.Internal.Indexed
 import Optics.Internal.Indexed.Classes
 import Optics.Internal.IxSetter
 import Optics.Internal.Optic
-import Optics.Internal.Utils
 
 -- | Type synonym for a type-modifying indexed setter.
 type IxSetter i s t a b = Optic A_Setter (WithIx i) s t a b
@@ -72,6 +69,8 @@ type IxSetter i s t a b = Optic A_Setter (WithIx i) s t a b
 type IxSetter' i s a = Optic' A_Setter (WithIx i) s a
 
 -- | Apply an indexed setter as a modifier.
+--
+-- /Note:/ for a strict variant see 'Optics.IxTraversal.iover''.
 iover
   :: (Is k A_Setter, is `HasSingleIndex` i)
   => Optic k is s t a b
@@ -79,22 +78,13 @@ iover
 iover o = \f -> runIxFunArrow (getOptic (castOptic @A_Setter o) (IxFunArrow f)) id
 {-# INLINE iover #-}
 
--- | Apply an indexed setter as a modifier, strictly.
-iover'
-  :: (Is k A_Setter, is `HasSingleIndex` i)
-  => Optic k is s t a b
-  -> (i -> a -> b) -> s -> t
-iover' o = \f ->
-  let star = getOptic (castOptic @A_Setter o) $ IxStar (\i -> wrapIdentity' . f i)
-  in unwrapIdentity' . runIxStar star id
-
-{-# INLINE iover' #-}
-
 -- | Apply an indexed setter.
 --
 -- @
 -- 'iset' o f ≡ 'iover' o (\i _ -> f i)
 -- @
+--
+-- /Note:/ for a strict variant see 'Optics.IxTraversal.iset''.
 --
 iset
   :: (Is k A_Setter, is `HasSingleIndex` i)
@@ -102,14 +92,6 @@ iset
   -> (i -> b) -> s -> t
 iset o = \f -> iover o (\i _ -> f i)
 {-# INLINE iset #-}
-
--- | Apply an indexed setter, strictly.
-iset'
-  :: (Is k A_Setter, is `HasSingleIndex` i)
-  => Optic k is s t a b
-  -> (i -> b) -> s -> t
-iset' o = \f -> iover' o (\i _ -> f i)
-{-# INLINE iset' #-}
 
 -- | Build an indexed setter from a function to modify the element(s).
 isets

--- a/optics-core/src/Optics/IxTraversal.hs
+++ b/optics-core/src/Optics/IxTraversal.hs
@@ -51,7 +51,10 @@ module Optics.IxTraversal
   , iscanl1Of
   , iscanr1Of
   , ifailover
+  -- ** Strict variants
   , ifailover'
+  , iover'
+  , iset'
 
   -- * Combinators
   , indices
@@ -216,6 +219,8 @@ iscanr1Of o f = fst . imapAccumROf o step Nothing
 
 -- | Try to map a function which uses the index over this 'IxTraversal',
 -- returning 'Nothing' if the 'IxTraversal' has no targets.
+--
+-- /Note:/ for a strict variant see 'ifailover''.
 ifailover
   :: (Is k A_Traversal, is `HasSingleIndex` i)
   => Optic k is s t a b
@@ -228,16 +233,78 @@ ifailover o = \f s ->
 {-# INLINE ifailover #-}
 
 -- | Version of 'ifailover' strict in the application of the function.
+--
+-- >>> ifailover itraversed (\_ _ -> errorWithoutStackTrace "oops") "abc" `seq` ()
+-- ()
+--
+-- >>> ifailover' itraversed (\_ _ -> errorWithoutStackTrace "oops") "abc" `seq` ()
+-- *** Exception: oops
+--
+-- Values not targeted by the traversal are not forced:
+--
+-- >>> length <$> ifailover' (itraversed % _2) (\_ _ -> 'x') [(undefined,'b')]
+-- Just 1
+--
 ifailover'
   :: (Is k A_Traversal, is `HasSingleIndex` i)
   => Optic k is s t a b
   -> (i -> a -> b) -> s -> Maybe t
 ifailover' o = \f s ->
-  let OrT visited t = itraverseOf o (\i -> wrapOrT . wrapIdentity' . f i) s
+  let OrT visited t = itraverseOf o (\i -> wrapOrT . wrapBox . f i) s
   in if visited
-     then Just (unwrapIdentity' t)
+     then Just $! unwrapBox t
      else Nothing
 {-# INLINE ifailover' #-}
+
+-- | Apply an indexed traversal as a modifier, strictly.
+--
+-- This is a strict version of 'Optics.IxSetter.iover': the new values are
+-- forced to WHNF if and only if the optic traverses at least one target. It
+-- requires an 'IxTraversal' rather than an 'Optics.IxSetter.IxSetter', because
+-- an 'Optics.IxSetter.IxSetter' provides no way to force the new values.
+--
+-- >>> length $ iover itraversed (\i _ -> errorWithoutStackTrace "oops") "abc"
+-- 3
+--
+-- >>> length $ iover' itraversed (\i _ -> errorWithoutStackTrace "oops") "abc"
+-- *** Exception: oops
+--
+-- Values not targeted by the traversal are not forced:
+--
+-- >>> length $ iover' (itraversed % _2) (\_ _ -> 'x') [(undefined,'b')]
+-- 1
+--
+iover'
+  :: (Is k A_Traversal, is `HasSingleIndex` i)
+  => Optic k is s t a b
+  -> (i -> a -> b) -> s -> t
+iover' o = \f ->
+  let star = getOptic (castOptic @A_Traversal o) $ IxStar (\i -> wrapBox . f i)
+  in unwrapBox . runIxStar star id
+{-# INLINE iover' #-}
+
+-- | Apply an indexed traversal, strictly.
+--
+-- This is a strict version of 'Optics.IxSetter.iset': the new values are forced
+-- to WHNF if and only if the optic traverses at least one target.
+--
+-- >>> length $ iset itraversed (\i -> errorWithoutStackTrace "oops") "abc"
+-- 3
+--
+-- >>> length $ iset' itraversed (\i -> errorWithoutStackTrace "oops") "abc"
+-- *** Exception: oops
+--
+-- Values not targeted by the traversal are not forced:
+--
+-- >>> length $ iset' (itraversed % _2) (\_ -> 'x') [(undefined,'b')]
+-- 1
+--
+iset'
+  :: (Is k A_Traversal, is `HasSingleIndex` i)
+  => Optic k is s t a b
+  -> (i -> b) -> s -> t
+iset' o = \f -> iover' o (\i _ -> f i)
+{-# INLINE iset' #-}
 
 ----------------------------------------
 -- Traversals

--- a/optics-core/src/Optics/Operators.hs
+++ b/optics-core/src/Optics/Operators.hs
@@ -28,6 +28,7 @@ import Optics.Getter
 import Optics.Optic
 import Optics.Review
 import Optics.Setter
+import Optics.Traversal
 
 -- | Flipped infix version of 'view'.
 (^.) :: Is k A_Getter => s -> Optic' k is s a -> a
@@ -58,6 +59,8 @@ infixl 8 ^..
 infixr 8 #
 
 -- | Infix version of 'over'.
+--
+-- /Note:/ for a strict variant see ('%!~').
 (%~) :: Is k A_Setter => Optic k is s t a b -> (a -> b) -> s -> t
 (%~) = over
 {-# INLINE (%~) #-}
@@ -65,13 +68,28 @@ infixr 8 #
 infixr 4 %~
 
 -- | Infix version of 'over''.
-(%!~) :: Is k A_Setter => Optic k is s t a b -> (a -> b) -> s -> t
+--
+-- /Note:/ for a lazy variant see ('%~').
+--
+-- >>> snd $ ('a','b') & _1 %~ errorWithoutStackTrace "oops"
+-- 'b'
+--
+-- >>> snd $ ('a','b') & _1 %!~ errorWithoutStackTrace "oops"
+-- *** Exception: oops
+--
+-- Values not targeted by the traversal are not forced:
+--
+-- >>> fst $ ('a', undefined) & _1 %!~ const 'x'
+-- 'x'
+(%!~) :: Is k A_Traversal => Optic k is s t a b -> (a -> b) -> s -> t
 (%!~) = over'
 {-# INLINE (%!~) #-}
 
 infixr 4 %!~
 
 -- | Infix version of 'set'.
+--
+-- /Note:/ for a strict variant see ('!~').
 (.~) :: Is k A_Setter => Optic k is s t a b -> b -> s -> t
 (.~) = set
 {-# INLINE (.~) #-}
@@ -79,7 +97,20 @@ infixr 4 %!~
 infixr 4 .~
 
 -- | Infix version of 'set''.
-(!~) :: Is k A_Setter => Optic k is s t a b -> b -> s -> t
+--
+-- /Note:/ for a lazy variant see ('.~').
+--
+-- >>> snd $ ('a','b') & _1 .~ errorWithoutStackTrace "oops"
+-- 'b'
+--
+-- >>> snd $ ('a','b') & _1 !~ errorWithoutStackTrace "oops"
+-- *** Exception: oops
+--
+-- Values not targeted by the traversal are not forced:
+--
+-- >>> fst $ ('a', undefined) & _1 !~ 'x'
+-- 'x'
+(!~) :: Is k A_Traversal => Optic k is s t a b -> b -> s -> t
 (!~) = set'
 {-# INLINE (!~) #-}
 
@@ -90,6 +121,8 @@ infixr 4 !~
 -- @
 -- o '?~' b ≡ 'set' o ('Just' b)
 -- @
+--
+-- /Note:/ for a strict variant see ('?!~').
 --
 -- >>> Nothing & equality ?~ 'x'
 -- Just 'x'
@@ -103,8 +136,22 @@ infixr 4 !~
 infixr 4 ?~
 
 -- | Strict version of ('?~').
-(?!~) :: Is k A_Setter => Optic k is s t a (Maybe b) -> b -> s -> t
-(?!~) = \o !b -> set' o (Just b)
+--
+-- The new value is forced to WHNF if and only if the optic traverses at
+-- least one target.
+--
+-- >>> snd $ (Nothing,'b') & _1 ?~ errorWithoutStackTrace "oops"
+-- 'b'
+--
+-- >>> snd $ (Nothing,'b') & _1 ?!~ errorWithoutStackTrace "oops"
+-- *** Exception: oops
+--
+-- Values not targeted by the traversal are not forced:
+--
+-- >>> fst $ (Nothing, undefined) & _1 ?!~ 'x'
+-- Just 'x'
+(?!~) :: Is k A_Traversal => Optic k is s t a (Maybe b) -> b -> s -> t
+(?!~) = \o b -> set' o (Just $! b)
 {-# INLINE (?!~) #-}
 
 infixr 4 ?!~

--- a/optics-core/src/Optics/Setter.hs
+++ b/optics-core/src/Optics/Setter.hs
@@ -52,8 +52,6 @@ module Optics.Setter
 
   -- * Additional elimination forms
   , set
-  , set'
-  , over'
   , rewriteOf
   , transformOf
 
@@ -66,7 +64,6 @@ import Data.Profunctor.Indexed
 
 import Optics.Internal.Optic
 import Optics.Internal.Setter
-import Optics.Internal.Utils
 
 -- | Type synonym for a type-modifying setter.
 type Setter s t a b = Optic A_Setter NoIx s t a b
@@ -75,6 +72,8 @@ type Setter s t a b = Optic A_Setter NoIx s t a b
 type Setter' s a = Optic' A_Setter NoIx s a
 
 -- | Apply a setter as a modifier.
+--
+-- /Note:/ for a strict variant see 'Optics.Traversal.over''.
 over
   :: Is k A_Setter
   => Optic k is s t a b
@@ -82,39 +81,13 @@ over
 over o = \f -> runFunArrow $ getOptic (castOptic @A_Setter o) (FunArrow f)
 {-# INLINE over #-}
 
--- | Apply a setter as a modifier, strictly.
---
--- TODO DOC: what exactly is the strictness property?
---
--- Example:
---
--- @
---  f :: Int -> (Int, a) -> (Int, a)
---  f k acc
---    | k > 0     = f (k - 1) $ 'over'' 'Data.Tuple.Optics._1' (+1) acc
---    | otherwise = acc
--- @
---
--- runs in constant space, but would result in a space leak if used with 'over'.
---
--- Note that replacing '$' with '$!' or 'Data.Tuple.Optics._1' with
--- 'Data.Tuple.Optics._1'' (which amount to the same thing) doesn't help when
--- 'over' is used, because the first coordinate of a pair is never forced.
---
-over'
-  :: Is k A_Setter
-  => Optic k is s t a b
-  -> (a -> b) -> s -> t
-over' o = \f ->
-  let star = getOptic (castOptic @A_Setter o) $ Star (wrapIdentity' . f)
-  in unwrapIdentity' . runStar star
-{-# INLINE over' #-}
-
 -- | Apply a setter.
 --
 -- @
 -- 'set' o v ≡ 'over' o ('const' v)
 -- @
+--
+-- /Note:/ for a strict variant see 'Optics.Traversal.set''.
 --
 -- >>> set _1 'x' ('y', 'z')
 -- ('x','z')
@@ -125,17 +98,6 @@ set
   -> b -> s -> t
 set o = over o . const
 {-# INLINE set #-}
-
--- | Apply a setter, strictly.
---
--- TODO DOC: what exactly is the strictness property?
---
-set'
-  :: Is k A_Setter
-  => Optic k is s t a b
-  -> b -> s -> t
-set' o = over' o . const
-{-# INLINE set' #-}
 
 -- | Build a setter from a function to modify the element(s), which must respect
 -- the well-formedness laws.

--- a/optics-core/src/Optics/Traversal.hs
+++ b/optics-core/src/Optics/Traversal.hs
@@ -61,7 +61,10 @@ module Optics.Traversal
   , rewriteMOf
   , transformMOf
   , failover
+  -- ** Strict variants
   , failover'
+  , over'
+  , set'
 
     -- * Combinators
   , backwards
@@ -286,6 +289,8 @@ transformMOf l f = go
 -- | Try to map a function over this 'Traversal', returning Nothing if the
 -- traversal has no targets.
 --
+-- /Note:/ for a strict variant see 'failover''.
+--
 -- >>> failover (element 3) (*2) [1,2]
 -- Nothing
 --
@@ -307,16 +312,97 @@ failover o = \f s ->
 {-# INLINE failover #-}
 
 -- | Version of 'failover' strict in the application of @f@.
+--
+-- >>> failover _1 (errorWithoutStackTrace "oops") ('a','b') `seq` ()
+-- ()
+--
+-- >>> failover' _1 (errorWithoutStackTrace "oops") ('a','b') `seq` ()
+-- *** Exception: oops
+--
+-- Values not targeted by the traversal are not forced:
+--
+-- >>> fmap fst $ failover' _1 (const 'x') ('a', undefined)
+-- Just 'x'
+--
 failover'
   :: Is k A_Traversal
   => Optic k is s t a b
   -> (a -> b) -> s -> Maybe t
 failover' o = \f s ->
-  let OrT visited t = traverseOf o (wrapOrT . wrapIdentity' . f) s
+  let OrT visited t = traverseOf o (wrapOrT . wrapBox . f) s
   in if visited
-     then Just (unwrapIdentity' t)
+     then Just $! unwrapBox t
      else Nothing
 {-# INLINE failover' #-}
+
+-- | Apply a traversal as a modifier, strictly.
+--
+-- This is a strict version of 'Optics.Setter.over': the new values are forced
+-- to WHNF if and only if the optic traverses at least one target. It requires a
+-- 'Traversal' rather than a 'Optics.Setter.Setter', because a
+-- 'Optics.Setter.Setter' provides no way to force the new values.
+--
+-- Example:
+--
+-- @
+--  f :: Int -> (Int, a) -> (Int, a)
+--  f k acc
+--    | k > 0     = f (k - 1) $ 'over'' 'Data.Tuple.Optics._1' (+1) acc
+--    | otherwise = acc
+-- @
+--
+-- runs in constant space, but would result in a space leak if used with
+-- 'Optics.Setter.over'.
+--
+-- Note that replacing '$' with '$!' or 'Data.Tuple.Optics._1' with
+-- 'Data.Tuple.Optics._1'' (which amount to the same thing) doesn't help when
+-- 'Optics.Setter.over' is used, because the first coordinate of a pair is
+-- never forced.
+--
+-- >>> snd $ over _1 (errorWithoutStackTrace "oops") ('a','b')
+-- 'b'
+--
+-- >>> snd $ over' _1 (errorWithoutStackTrace "oops") ('a','b')
+-- *** Exception: oops
+--
+-- Values not targeted by the traversal are not forced:
+--
+-- >>> fst $ over' _1 (const 'x') ('a', undefined)
+-- 'x'
+--
+over'
+  :: Is k A_Traversal
+  => Optic k is s t a b
+  -> (a -> b) -> s -> t
+over' o = \f ->
+  let star = getOptic (castOptic @A_Traversal o) $ Star (wrapBox . f)
+  in unwrapBox . runStar star
+{-# INLINE over' #-}
+
+-- | Apply a traversal, strictly.
+--
+-- This is a strict version of 'Optics.Setter.set': the new value is forced to
+-- WHNF if and only if the optic traverses at least one target. If forcing the
+-- new value is inexpensive, then it is cheaper to do so manually and use
+-- 'Optics.Setter.set'.
+--
+-- >>> snd $ set _1 (errorWithoutStackTrace "oops") ('a','b')
+-- 'b'
+--
+-- >>> snd $ set' _1 (errorWithoutStackTrace "oops") ('a','b')
+-- *** Exception: oops
+--
+-- Values not targeted by the traversal are not forced:
+--
+-- >>> fst $ set' _1 'x' ('a', undefined)
+-- 'x'
+--
+set'
+  :: Is k A_Traversal
+  => Optic k is s t a b
+  -> b -> s -> t
+set' o = over' o . const
+{-# INLINE set' #-}
 
 ----------------------------------------
 -- Traversals

--- a/optics-extra/CHANGELOG.md
+++ b/optics-extra/CHANGELOG.md
@@ -1,5 +1,9 @@
 # optics-extra-0.5 (2026-??-??)
 * Drop support for GHC older than 9.2.
+* **Breaking changes**:
+  - Restrict `modifying'` and `assign'` to traversals. Setters are not capable
+    of actually making strict modifications, so these operations were just
+    silently lazier than expected when passed setters.
 
 # optics-extra-0.4.2.1 (2022-05-20)
 * Fix for previous release when used with `mtl-2.3` and `transformers-0.5`.

--- a/optics-extra/src/Optics/State.hs
+++ b/optics-extra/src/Optics/State.hs
@@ -26,6 +26,8 @@ import Optics.Core
 
 -- | Map over the target(s) of an 'Optic' in our monadic state.
 --
+-- /Note:/ for a strict variant see 'modifying''.
+--
 -- >>> execState (do modifying _1 (*10); modifying _2 $ stimes 5) (6,"o")
 -- (60,"ooooo")
 --
@@ -47,8 +49,13 @@ modifying o = modify . over o
 --
 -- >>> flip evalState ('a','b') $ modifying' _1 (errorWithoutStackTrace "oops")
 -- *** Exception: oops
+--
+-- Values not targeted by the traversal are not forced:
+--
+-- >>> fst $ execState (modifying' _1 (const 'x')) ('a', undefined)
+-- 'x'
 modifying'
-  :: (Is k A_Setter, MonadState s m)
+  :: (Is k A_Traversal, MonadState s m)
   => Optic k is s s a b
   -> (a -> b)
   -> m ()
@@ -57,6 +64,8 @@ modifying' o = modify' . over' o
 
 -- | Replace the target(s) of an 'Optic' in our monadic state with a new value,
 -- irrespective of the old.
+--
+-- /Note:/ for a strict variant see 'assign''.
 --
 -- >>> execState (do assign _1 'c'; assign _2 'd') ('a','b')
 -- ('c','d')
@@ -79,8 +88,13 @@ assign o = modifying o . const
 --
 -- >>> flip evalState ('a','b') $ assign' _1 (errorWithoutStackTrace "oops")
 -- *** Exception: oops
+--
+-- Values not targeted by the traversal are not forced:
+--
+-- >>> fst $ execState (assign' _1 'x') ('a', undefined)
+-- 'x'
 assign'
-  :: (Is k A_Setter, MonadState s m)
+  :: (Is k A_Traversal, MonadState s m)
   => Optic k is s s a b
   -> b
   -> m ()

--- a/optics/CHANGELOG.md
+++ b/optics/CHANGELOG.md
@@ -7,6 +7,14 @@
   `Optics.IxFold`.
 * Mention the resulting optic kind in the error message about optics that cannot
   be composed.
+* Fix `failover'` and `ifailover'` being lazier than expected: they wrapped the
+  result of the strict traversal in `Just` without forcing it, so the new values
+  were not forced until the contents of the `Just` were demanded, unlike with
+  `over'` and `iover'`.
+* Fix `(?!~)` being stricter than expected: it forced the new value eagerly,
+  even if the traversal had no targets, unlike `(!~)` and the other strict
+  modifications. Now the value is forced if and only if the traversal has at
+  least one target.
 * **Breaking changes**:
   - Rename the `traverse_`-like `Fold` constructor `foldVL` to `mkFold`. The new
     `foldVL` now builds a `Fold` from its van Laarhoven representation `FoldVL`.
@@ -16,6 +24,13 @@
     (`Optics.IxAffineFold`). A `fooVL` function now consistently builds an optic
     from its van Laarhoven representation `FooVL`, while `mkFoo` lifts a
     `traverse_`-like function.
+  - Restrict `over'`, `set'`, `iover'`, `iset'` and the associated operators
+    `(%!~)`, `(!~)` and `(?!~)` to require traversals rather than just setters.
+    Setters are not capable of actually making strict modifications, so these
+    operations were just silently lazier than expected when passed setters.
+  - Restrict `modifying'` and `assign'` to traversals, for the same reason.
+  - Move `over'` and `set'` from `Optics.Setter` to `Optics.Traversal`, and
+    `iover'` and `iset'` from `Optics.IxSetter` to `Optics.IxTraversal`.
 
 # optics-0.4.2.1 (2023-06-22)
 * Fix compilation of tests with GHC 9.4 and 9.6

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -990,6 +990,9 @@ import Data.Either.Optics                    as P
 -- +--------------+-----------------+-------------------------------------------+------------------------------+-------------------------------+-------------------------------------------+
 -- | '?~'         | '?!~'           | 'Optics.State.Operators.?='               | 'Optics.State.Operators.<?=' | 'Optics.State.Operators.<<?=' | Replace target(s) with 'Just' a value.    |
 -- +--------------+-----------------+-------------------------------------------+------------------------------+-------------------------------+-------------------------------------------+
+--
+-- The combinators in the @Strict@ column require a 'Traversal' rather than a
+-- 'Setter', because a 'Setter' provides no way to force the new values.
 
 -- $setup
 -- >>> import Control.Monad.Reader

--- a/optics/tests/Optics/Tests/Eta.hs
+++ b/optics/tests/Optics/Tests/Eta.hs
@@ -40,7 +40,7 @@ etaTests = testGroup "Eta expansion"
     assertSuccess $(inspectTest $ 'eta7lhs === 'eta7rhs)
   , testCase "optimized eta7lhs" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'eta7lhs)
-  , testCase "over' mapped = \\f -> over' mapped f" $
+  , testCase "over' traversed = \\f -> over' traversed f" $
     assertSuccess $(inspectTest $ 'eta8lhs === 'eta8rhs)
   , testCase "optimized eta8lhs" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'eta8lhs)
@@ -48,7 +48,7 @@ etaTests = testGroup "Eta expansion"
     assertSuccess $(inspectTest $ 'eta9lhs === 'eta9rhs)
   , testCase "optimized eta9lhs" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'eta9lhs)
-  , testCase "iover' imapped = \\f -> iover' imapped f" $
+  , testCase "iover' itraversed = \\f -> iover' itraversed f" $
     assertSuccess $(inspectTest $ 'eta10lhs === 'eta10rhs)
   , testCase "optimized eta10lhs" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'eta10lhs)
@@ -56,7 +56,7 @@ etaTests = testGroup "Eta expansion"
     assertSuccess $(inspectTest $ 'eta11lhs === 'eta11rhs)
   , testCase "optimized eta11lhs" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'eta11lhs)
-  , testCase "iset' imapped = \\f -> iset' imapped f" $
+  , testCase "iset' itraversed = \\f -> iset' itraversed f" $
     assertSuccess $(inspectTest $ 'eta12lhs === 'eta12rhs)
   , testCase "optimized eta12lhs" $
     assertSuccess $(inspectTest $ hasNoProfunctors 'eta12lhs)
@@ -96,9 +96,9 @@ eta7lhs   = over mapped
 eta7rhs f = over mapped f
 
 eta8lhs, eta8rhs
-  :: Functor f => (a -> b) -> f a -> f b
-eta8lhs   = over' mapped
-eta8rhs f = over' mapped f
+  :: Traversable f => (a -> b) -> f a -> f b
+eta8lhs   = over' traversed
+eta8rhs f = over' traversed f
 
 eta9lhs, eta9rhs
   :: FunctorWithIndex i f => (i -> a -> b) -> f a -> f b
@@ -106,9 +106,9 @@ eta9lhs   = iover imapped
 eta9rhs f = iover imapped f
 
 eta10lhs, eta10rhs
-  :: FunctorWithIndex i f => (i -> a -> b) -> f a -> f b
-eta10lhs   = iover' imapped
-eta10rhs f = iover' imapped f
+  :: TraversableWithIndex i f => (i -> a -> b) -> f a -> f b
+eta10lhs   = iover' itraversed
+eta10rhs f = iover' itraversed f
 
 eta11lhs, eta11rhs
   :: (FunctorWithIndex i f, FunctorWithIndex j g)
@@ -117,10 +117,10 @@ eta11lhs   = iset (imapped <%> imapped)
 eta11rhs f = iset (imapped <%> imapped) f
 
 eta12lhs, eta12rhs
-  :: (FunctorWithIndex i f, FunctorWithIndex j g)
+  :: (TraversableWithIndex i f, TraversableWithIndex j g)
   => ((i, j) -> b) -> f (g a) -> f (g b)
-eta12lhs   = iset' (imapped <%> imapped)
-eta12rhs f = iset' (imapped <%> imapped) f
+eta12lhs   = iset' (itraversed <%> itraversed)
+eta12rhs f = iset' (itraversed <%> itraversed) f
 
 -- workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/26436
 _unused :: ()


### PR DESCRIPTION
Fixes #473.

Setters provide no way to force the new values, so over', set', iover', iset', (%!~), (!~), (?!~), modifying' and assign' were silently lazier than expected when passed a setter. Require A_Traversal instead, which also makes the Mapping (Star Identity') and Mapping (IxStar Identity') instances unnecessary, as they existed only to let those operations accept setters and then do nothing.

Rename Identity' to Box while at it: with the Mapping instances gone the {-# UNPACK #-} !() field carries no weight, so a plain one-field box with a strict wrapper does the same job.

Adapted from #475, but without its Solo (and hence OneTuple) dependency.