### PR TITLE
Add instances for the strict boxed vector, require vector >= 0.13.2

### DIFF
--- a/optics-extra/CHANGELOG.md
+++ b/optics-extra/CHANGELOG.md
@@ -1,5 +1,8 @@
 # optics-extra-0.5 (2026-??-??)
 * Drop support for GHC older than 9.2.
+* Add `Each`, `Cons`, `Snoc`, `Ixed` and `AsEmpty` instances for the strict boxed
+  vector from `Data.Vector.Strict`, along with the `Data.Vector.Strict.Optics`
+  module. Consequently, `vector >= 0.13.2` is now required.
 * **Breaking changes**:
   - Restrict `modifying'` and `assign'` to traversals. Setters are not capable
     of actually making strict modifications, so these operations were just

--- a/optics-extra/optics-extra.cabal
+++ b/optics-extra/optics-extra.cabal
@@ -70,7 +70,7 @@ library
                , text                   >= 1.2       && <1.3 || >=2.0 && <2.2
                , transformers           >= 0.5       && <0.7
                , unordered-containers   >= 0.2.6     && <0.3
-               , vector                 >= 0.11      && <0.14
+               , vector                 >= 0.13.2    && <0.14
                , indexed-traversable-instances >=0.1 && <0.2
 
   exposed-modules: Optics.Extra
@@ -98,6 +98,7 @@ library
                    Data.Text.Strict.Optics
                    Data.Vector.Generic.Optics
                    Data.Vector.Optics
+                   Data.Vector.Strict.Optics
 
                    -- internal modules
                    Optics.Extra.Internal.ByteString

--- a/optics-extra/src/Data/Vector/Strict/Optics.hs
+++ b/optics-extra/src/Data/Vector/Strict/Optics.hs
@@ -1,0 +1,84 @@
+-- | This module provides lenses and traversals for working with strict boxed
+-- vectors.
+--
+-- @since 0.5
+module Data.Vector.Strict.Optics
+  ( toVectorOf
+  -- * Isomorphisms
+  , vector
+  , forced
+  -- * Lenses
+  , sliced
+  -- * Traversal of individual indices
+  , ordinals
+  ) where
+
+import Data.Vector.Strict (Vector)
+import Optics.Core
+import qualified Data.Vector.Generic.Optics as G
+
+-- $setup
+-- >>> import qualified Data.Vector.Strict as Vector
+-- >>> import Optics.Core
+
+-- | @sliced i n@ provides a 'Lens' that edits the @n@ elements starting at
+-- index @i@ from a 'Lens'.
+--
+-- This is only a valid 'Lens' if you do not change the length of the resulting
+-- 'Vector'.
+--
+-- Attempting to return a longer or shorter vector will result in violations of
+-- the 'Lens' laws.
+--
+-- >>> Vector.fromList [1..10] ^. sliced 2 5 == Vector.fromList [3,4,5,6,7]
+-- True
+--
+-- >>> (Vector.fromList [1..10] & sliced 2 5 % mapped .~ 0) == Vector.fromList [1,2,0,0,0,0,0,8,9,10]
+-- True
+sliced
+  :: Int -- ^ @i@ starting index
+  -> Int -- ^ @n@ length
+  -> Lens' (Vector a) (Vector a)
+sliced = G.sliced
+{-# INLINE sliced #-}
+
+-- | Similar to 'toListOf', but returning a 'Vector'.
+--
+-- >>> toVectorOf each (8,15) == Vector.fromList [8,15]
+-- True
+toVectorOf
+  :: Is k A_Fold
+  => Optic' k is s a
+  -> s
+  -> Vector a
+toVectorOf = G.toVectorOf
+{-# INLINE toVectorOf #-}
+
+-- | Convert a list to a 'Vector' (or back)
+--
+-- >>> [1,2,3] ^. vector == Vector.fromList [1,2,3]
+-- True
+--
+-- >>> [1,2,3] ^. vector % re vector
+-- [1,2,3]
+--
+-- >>> Vector.fromList [0,8,15] ^. re vector % vector == Vector.fromList [0,8,15]
+-- True
+vector :: Iso [a] [b] (Vector a) (Vector b)
+vector = G.vector
+{-# INLINE vector #-}
+
+-- | Convert a 'Vector' to a version that doesn't retain any extra
+-- memory.
+forced :: Iso (Vector a) (Vector b) (Vector a) (Vector b)
+forced = G.forced
+{-# INLINE forced #-}
+
+-- | This 'Traversal' will ignore any duplicates in the supplied list of
+-- indices.
+--
+-- >>> toListOf (ordinals [1,3,2,5,9,10]) $ Vector.fromList [2,4..40]
+-- [4,8,6,12,20,22]
+ordinals :: forall a. [Int] -> IxTraversal' Int (Vector a) a
+ordinals = G.ordinals
+{-# INLINE ordinals #-}

--- a/optics-extra/src/Optics/At.hs
+++ b/optics-extra/src/Optics/At.hs
@@ -56,6 +56,7 @@ import qualified Data.Text.Lazy as LazyT
 import qualified Data.Vector as Vector hiding (indexed)
 import qualified Data.Vector.Primitive as Prim
 import qualified Data.Vector.Storable as Storable
+import qualified Data.Vector.Strict as Strict hiding (indexed)
 import qualified Data.Vector.Unboxed as Unboxed hiding (indexed)
 import Data.Word (Word8)
 
@@ -69,6 +70,7 @@ import Optics.Core
 type instance Index (HashSet a) = a
 type instance Index (HashMap k a) = k
 type instance Index (Vector.Vector a) = Int
+type instance Index (Strict.Vector a) = Int
 type instance Index (Prim.Vector a) = Int
 type instance Index (Storable.Vector a) = Int
 type instance Index (Unboxed.Vector a) = Int
@@ -103,6 +105,15 @@ instance Ixed (Vector.Vector a) where
   ix i = atraversalVL $ \point f v ->
     if 0 <= i && i < Vector.length v
     then f (v Vector.! i) <&> \a -> v Vector.// [(i, a)]
+    else point v
+  {-# INLINE ix #-}
+
+type instance IxValue (Strict.Vector a) = a
+-- | @since 0.5
+instance Ixed (Strict.Vector a) where
+  ix i = atraversalVL $ \point f v ->
+    if 0 <= i && i < Strict.length v
+    then f (v Strict.! i) <&> \a -> v Strict.// [(i, a)]
     else point v
   {-# INLINE ix #-}
 

--- a/optics-extra/src/Optics/Cons.hs
+++ b/optics-extra/src/Optics/Cons.hs
@@ -36,6 +36,7 @@ import qualified Data.Text.Lazy as LazyT
 import qualified Data.Vector as Vector
 import qualified Data.Vector.Primitive as Prim
 import qualified Data.Vector.Storable as Storable
+import qualified Data.Vector.Strict as Strict
 import qualified Data.Vector.Unboxed as Unbox
 
 import Optics.Core
@@ -66,6 +67,14 @@ instance Cons (Vector a) (Vector b) a b where
     else Right (Vector.unsafeHead v, Vector.unsafeTail v)
   {-# INLINE _Cons #-}
 
+-- | @since 0.5
+instance Cons (Strict.Vector a) (Strict.Vector b) a b where
+  _Cons = prism (uncurry' Strict.cons) $ \v ->
+    if Strict.null v
+    then Left Strict.empty
+    else Right (Strict.unsafeHead v, Strict.unsafeTail v)
+  {-# INLINE _Cons #-}
+
 instance (Prim a, Prim b) => Cons (Prim.Vector a) (Prim.Vector b) a b where
   _Cons = prism (uncurry' Prim.cons) $ \v ->
     if Prim.null v
@@ -93,6 +102,13 @@ instance Snoc (Vector a) (Vector b) a b where
   _Snoc = prism (uncurry' Vector.snoc) $ \v -> if Vector.null v
     then Left Vector.empty
     else Right (Vector.unsafeInit v, Vector.unsafeLast v)
+  {-# INLINE _Snoc #-}
+
+-- | @since 0.5
+instance Snoc (Strict.Vector a) (Strict.Vector b) a b where
+  _Snoc = prism (uncurry' Strict.snoc) $ \v -> if Strict.null v
+    then Left Strict.empty
+    else Right (Strict.unsafeInit v, Strict.unsafeLast v)
   {-# INLINE _Snoc #-}
 
 instance (Prim a, Prim b) => Snoc (Prim.Vector a) (Prim.Vector b) a b where

--- a/optics-extra/src/Optics/Each.hs
+++ b/optics-extra/src/Optics/Each.hs
@@ -29,6 +29,7 @@ import Data.Word (Word8)
 import qualified Data.Vector as V
 import qualified Data.Vector.Primitive as VP
 import qualified Data.Vector.Storable as VS
+import qualified Data.Vector.Strict as VStrict
 import qualified Data.Vector.Unboxed as VU
 
 import Optics.Core
@@ -45,6 +46,13 @@ instance k ~ k' => Each k (HashMap k a) (HashMap k' b) a b where
 
 -- | @'each' :: 'IxTraversal' Int ('V.Vector' a) ('V.Vector' b) a b@
 instance Each Int (V.Vector a) (V.Vector b) a b where
+  each = vectorTraverse
+  {-# INLINE[1] each #-}
+
+-- | @'each' :: 'IxTraversal' Int ('VStrict.Vector' a) ('VStrict.Vector' b) a b@
+--
+-- @since 0.5
+instance Each Int (VStrict.Vector a) (VStrict.Vector b) a b where
   each = vectorTraverse
   {-# INLINE[1] each #-}
 

--- a/optics-extra/src/Optics/Empty.hs
+++ b/optics-extra/src/Optics/Empty.hs
@@ -27,6 +27,7 @@ import qualified Data.Text as StrictT
 import qualified Data.Text.Lazy as LazyT
 import qualified Data.Vector as Vector
 import qualified Data.Vector.Storable as Storable
+import qualified Data.Vector.Strict as Strict
 import qualified Data.Vector.Unboxed as Unboxed
 
 import Optics.Core
@@ -46,6 +47,11 @@ instance AsEmpty (HashSet a) where
 
 instance AsEmpty (Vector.Vector a) where
   _Empty = nearly Vector.empty Vector.null
+  {-# INLINE _Empty #-}
+
+-- | @since 0.5
+instance AsEmpty (Strict.Vector a) where
+  _Empty = nearly Strict.empty Strict.null
   {-# INLINE _Empty #-}
 
 instance Unboxed.Unbox a => AsEmpty (Unboxed.Vector a) where

--- a/optics/CHANGELOG.md
+++ b/optics/CHANGELOG.md
@@ -5,6 +5,9 @@
   and `FoldVL`, `foldVL` and `toFoldVL` in `Optics.Fold`.
 * Add `iminimumOf`, `imaximumOf`, `iminimumByOf` and `imaximumByOf` to
   `Optics.IxFold`.
+* Add `Each`, `Cons`, `Snoc`, `Ixed` and `AsEmpty` instances for the strict boxed
+  vector from `Data.Vector.Strict`, along with the `Data.Vector.Strict.Optics`
+  module. Consequently, `vector >= 0.13.2` is now required.
 * Mention the resulting optic kind in the error message about optics that cannot
   be composed.
 * Fix `failover'` and `ifailover'` being lazier than expected: they wrapped the

--- a/optics/optics.cabal
+++ b/optics/optics.cabal
@@ -143,6 +143,7 @@ library
                     , Data.Typeable.Optics
                     , Data.Vector.Generic.Optics
                     , Data.Vector.Optics
+                    , Data.Vector.Strict.Optics
                     , GHC.Generics.Optics
                     , Numeric.Optics
   


### PR DESCRIPTION
Add Each, Cons, Snoc, Ixed and AsEmpty instances for Data.Vector.Strict, along with the Data.Vector.Strict.Optics module. Requires vector-0.13.2.

Fixes #522.