### PR TITLE
Drop the HasField constraint from gafield

### DIFF
--- a/optics-core/CHANGELOG.md
+++ b/optics-core/CHANGELOG.md
@@ -15,6 +15,10 @@
   even if the traversal had no targets, unlike `(!~)` and the other strict
   modifications. Now the value is forced if and only if the traversal has at
   least one target.
+* Fix spurious `-Wincomplete-record-selectors` warnings at every use site of
+  `gafield` and affine field labels with GHC >= 9.14.1 resulting from `HasField`
+  constraints being solved for partial fields. As a consequence, the field
+  selector no longer needs to be in scope for `gafield` to work.
 * **Breaking changes**:
   - Rename the `traverse_`-like `Fold` constructor `foldVL` to `mkFold`. The new
     `foldVL` now builds a `Fold` from its van Laarhoven representation `FoldVL`.

--- a/optics-core/src/Optics/Internal/Generic.hs
+++ b/optics-core/src/Optics/Internal/Generic.hs
@@ -187,11 +187,12 @@ instance
 -- Affine field
 
 class GAffineFieldImpl (repDefined :: Bool)
-                       (name :: Symbol) s t a b | name s -> a
-                                             {- These hold morally, but we can't prove it.
-                                                , name t -> b
-                                                , name s b -> t
-                                                , name t a -> s -} where
+                       (name :: Symbol) s t a b
+      {- These hold morally, but we can't prove it.
+         | name s -> a
+         , name t -> b
+         , name s b -> t
+         , name t a -> s -} where
 
   gafieldImpl :: AffineTraversal s t a b
 
@@ -199,7 +200,16 @@ instance
   ( Generic s
   , Generic t
   , path ~ GetFieldPaths s name (Rep s)
-  , HasField name s a -- require the field to be in scope
+  -- Below constraint can't be here anymore: since GHC 9.14.1
+  -- -Wincomplete-record-selectors generates warnings about partial fields
+  -- whenever an appropriate HasField constraint is solved, not whenever its
+  -- evidence (ie. the getField method) is used. For more info see
+  -- https://gitlab.haskell.org/ghc/ghc/-/issues/26686.
+  --
+  -- The consequence of this is that the field no longer needs to be in scope
+  -- for 'gafield' to work.
+  --
+  --, HasField name s a -- require the field to be in scope
   , Unless (AnyHasPath path)
     (TypeError
       (Text "Type " :<>: QuoteType s :<>:

--- a/optics/CHANGELOG.md
+++ b/optics/CHANGELOG.md
@@ -15,6 +15,10 @@
   even if the traversal had no targets, unlike `(!~)` and the other strict
   modifications. Now the value is forced if and only if the traversal has at
   least one target.
+* Fix spurious `-Wincomplete-record-selectors` warnings at every use site of
+  `gafield` and affine field labels with GHC >= 9.14.1 resulting from `HasField`
+  constraints being solved for partial fields. As a consequence, the field
+  selector no longer needs to be in scope for `gafield` to work.
 * **Breaking changes**:
   - Rename the `traverse_`-like `Fold` constructor `foldVL` to `mkFold`. The new
     `foldVL` now builds a `Fold` from its van Laarhoven representation `FoldVL`.


### PR DESCRIPTION
It only checked that the field is in scope, but since GHC 9.14.1 -Wincomplete-record-selectors fires whenever a HasField constraint for a partial field is solved, warning at every use site.

See https://gitlab.haskell.org/ghc/ghc/-/issues/26686.