### PR TITLE
Make doctests work with more GHC versions

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -303,10 +303,6 @@ jobs:
           if [ $((HCNUMVER < 90800)) -ne 0 ] ; then echo "package metametapost" >> cabal.project ; fi
           if [ $((HCNUMVER < 90800)) -ne 0 ] ; then echo "    ghc-options: -j4" >> cabal.project ; fi
           cat >> cabal.project <<EOF
-          allow-newer: indexed-traversable-instances:base
-          allow-newer: indexed-traversable:base
-          allow-newer: indexed-traversable:containers
-          allow-newer: these:base
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(indexed-profunctors|metametapost|optics|optics-core|optics-extra|optics-sop|optics-th|optics-vl|template-haskell-optics)$/; }' >> cabal.project.local
           cat cabal.project
@@ -336,8 +332,8 @@ jobs:
           $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
       - name: docspec
         run: |
-          if [ $((HCNUMVER >= 90800 && HCNUMVER < 91400)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all ; fi
-          if [ $((HCNUMVER >= 90800 && HCNUMVER < 91400)) -ne 0 ] ; then cabal-docspec $ARG_COMPILER ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then cabal-docspec $ARG_COMPILER ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_optics} || false

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,8 +1,6 @@
 branches:       master
 -- - GHC 9.2 sometimes doesn't resolve TypeError for JoinKinds
--- - GHC-9.4 and 9.6 have some issue with overlapping instances for optic labels
--- - GHC 9.14 changed formatting of :t
-docspec:        >=9.8 && <9.14
+docspec:        >=9.4
 tests:          True
 benchmarks:     True
 jobs-selection: uniform

--- a/cabal.project
+++ b/cabal.project
@@ -13,9 +13,3 @@ packages:
   metametapost/*.cabal
 
 tests: true
-
--- For GHC-9.14.1.
-allow-newer: indexed-traversable-instances:base
-           , indexed-traversable:base
-           , indexed-traversable:containers
-           , these:base

--- a/optics-core/src/Optics/Internal/Generic.hs
+++ b/optics-core/src/Optics/Internal/Generic.hs
@@ -136,7 +136,6 @@ instance
 
 instance
   ( path ~ GSetFieldPath con epath
-  , When (IsLeft epath) (HideReps g h)
   , GSetFieldProd path g h b
   ) => GSetFieldSum (PathLeaf epath) (M1 C (MetaCons con fix hs) g)
                                       (M1 C (MetaCons con fix hs) h) b where
@@ -316,7 +315,6 @@ instance
   , path ~ If (n <=? 0)
               (TypeError (Text "There is no 0th position"))
               (GetPositionPaths s n (Rep s))
-  , When (n <=? 0) (HideReps (Rep s) (Rep t))
   , GPositionSum path (Rep s) (Rep t) a b
   ) => GPositionImpl True n s t a b where
   gpositionImpl = withLens
@@ -347,7 +345,6 @@ instance
 
 instance
   ( path ~ GPositionPath con epath
-  , When (IsLeft epath) (HideReps g h)
   , GFieldProd path g h a b
   ) => GPositionSum (PathLeaf epath) (M1 C (MetaCons con fix hs) g)
                                       (M1 C (MetaCons con fix hs) h) a b where
@@ -386,7 +383,6 @@ instance
       (Text "Type " :<>: QuoteType s :<>:
        Text " doesn't have a constructor named " :<>: QuoteSymbol name))
     epath
-  , When (IsLeft epath) (HideReps (Rep s) (Rep t))
   , GConstructorSum path (Rep s) (Rep t) a b
   ) => GConstructorImpl True name s t a b where
   gconstructorImpl = withPrism (generic % gconstructorSum @path) prism

--- a/optics-core/src/Optics/Internal/Generic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Generic/TypeLevel.hs
@@ -14,12 +14,10 @@ module Optics.Internal.Generic.TypeLevel
   , GetPositionPaths
   , GetPositionPath
   -- * Misc
-  , HideReps
   , AnyHasPath
   , NoGenericError
   ) where
 
-import Data.Kind
 import Data.Type.Bool
 import Data.Type.Equality
 import GHC.Generics
@@ -109,13 +107,6 @@ type family ContinueWhenLeft (r :: Either (Nat, Nat) [Path]) g acc
 
 ----------------------------------------
 -- Misc
-
-data Void1 a
--- | Generate bogus equality constraints that attempt to unify generic
--- representations with this type in case there is an error such as missing
--- field, constructor etc. so these huge types don't leak into error messages.
-type family HideReps (g :: Type -> Type) (h :: Type -> Type) :: Constraint where
-  HideReps g h = (g ~ Void1, h ~ Void1)
 
 -- | Check if any leaf in the tree has a '[Path]'.
 type family AnyHasPath (path :: PathTree e) :: Bool where

--- a/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
+++ b/optics-core/src/Optics/Internal/Optic/TypeLevel.hs
@@ -132,10 +132,6 @@ type family FromRight (def :: b) (e :: Either a b) :: b where
   FromRight _   (Right b) = b
   FromRight def (Left  _) = def
 
-type family IsLeft (e :: Either a b) :: Bool where
-  IsLeft (Left _)  = True
-  IsLeft (Right _) = False
-
 ----------------------------------------
 -- Errors
 

--- a/optics/src/Optics.hs
+++ b/optics/src/Optics.hs
@@ -614,8 +614,7 @@ import Data.Either.Optics                    as P
 -- Since 'Optic' is a rank-1 type, it is easy to store optics in a
 -- datastructure:
 --
--- >>> :t [folded, backwards_ folded]
--- [folded, backwards_ folded] :: Foldable f => [Fold (f a) a]
+-- >>> let twoFolds = [folded, backwards_ folded]
 --
 -- It is possible to define aliases for optics without the monomorphism
 -- restriction spoiling the fun:


### PR DESCRIPTION
Also fixes error messages for generic optics with GHC 9.14. HideReps was a hack for slightly better error messages in older versions (I think, my memory is hazy), but it actively hurts in 9.14, so has to be removed anyway.